### PR TITLE
fix: suppress UL loopback and restore DL audio for circuit calls via …

### DIFF
--- a/crates/tetra-entities/src/net_brew/entity.rs
+++ b/crates/tetra-entities/src/net_brew/entity.rs
@@ -776,6 +776,9 @@ impl BrewEntity {
         for ts in ts_to_remove {
             self.ul_forwarded.remove(&ts);
         }
+        // Also remove from active_calls — circuit calls are registered there by
+        // NetworkCircuitMediaReady so that DL audio from TetraPack reaches the MS.
+        self.active_calls.remove(&brew_uuid);
         if had_jitter || had_ts {
             tracing::info!("BrewEntity: dropped circuit uuid={}", brew_uuid);
         } else {
@@ -905,7 +908,7 @@ impl TetraEntityTrait for BrewEntity {
             }
             SapMsgInner::CmceCallControl(CallControl::NetworkCircuitMediaReady { brew_uuid, call_id, ts }) => {
                 tracing::info!("BrewEntity: circuit media ready uuid={} call_id={} ts={}", brew_uuid, call_id, ts);
-                // Register this circuit for UL voice forwarding on the given timeslot
+                // Register UL forwarding: UL voice on `ts` gets sent to TetraPack.
                 self.ul_forwarded.insert(
                     ts,
                     UlForwardedCall {
@@ -917,6 +920,22 @@ impl TetraEntityTrait for BrewEntity {
                         frame_count: 0,
                     },
                 );
+                // Register in active_calls with ts already known, so that DL voice frames
+                // received from TetraPack (handle_voice_frame + drain_jitter_playout) are
+                // actually delivered to the MS on this timeslot.
+                // Without this, handle_voice_frame drops incoming DL audio silently because
+                // the uuid is not found in active_calls, causing the caller to hear only
+                // their own loopback echo instead of the remote party.
+                self.active_calls.entry(brew_uuid).or_insert_with(|| ActiveCall {
+                    uuid: brew_uuid,
+                    call_id: Some(call_id),
+                    ts: Some(ts),
+                    usage: None,
+                    source_issi: 0,
+                    dest_gssi: 0,
+                    frame_count: 0,
+                });
+                // Ensure jitter buffer exists
                 self.dl_jitter
                     .entry(brew_uuid)
                     .or_insert_with(|| VoiceJitterBuffer::with_initial_latency(

--- a/crates/tetra-entities/src/umac/subcomp/bs_sched.rs
+++ b/crates/tetra-entities/src/umac/subcomp/bs_sched.rs
@@ -1,6 +1,6 @@
 use tetra_core::{BitBuffer, Direction, PhyBlockNum, PhysicalChannel, TdmaTime, TetraAddress, Todo, TxReporter, unimplemented_log};
 use tetra_saps::{
-    control::call_control::Circuit,
+    control::call_control::{Circuit, CircuitDlMediaSource},
     tmv::{TmvUnitdataReq, TmvUnitdataReqSlot, enums::logical_chans::LogicalChannel},
 };
 
@@ -504,6 +504,19 @@ impl BsChannelScheduler {
             return None;
         }
         self.circuits.ul[ts as usize - 1].as_ref().and_then(|c| c.peer_ts)
+    }
+
+    /// Return the DL media source for the UL circuit on `ts`.
+    /// `LocalLoopback` = reflect UL back to DL (group/simplex calls).
+    /// `SwMI` = DL audio comes from Brew; suppress local loopback.
+    pub fn ul_circuit_dl_media_source(&self, ts: u8) -> CircuitDlMediaSource {
+        if !(1..=4).contains(&ts) {
+            return CircuitDlMediaSource::LocalLoopback;
+        }
+        self.circuits.ul[ts as usize - 1]
+            .as_ref()
+            .map(|c| c.dl_media_source)
+            .unwrap_or(CircuitDlMediaSource::LocalLoopback)
     }
 
     pub fn close_circuit(&mut self, dir: Direction, ts: u8) -> Option<Circuit> {

--- a/crates/tetra-entities/src/umac/umac_bs.rs
+++ b/crates/tetra-entities/src/umac/umac_bs.rs
@@ -1272,8 +1272,11 @@ impl UmacBs {
                 }
 
                 // Determine DL target timeslot:
-                //   - Full-duplex P2P: UL on `ts` is cross-routed to peer MS's DL on `peer_ts`.
-                //   - Simplex / group / network call: peer_ts is None → classic same-ts loopback.
+                //   - Full-duplex P2P (local): UL on `ts` is cross-routed to peer MS's DL on `peer_ts`.
+                //   - Group / simplex (LocalLoopback, no peer_ts): same-ts loopback so all members hear.
+                //   - Circuit call via Brew/TetraPack (SwMI, no peer_ts): suppress local loopback entirely.
+                //     DL audio comes from Brew via TmdCircuitDataReq; looping back UL here causes the
+                //     calling MS to hear their own voice instead of the remote party.
                 // Refresh the peer's UL inactivity timer too, so the remote MS isn't timed out
                 // while only the other party is talking.
                 let dl_target_ts = match self.channel_scheduler.ul_circuit_peer_ts(ts) {
@@ -1286,7 +1289,16 @@ impl UmacBs {
                         tracing::trace!("rx_tmd_prim: duplex P2P cross-route UL ts={} -> DL ts={}", ts, peer_ts);
                         peer_ts
                     }
-                    None => ts,
+                    None => {
+                        use tetra_saps::control::call_control::CircuitDlMediaSource;
+                        if self.channel_scheduler.ul_circuit_dl_media_source(ts) == CircuitDlMediaSource::SwMI {
+                            // Circuit call: DL audio comes from Brew, not local loopback.
+                            // Suppress UL->DL loopback to prevent caller hearing their own voice.
+                            tracing::trace!("rx_tmd_prim: circuit call ts={}, suppressing local UL loopback (SwMI)", ts);
+                            return;
+                        }
+                        ts
+                    }
                 };
 
                 if self.channel_scheduler.circuit_is_active(Direction::Dl, dl_target_ts) {


### PR DESCRIPTION
…Brew

- umac_bs: read dl_media_source to suppress UL->DL loopback when SwMI
- bs_sched: add ul_circuit_dl_media_source() helper
- net_brew/entity: register circuit calls in active_calls on MediaReady so DL voice from TetraPack reaches the MS; clean up on drop