### PR TITLE
fix: reset call timeout on network speaker change; drain jitter buffe…

### DIFF
--- a/crates/tetra-entities/src/cmce/subentities/cc_bs/call.rs
+++ b/crates/tetra-entities/src/cmce/subentities/cc_bs/call.rs
@@ -164,6 +164,14 @@ impl ActiveCall {
         self.hangtime_start = Some(now);
     }
 
+    /// Reset the call timeout clock. Called when a new network speaker takes the floor so that
+    /// the 120s (T2m) window is measured from the latest transmission, not from call creation.
+    /// Without this, a conversation with multiple back-to-back speakers always expires at
+    /// `created_at + timeout` regardless of how recently the last speaker started talking.
+    pub(super) fn reset_timeout(&mut self, now: TdmaTime) {
+        self.created_at = now;
+    }
+
     pub(super) fn grant_floor(&mut self, source_issi: u32, speaker_addr: Option<TetraAddress>) {
         self.source_issi = source_issi;
         self.tx_active = true;
@@ -252,6 +260,9 @@ pub(super) struct IndividualCall {
     pub(super) network_call: Option<NetworkCircuitCall>,
     /// True once CONNECT_REQUEST has been sent for Brew-originated setup.
     pub(super) connect_request_sent: bool,
+    /// SSI of the party currently holding the floor (simplex P2P only).
+    /// None until the call is active. Used by UL inactivity timeout to force TX-CEASED.
+    pub(super) floor_holder: Option<u32>,
 }
 
 impl IndividualCall {

--- a/crates/tetra-entities/src/cmce/subentities/cc_bs/fsm/group.rs
+++ b/crates/tetra-entities/src/cmce/subentities/cc_bs/fsm/group.rs
@@ -304,6 +304,7 @@ impl CcBsSubentity {
         Self::validate_group_transition(call_id, state, GroupEvent::NetworkCallStart)?;
 
         call.grant_floor(source_issi, None);
+        call.reset_timeout(self.dltime);
         call.brew_uuid = Some(brew_uuid);
         if let CallOrigin::Network { brew_uuid: old_uuid } = call.origin
             && old_uuid != brew_uuid

--- a/crates/tetra-entities/src/net_brew/components/jitter_buffer.rs
+++ b/crates/tetra-entities/src/net_brew/components/jitter_buffer.rs
@@ -122,6 +122,21 @@ impl VoiceJitterBuffer {
         self.target_frames.max(BREW_JITTER_MIN_FRAMES)
     }
 
+    pub fn is_empty(&self) -> bool {
+        self.frames.is_empty()
+    }
+
+    pub fn len(&self) -> usize {
+        self.frames.len()
+    }
+
+    /// Pop a frame unconditionally — used when draining after GROUP_IDLE.
+    /// Unlike pop_ready, this does not wait for target_frames to accumulate;
+    /// it returns None only when the buffer is truly empty.
+    pub fn pop_drain(&mut self) -> Option<JitterFrame> {
+        self.frames.pop_front()
+    }
+
     fn recompute_target(&mut self) {
         let jitter_component = ((self.jitter_us_ewma * 2.0) / BREW_EXPECTED_FRAME_INTERVAL_US).ceil() as usize;
         let target = BREW_JITTER_BASE_FRAMES + self.initial_latency_frames + jitter_component + self.underrun_boost;

--- a/crates/tetra-entities/src/net_brew/entity.rs
+++ b/crates/tetra-entities/src/net_brew/entity.rs
@@ -112,6 +112,9 @@ pub struct BrewEntity {
     active_calls: HashMap<Uuid, ActiveCall>,
     /// Per-call jitter/playout buffer for downlink voice from Brew.
     dl_jitter: HashMap<Uuid, VoiceJitterBuffer>,
+    /// Jitter buffers that are draining after GROUP_IDLE — kept alive until empty so the
+    /// last frames of a transmission are played out instead of being silently discarded.
+    draining_jitter: HashMap<Uuid, (u8, VoiceJitterBuffer)>,
 
     /// DL calls in hangtime keyed by dest_gssi — circuit stays open, waiting for
     /// new speaker or timeout. Only one hanging call per GSSI.
@@ -164,6 +167,7 @@ impl BrewEntity {
             command_sender,
             active_calls: HashMap::new(),
             dl_jitter: HashMap::new(),
+            draining_jitter: HashMap::new(),
             hanging_calls: HashMap::new(),
             ul_forwarded: HashMap::new(),
             subscriber_groups: HashMap::new(),
@@ -569,7 +573,20 @@ impl BrewEntity {
             tracing::debug!("BrewEntity: GROUP_IDLE for unknown uuid={}", uuid);
             return;
         };
-        self.dl_jitter.remove(&uuid);
+
+        // Move jitter buffer to draining instead of dropping it — remaining frames
+        // will continue to be played out until the buffer empties naturally.
+        if let Some(jitter) = self.dl_jitter.remove(&uuid) {
+            if let Some(ts) = call.ts {
+                if !jitter.is_empty() {
+                    tracing::debug!(
+                        "BrewEntity: GROUP_IDLE uuid={} moving {} buffered frames to drain",
+                        uuid, jitter.len()
+                    );
+                    self.draining_jitter.insert(uuid, (ts, jitter));
+                }
+            }
+        }
 
         tracing::info!(
             "BrewEntity: group call ended uuid={} call_id={:?} gssi={} frames={}",
@@ -693,6 +710,28 @@ impl BrewEntity {
             }
         }
 
+        // Also drain buffers from calls that ended (GROUP_IDLE) but still have frames buffered.
+        let finished: Vec<Uuid> = self
+            .draining_jitter
+            .iter_mut()
+            .filter_map(|(uuid, (ts, jitter))| {
+                if *ts != self.dltime.t {
+                    return None;
+                }
+                match jitter.pop_drain() {
+                    Some(frame) => {
+                        to_send.push((*ts, *uuid, 0, frame));
+                        None
+                    }
+                    None => Some(*uuid),
+                }
+            })
+            .collect();
+        for uuid in finished {
+            tracing::debug!("BrewEntity: drain complete for uuid={}", uuid);
+            self.draining_jitter.remove(&uuid);
+        }
+
         for (ts, uuid, target_frames, frame) in to_send {
             tracing::trace!(
                 "BrewEntity: playout uuid={} ts={} rx_seq={} age_ms={} target_frames={}",
@@ -731,6 +770,7 @@ impl BrewEntity {
         // Clear hanging call tracking
         self.hanging_calls.clear();
         self.dl_jitter.clear();
+        self.draining_jitter.clear();
     }
 
     /// Handle NetworkCallReady response from CMCE
@@ -761,6 +801,7 @@ impl BrewEntity {
         // Flush and remove jitter buffer immediately — prevents DL voice frames
         // from being sent to UMAC after the circuit is already closed.
         let had_jitter = self.dl_jitter.remove(&brew_uuid).is_some();
+        self.draining_jitter.remove(&brew_uuid);
         let ts_to_remove: Vec<u8> = self
             .ul_forwarded
             .iter()


### PR DESCRIPTION
fix: call reliability fixes and missing IndividualCall field

1. Add missing floor_holder field to IndividualCall (call.rs)
   The struct was missing pub(super) floor_holder: Option<u32> which is
   referenced by individual.rs, network.rs, setup.rs, uplink.rs and
   timers.rs for simplex P2P floor tracking. This was preventing the
   project from compiling.

2. Call timeout reset on network speaker change (call.rs, group.rs)
   Group calls with multiple back-to-back speakers were being cut off
   after 120s from the first transmission regardless of ongoing activity.
   created_at is now reset each time a new network speaker takes the floor,
   so the timeout window is measured from the last transmission.

3. Jitter buffer drain after GROUP_IDLE (entity.rs, jitter_buffer.rs)
   When a transmission ended, the jitter buffer was discarded immediately
   causing the last 0.5-1s of audio to be lost. Buffers are now moved to
   a draining queue and played out completely before being released.