### PR TITLE
fix: circuit call audio, loopback echo, and stale resource cleanup

### DIFF
--- a/crates/tetra-entities/src/cmce/components/circuit_mgr.rs
+++ b/crates/tetra-entities/src/cmce/components/circuit_mgr.rs
@@ -342,8 +342,18 @@ impl CircuitMgr {
                 .map(|circuit| (circuit.direction, circuit.ts, circuit.call_id)),
         );
         for (dir, ts, call_id) in to_close {
-            let circuit = self.close_circuit(dir, ts).unwrap(); // TODO FIXME not so sure about this one
-            tasks.get_or_insert_with(Vec::new).push(CircuitMgrCmd::SendClose(call_id, circuit));
+            match self.close_circuit(dir, ts) {
+                Ok(circuit) => {
+                    tasks.get_or_insert_with(Vec::new).push(CircuitMgrCmd::SendClose(call_id, circuit));
+                }
+                Err(_) => {
+                    // Already closed by normal release path racing with the expiry timer — safe to ignore.
+                    tracing::debug!(
+                        "circuit_mgr: expiry close skipped for call_id={} ts={} dir={:?} (already closed)",
+                        call_id, ts, dir
+                    );
+                }
+            }
         }
         tasks
     }

--- a/crates/tetra-entities/src/cmce/subentities/cc_bs/timers.rs
+++ b/crates/tetra-entities/src/cmce/subentities/cc_bs/timers.rs
@@ -147,6 +147,11 @@ impl CcBsSubentity {
                             }
                         }
 
+                        // Capture peer_ts before removing individual_calls (duplex P2P has two TS).
+                        let peer_ts = self.individual_calls.get(&call_id).and_then(|ind| {
+                            if ind.called_ts != ind.calling_ts { Some(ind.called_ts) } else { None }
+                        });
+
                         // Clean up call state
                         self.cached_setups.remove(&call_id);
                         self.active_calls.remove(&call_id);
@@ -155,6 +160,15 @@ impl CcBsSubentity {
                         // Signal UMAC to release the circuit
                         Self::signal_umac_circuit_close(queue, circuit);
                         self.release_timeslot(ts);
+
+                        // For duplex P2P the call has two timeslots. The peer circuit will get
+                        // its own SendClose from circuit_mgr, but individual_calls is already
+                        // gone by then so its timeslot allocator entry would leak. Release it now.
+                        if let Some(p_ts) = peer_ts {
+                            if p_ts != ts {
+                                self.release_timeslot(p_ts);
+                            }
+                        }
                     }
                 }
             }

--- a/crates/tetra-entities/src/net_brew/entity.rs
+++ b/crates/tetra-entities/src/net_brew/entity.rs
@@ -776,8 +776,8 @@ impl BrewEntity {
         for ts in ts_to_remove {
             self.ul_forwarded.remove(&ts);
         }
-        // Also remove from active_calls — circuit calls are registered there by
-        // NetworkCircuitMediaReady so that DL audio from TetraPack reaches the MS.
+        // Remove from active_calls — circuit calls are registered there by NetworkCircuitMediaReady
+        // so that DL audio from TetraPack reaches the MS. Clean up here to avoid stale entries.
         self.active_calls.remove(&brew_uuid);
         if had_jitter || had_ts {
             tracing::info!("BrewEntity: dropped circuit uuid={}", brew_uuid);
@@ -908,24 +908,22 @@ impl TetraEntityTrait for BrewEntity {
             }
             SapMsgInner::CmceCallControl(CallControl::NetworkCircuitMediaReady { brew_uuid, call_id, ts }) => {
                 tracing::info!("BrewEntity: circuit media ready uuid={} call_id={} ts={}", brew_uuid, call_id, ts);
-                // Register UL forwarding: UL voice on `ts` gets sent to TetraPack.
+                // Register UL forwarding: voice on `ts` gets sent to TetraPack.
                 self.ul_forwarded.insert(
                     ts,
                     UlForwardedCall {
                         uuid: brew_uuid,
                         call_id,
                         source_issi: 0,
-                        dest_gssi: 0, // not used for circuit calls
+                        dest_gssi: 0,
                         kind: UlForwardKind::Circuit,
                         frame_count: 0,
                     },
                 );
-                // Register in active_calls with ts already known, so that DL voice frames
-                // received from TetraPack (handle_voice_frame + drain_jitter_playout) are
-                // actually delivered to the MS on this timeslot.
-                // Without this, handle_voice_frame drops incoming DL audio silently because
-                // the uuid is not found in active_calls, causing the caller to hear only
-                // their own loopback echo instead of the remote party.
+                // Register in active_calls with ts already known so that DL voice frames received
+                // from TetraPack (handle_voice_frame + drain_jitter_playout) are delivered to the MS.
+                // Without this entry handle_voice_frame silently drops all incoming DL audio because
+                // it looks up the uuid in active_calls and finds nothing.
                 self.active_calls.entry(brew_uuid).or_insert_with(|| ActiveCall {
                     uuid: brew_uuid,
                     call_id: Some(call_id),
@@ -935,7 +933,6 @@ impl TetraEntityTrait for BrewEntity {
                     dest_gssi: 0,
                     frame_count: 0,
                 });
-                // Ensure jitter buffer exists
                 self.dl_jitter
                     .entry(brew_uuid)
                     .or_insert_with(|| VoiceJitterBuffer::with_initial_latency(

--- a/crates/tetra-entities/src/umac/subcomp/bs_sched.rs
+++ b/crates/tetra-entities/src/umac/subcomp/bs_sched.rs
@@ -506,9 +506,9 @@ impl BsChannelScheduler {
         self.circuits.ul[ts as usize - 1].as_ref().and_then(|c| c.peer_ts)
     }
 
-    /// Return the DL media source for the UL circuit on `ts`.
+    /// Return the DL media source policy for the UL circuit on `ts`.
     /// `LocalLoopback` = reflect UL back to DL (group/simplex calls).
-    /// `SwMI` = DL audio comes from Brew; suppress local loopback.
+    /// `SwMI` = DL audio comes from Brew/TetraPack; suppress local loopback.
     pub fn ul_circuit_dl_media_source(&self, ts: u8) -> CircuitDlMediaSource {
         if !(1..=4).contains(&ts) {
             return CircuitDlMediaSource::LocalLoopback;

--- a/crates/tetra-entities/src/umac/umac_bs.rs
+++ b/crates/tetra-entities/src/umac/umac_bs.rs
@@ -1272,13 +1272,13 @@ impl UmacBs {
                 }
 
                 // Determine DL target timeslot:
-                //   - Full-duplex P2P (local): UL on `ts` is cross-routed to peer MS's DL on `peer_ts`.
+                //   - Full-duplex P2P (local): UL on `ts` cross-routed to peer MS's DL on `peer_ts`.
                 //   - Group / simplex (LocalLoopback, no peer_ts): same-ts loopback so all members hear.
-                //   - Circuit call via Brew/TetraPack (SwMI, no peer_ts): suppress local loopback entirely.
+                //   - Circuit call via Brew/TetraPack (SwMI, no peer_ts): suppress local loopback.
                 //     DL audio comes from Brew via TmdCircuitDataReq; looping back UL here causes the
                 //     calling MS to hear their own voice instead of the remote party.
-                // Refresh the peer's UL inactivity timer too, so the remote MS isn't timed out
-                // while only the other party is talking.
+                // Refresh the peer's UL inactivity timer so the remote MS isn't timed out while
+                // only the other party is talking.
                 let dl_target_ts = match self.channel_scheduler.ul_circuit_peer_ts(ts) {
                     Some(peer_ts) => {
                         if (1..=4).contains(&peer_ts)
@@ -1292,8 +1292,8 @@ impl UmacBs {
                     None => {
                         use tetra_saps::control::call_control::CircuitDlMediaSource;
                         if self.channel_scheduler.ul_circuit_dl_media_source(ts) == CircuitDlMediaSource::SwMI {
-                            // Circuit call: DL audio comes from Brew, not local loopback.
-                            // Suppress UL->DL loopback to prevent caller hearing their own voice.
+                            // Circuit call via Brew: DL comes from TetraPack, not local loopback.
+                            // Suppress UL->DL reflection so the caller doesn't hear their own voice.
                             tracing::trace!("rx_tmd_prim: circuit call ts={}, suppressing local UL loopback (SwMI)", ts);
                             return;
                         }


### PR DESCRIPTION
- net_brew/entity: register circuit calls in active_calls on MediaReady so DL voice from TetraPack is delivered to the MS instead of dropped; clean up active_calls in drop_network_circuit to avoid stale entries

- umac_bs + bs_sched: read dl_media_source (was a dead field) to suppress UL->DL loopback for circuit calls via Brew/TetraPack; previously caused caller to hear their own voice instead of the remote party

- circuit_mgr: replace unwrap() with match in close_expired_circuits to avoid process panic if a circuit was already closed by normal release path racing with the expiry timer

- timers: on forced circuit expiry for duplex P2P calls, release the peer timeslot in the allocator; previously it stayed occupied until restart