### PR TITLE
dashboard: add RadioID callsign lookup column to Radios, Calls and Last Heard

### DIFF
--- a/crates/tetra-entities/src/net_dashboard/callsign.rs
+++ b/crates/tetra-entities/src/net_dashboard/callsign.rs
@@ -1,0 +1,168 @@
+//! RadioID callsign lookup for the dashboard.
+//!
+//! Callsigns are resolved in two stages:
+//!
+//! 1. **In-memory cache** — once a callsign is resolved it is kept for the
+//!    lifetime of the process so repeat lookups are free.
+//!
+//! 2. **Local `dmrids.dat` bulk database** — downloaded once from RadioID on
+//!    first use (or on explicit refresh) and stored at
+//!    `<config_dir>/dmrids.dat`.  A background thread refreshes it every 24 h.
+//!    The file format is CSV: `id,callsign,name,...` (RadioID bulk export).
+//!
+//! 3. **RadioID REST API** — used as a fallback when the local DB has no entry
+//!    for an ISSI.  Results are inserted into the in-memory cache.
+//!
+//! The HTTP handler (`GET /api/callsign?issi=<n>`) is intentionally kept
+//! synchronous (blocking reqwest) so it fits the existing server architecture
+//! without introducing async complexity.
+
+use std::collections::HashMap;
+use std::fs;
+use std::io::{BufRead, BufReader};
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+const RADIOID_API: &str = "https://radioid.net/api/dmr/user/?id=";
+const DMRIDS_URL:  &str = "https://radioid.net/static/dmrids.dat";
+const REFRESH_INTERVAL: Duration = Duration::from_secs(24 * 60 * 60);
+
+// ---------------------------------------------------------------------------
+// Public shared handle
+// ---------------------------------------------------------------------------
+
+#[derive(Clone)]
+pub struct CallsignDb(Arc<Mutex<Inner>>);
+
+struct Inner {
+    /// ISSI → callsign, populated from either the bulk DB or the REST API.
+    cache: HashMap<u32, String>,
+    /// Path to the on-disk dmrids.dat file.
+    dat_path: PathBuf,
+    /// When we last refreshed the bulk DB from RadioID.
+    last_refresh: Option<Instant>,
+}
+
+impl CallsignDb {
+    /// Create a new database. `data_dir` is where `dmrids.dat` will be stored
+    /// (typically the same directory as the config file).
+    pub fn new(data_dir: &Path) -> Self {
+        let dat_path = data_dir.join("dmrids.dat");
+        let mut inner = Inner {
+            cache: HashMap::new(),
+            dat_path: dat_path.clone(),
+            last_refresh: None,
+        };
+        // Load existing on-disk DB immediately so lookups work before the
+        // background refresh completes.
+        if dat_path.exists() {
+            inner.load_dat_file();
+        }
+        let db = CallsignDb(Arc::new(Mutex::new(inner)));
+        // Spawn background refresh thread.
+        {
+            let db2 = db.clone();
+            std::thread::Builder::new()
+                .name("callsign-refresh".into())
+                .spawn(move || db2.refresh_loop())
+                .ok();
+        }
+        db
+    }
+
+    /// Look up a callsign for the given ISSI.
+    /// Returns `None` if the ISSI is unknown to both the local DB and RadioID.
+    pub fn lookup(&self, issi: u32) -> Option<String> {
+        // Fast path: in-memory cache hit.
+        {
+            let inner = self.0.lock().unwrap();
+            if let Some(cs) = inner.cache.get(&issi) {
+                return Some(cs.clone());
+            }
+        }
+        // Slow path: query RadioID REST API.
+        self.api_lookup(issi)
+    }
+
+    // -----------------------------------------------------------------------
+    // Private helpers
+    // -----------------------------------------------------------------------
+
+    fn api_lookup(&self, issi: u32) -> Option<String> {
+        let url = format!("{}{}", RADIOID_API, issi);
+        let client = reqwest::blocking::Client::builder()
+            .timeout(Duration::from_secs(5))
+            .build()
+            .ok()?;
+        let resp: serde_json::Value = client.get(&url).send().ok()?.json().ok()?;
+        let cs = resp["results"][0]["callsign"].as_str()?.to_string();
+        // Store in cache for future lookups.
+        self.0.lock().unwrap().cache.insert(issi, cs.clone());
+        Some(cs)
+    }
+
+    fn refresh_loop(&self) {
+        loop {
+            let needs_refresh = {
+                let inner = self.0.lock().unwrap();
+                match inner.last_refresh {
+                    None => true,
+                    Some(t) => t.elapsed() >= REFRESH_INTERVAL,
+                }
+            };
+            if needs_refresh {
+                self.download_dat();
+            }
+            std::thread::sleep(Duration::from_secs(60 * 60)); // check every hour
+        }
+    }
+
+    fn download_dat(&self) {
+        tracing::info!("callsign: downloading dmrids.dat from RadioID…");
+        let client = match reqwest::blocking::Client::builder()
+            .timeout(Duration::from_secs(120))
+            .build()
+        {
+            Ok(c) => c,
+            Err(e) => { tracing::warn!("callsign: failed to build client: {e}"); return; }
+        };
+        let dat_path = self.0.lock().unwrap().dat_path.clone();
+        let bytes = match client.get(DMRIDS_URL).send().and_then(|r| r.bytes()) {
+            Ok(b) => b,
+            Err(e) => { tracing::warn!("callsign: dmrids.dat download failed: {e}"); return; }
+        };
+        if let Err(e) = fs::write(&dat_path, &bytes) {
+            tracing::warn!("callsign: failed to write dmrids.dat: {e}");
+            return;
+        }
+        tracing::info!("callsign: dmrids.dat saved ({} bytes), loading…", bytes.len());
+        let mut inner = self.0.lock().unwrap();
+        inner.load_dat_file();
+        inner.last_refresh = Some(Instant::now());
+    }
+}
+
+impl Inner {
+    /// Parse `dmrids.dat` into the in-memory cache.
+    /// Format: `<id>,<callsign>,<name>,...` one entry per line, no header.
+    fn load_dat_file(&mut self) {
+        let file = match fs::File::open(&self.dat_path) {
+            Ok(f) => f,
+            Err(e) => { tracing::warn!("callsign: cannot open dmrids.dat: {e}"); return; }
+        };
+        let reader = BufReader::new(file);
+        let mut count = 0usize;
+        for line in reader.lines().map_while(Result::ok) {
+            let mut parts = line.splitn(3, ',');
+            let id_str = parts.next().unwrap_or("").trim();
+            let callsign = parts.next().unwrap_or("").trim();
+            if callsign.is_empty() { continue; }
+            if let Ok(id) = id_str.parse::<u32>() {
+                self.cache.insert(id, callsign.to_string());
+                count += 1;
+            }
+        }
+        tracing::info!("callsign: loaded {count} entries from dmrids.dat");
+    }
+}

--- a/crates/tetra-entities/src/net_dashboard/html.rs
+++ b/crates/tetra-entities/src/net_dashboard/html.rs
@@ -1291,6 +1291,7 @@ td code{
             <table>
               <thead><tr>
                 <th data-i18n="th_issi">ISSI</th>
+                <th data-i18n="th_callsign">Callsign</th>
                 <th data-i18n="th_groups">Groups</th>
                 <th class="col-mobile-hide" data-i18n="th_ee">EE</th>
                 <th data-i18n="th_signal">Signal</th>
@@ -1318,6 +1319,7 @@ td code{
                 <th class="col-mobile-hide" data-i18n="th_id">ID</th>
                 <th data-i18n="th_type">Type</th>
                 <th data-i18n="th_caller">Caller</th>
+                <th data-i18n="th_callsign">Callsign</th>
                 <th data-i18n="th_dest">Destination</th>
                 <th data-i18n="th_speaker">Speaker</th>
                 <th data-i18n="th_duration">Duration</th>
@@ -1344,6 +1346,7 @@ td code{
               <thead><tr>
                 <th data-i18n="th_time">Time</th>
                 <th data-i18n="th_issi">ISSI</th>
+                <th data-i18n="th_callsign">Callsign</th>
                 <th data-i18n="th_activity">Activity</th>
                 <th data-i18n="th_dest">Destination</th>
               </tr></thead>
@@ -1935,7 +1938,7 @@ const LANGS={
     live_sds_sent:'sent',live_sds_times:'×',live_sds_forever:'∞',live_sds_delete:'✕',
     fallback_title:'⚠ FALLBACK CONFIG ACTIVE — Primary config failed to load',
     sds_msg_label:'Message',cancel:'Cancel',send:'Send',
-    th_issi:'ISSI',th_groups:'Groups',th_ee:'EE',th_signal:'Signal',
+    th_issi:'ISSI',th_callsign:'Callsign',th_groups:'Groups',th_ee:'EE',th_signal:'Signal',
     tg_selected:'Selected talkgroup (last keyed up)',tg_scan_hint:'Scanned/affiliated talkgroups — selected one is marked ▶',
     tg_affiliated_short:'affiliated',tg_affiliated_hint:'Other talkgroups this radio is affiliated to (kept attached on the BS even when scan is off on the device)',
     th_status:'Status',th_last_seen:'Last seen',th_actions:'Actions',
@@ -2006,7 +2009,7 @@ const LANGS={
     fallback_title:'⚠ CONFIG DE REZERVĂ ACTIV — Config principal nu a putut fi încărcat',
     sds_title:'⬡ Trimite Mesaj SDS',sds_dest:'ISSI Destinatar',
     sds_msg_label:'Mesaj',cancel:'Anulează',send:'Trimite',
-    th_issi:'ISSI',th_groups:'Grupuri',th_ee:'EE',th_signal:'Semnal',
+    th_issi:'ISSI',th_callsign:'Callsign',th_groups:'Grupuri',th_ee:'EE',th_signal:'Semnal',
     tg_selected:'Grup selectat (ultima transmisie)',tg_scan_hint:'Grupuri scanate/afiliate — cel selectat este marcat cu ▶',
     tg_affiliated_short:'afiliate',tg_affiliated_hint:'Alte grupuri la care radio-ul este afiliat (rămân atașate la BS chiar și când scan e oprit din statie)',
     th_status:'Status',th_last_seen:'Văzut',th_actions:'Acțiuni',
@@ -2076,7 +2079,7 @@ const LANGS={
     fallback_title:'⚠ FALLBACK-KONFIGURATION AKTIV — Primäre Konfiguration konnte nicht geladen werden',
     sds_title:'⬡ SDS-Nachricht senden',sds_dest:'Ziel-ISSI',
     sds_msg_label:'Nachricht',cancel:'Abbrechen',send:'Senden',
-    th_issi:'ISSI',th_groups:'Gruppen',th_ee:'EE',th_signal:'Signal',
+    th_issi:'ISSI',th_callsign:'Callsign',th_groups:'Gruppen',th_ee:'EE',th_signal:'Signal',
     th_status:'Status',th_last_seen:'Zuletzt',th_actions:'Aktionen',
     th_id:'ID',th_type:'Typ',th_caller:'Anrufer',
     th_dest:'Ziel',th_speaker:'Sprecher',th_duration:'Dauer',
@@ -2144,7 +2147,7 @@ const LANGS={
     fallback_title:'⚠ CONFIGURACIÓN DE RESERVA ACTIVA — No se pudo cargar la configuración principal',
     sds_title:'⬡ Enviar Mensaje SDS',sds_dest:'ISSI Destino',
     sds_msg_label:'Mensaje',cancel:'Cancelar',send:'Enviar',
-    th_issi:'ISSI',th_groups:'Grupos',th_ee:'EE',th_signal:'Señal',
+    th_issi:'ISSI',th_callsign:'Callsign',th_groups:'Grupos',th_ee:'EE',th_signal:'Señal',
     th_status:'Estado',th_last_seen:'Visto',th_actions:'Acciones',
     th_id:'ID',th_type:'Tipo',th_caller:'Llamante',
     th_dest:'Destino',th_speaker:'Hablante',th_duration:'Duración',
@@ -2207,7 +2210,7 @@ const LANGS={
     wx_periodic_interval:'Időköz (másodperc)',wx_interval_hint:'Legalább 300 mp (5 perc), hogy ne terhelje túl az időjárás API-t.',wx_periodic_incomplete:'Add meg az állomás ICAO-t és a célt az időszakos módhoz.',
     sds_title:'⬡ SDS üzenet küldése',sds_dest:'Cél ISSI',
     sds_msg_label:'Üzenet',cancel:'Mégse',send:'Küldés',
-    th_issi:'ISSI',th_groups:'Csoportok',th_ee:'EE',th_signal:'Jelerősség',
+    th_issi:'ISSI',th_callsign:'Callsign',th_groups:'Csoportok',th_ee:'EE',th_signal:'Jelerősség',
     th_status:'Állapot',th_last_seen:'Utoljára látva',th_actions:'Műveletek',
     th_id:'ID',th_type:'Típus',th_caller:'Hívó',
     th_dest:'Cél',th_speaker:'Beszélő',th_duration:'Időtartam',
@@ -2272,7 +2275,7 @@ const LANGS={
     live_sds_sent:'已发送',live_sds_times:'次',live_sds_forever:'∞',live_sds_delete:'删除',
     fallback_title:'⚠ 正在使用后备配置 — 主配置加载失败',
     sds_msg_label:'消息内容',cancel:'取消',send:'发送',
-    th_issi:'ISSI',th_groups:'群组',th_ee:'EE',th_signal:'信号',
+    th_issi:'ISSI',th_callsign:'Callsign',th_groups:'群组',th_ee:'EE',th_signal:'信号',
     th_status:'状态',th_last_seen:'最后在线',th_actions:'操作',
     th_id:'ID',th_type:'类型',th_caller:'主叫',
     th_dest:'被叫',th_speaker:'讲话者',th_duration:'时长',
@@ -2969,6 +2972,25 @@ function tsVoice(ts){
 }
 setInterval(updateTsBlocks, 150); // refresh to catch voice decay + duration tick
 
+// ── RadioID callsign cache ─────────────────────────────────────────────────
+const callsignCache={};
+const callsignPending=new Set();
+function fetchCallsign(issi,cb){
+  if(callsignCache[issi]){cb(callsignCache[issi]);return;}
+  if(callsignPending.has(issi))return;
+  callsignPending.add(issi);
+  fetch(`/api/callsign?issi=${issi}`,{credentials:'same-origin'})
+    .then(r=>r.json())
+    .then(d=>{
+      const cs=d.callsign||'—';
+      callsignCache[issi]=cs;
+      callsignPending.delete(issi);
+      cb(cs);
+      document.querySelectorAll(`td.cs-cell[data-issi="${issi}"]`).forEach(el=>el.textContent=cs);
+    })
+    .catch(()=>{callsignCache[issi]='?';callsignPending.delete(issi);});
+}
+
 function renderStations(){
   const ms=Object.values(state.ms);
   const msCount=ms.length,callCount=Object.keys(state.calls).length;
@@ -2978,7 +3000,7 @@ function renderStations(){
   const bc=document.getElementById('badge-calls');
   if(bc){bc.textContent=callCount;bc.style.display=callCount?'flex':'none';}
   const tb=document.getElementById('ms-tbody');
-  if(!ms.length){tb.innerHTML=`<tr><td colspan="7"><div class="empty-state"><div class="empty-icon">📡</div><div class="empty-text">${t('no_terminals')}</div></div></td></tr>`;return;}
+  if(!ms.length){tb.innerHTML=`<tr><td colspan="8"><div class="empty-state"><div class="empty-icon">📡</div><div class="empty-text">${t('no_terminals')}</div></div></td></tr>`;return;}
   tb.innerHTML=ms.sort((a,b)=>a.issi-b.issi).map(m=>{
     const r=m.rssi_dbfs,rL=r!=null?`${r.toFixed(1)} dBFS`:'—',pct=rssiPct(r),col=rssiColor(r);
     let grps;
@@ -3014,8 +3036,12 @@ function renderStations(){
       grps='<span class="badge badge-dim">—</span>';
     }
     const ls=m._last_seen_ts?Math.floor((Date.now()-m._last_seen_ts)/1000):m.last_seen_secs_ago;
+    const mcs=callsignCache[m.issi]||'…';
+    if(!callsignCache[m.issi])fetchCallsign(m.issi,()=>{});
     return`<tr>
-      <td><code>${m.issi}</code></td><td>${grps}</td>
+      <td><code>${m.issi}</code></td>
+      <td class="cs-cell" data-issi="${m.issi}" style="font-family:var(--mono);font-size:12px;color:var(--accent2)">${mcs}</td>
+      <td>${grps}</td>
       <td class="col-mobile-hide" style="text-align:center">${eeLabel(m.energy_saving_mode||0)}</td>
       <td><div class="rssi-bar"><div class="rssi-track"><div class="rssi-fill" style="width:${pct}%;background:${col}"></div></div><span class="rssi-val" style="color:${col}">${rL}</span></div></td>
       <td><span class="badge badge-green">${t('online_badge')}</span></td>
@@ -3028,7 +3054,7 @@ function renderStations(){
 function renderCalls(){
   document.getElementById('stat-calls').textContent=Object.keys(state.calls).length;
   const tb=document.getElementById('calls-tbody'),calls=Object.values(state.calls);
-  if(!calls.length){tb.innerHTML=`<tr><td colspan="6"><div class="empty-state"><div class="empty-icon">☎</div><div class="empty-text">${t('no_calls')}</div></div></td></tr>`;return;}
+  if(!calls.length){tb.innerHTML=`<tr><td colspan="7"><div class="empty-state"><div class="empty-icon">☎</div><div class="empty-text">${t('no_calls')}</div></div></td></tr>`;return;}
   tb.innerHTML=calls.map(c=>{
     const dur=Math.floor((Date.now()-(c.started_at||Date.now()))/1000);
     const mm=String(Math.floor(dur/60)).padStart(2,'0'),ss=String(dur%60).padStart(2,'0');
@@ -3036,21 +3062,29 @@ function renderCalls(){
     const label=c.call_type==='group'?t('call_group'):(c.simplex?t('call_p2p_s'):t('call_p2p_d'));
     const to=c.call_type==='group'?`GSSI ${c.gssi}`:`ISSI ${c.called_issi}`;
     const spk=c.active_speaker?`<code>${c.active_speaker}</code>`:'<span style="color:var(--text3)">—</span>';
-    return`<tr><td class="col-mobile-hide"><code>${c.call_id}</code></td><td><span class="badge ${badge}">${label}</span></td><td>${c.caller_issi?`<code>${c.caller_issi}</code>`:'—'}</td><td>${to}</td><td>${spk}</td><td style="font-family:var(--mono);font-size:12px;color:var(--accent2);font-weight:600">${mm}:${ss}</td></tr>`;
+    const ccs=c.caller_issi?(callsignCache[c.caller_issi]||'…'):'—';
+    if(c.caller_issi&&!callsignCache[c.caller_issi])fetchCallsign(c.caller_issi,()=>{});
+    return`<tr><td class="col-mobile-hide"><code>${c.call_id}</code></td><td><span class="badge ${badge}">${label}</span></td><td>${c.caller_issi?`<code>${c.caller_issi}</code>`:'—'}</td><td class="cs-cell" data-issi="${c.caller_issi}" style="font-family:var(--mono);font-size:12px;color:var(--accent2)">${ccs}</td><td>${to}</td><td>${spk}</td><td style="font-family:var(--mono);font-size:12px;color:var(--accent2);font-weight:600">${mm}:${ss}</td></tr>`;
   }).join('');
 }
 
 function renderLastHeard(){
   const tb=document.getElementById('lastheard-tbody');
   if(!tb)return;
-  if(!state.lastHeard.length){tb.innerHTML=`<tr><td colspan="4"><div class="empty-state"><div class="empty-icon">🎙</div><div class="empty-text">${t('no_activity')}</div></div></td></tr>`;return;}
+  if(!state.lastHeard.length){tb.innerHTML=`<tr><td colspan="5"><div class="empty-state"><div class="empty-icon">🎙</div><div class="empty-text">${t('no_activity')}</div></div></td></tr>`;return;}
   tb.innerHTML=state.lastHeard.map(e=>{
     const destStr=e.dest?`<code>${e.dest}</code>`:'<span style="color:var(--text3)">—</span>';
     const isOnline=!!state.ms[e.issi];
     const issiHtml=`<code>${e.issi}</code>${isOnline?` <span class="badge badge-green" style="font-size:9px">${t('online_badge')}</span>`:''}`;
+    const lcs=callsignCache[e.issi]||'…';
+    if(!callsignCache[e.issi])fetchCallsign(e.issi,()=>{
+      document.querySelectorAll(`td.cs-cell[data-issi="${e.issi}"]`).forEach(el=>el.textContent=callsignCache[e.issi]||'—');
+    });
     return`<tr>
       <td style="font-family:var(--mono);font-size:11px;color:var(--text2)">${e.ts}</td>
-      <td>${issiHtml}</td><td>${activityBadge(e.activity)}</td><td>${destStr}</td>
+      <td>${issiHtml}</td>
+      <td class="cs-cell" data-issi="${e.issi}" style="font-family:var(--mono);font-size:12px;color:var(--accent2)">${lcs}</td>
+      <td>${activityBadge(e.activity)}</td><td>${destStr}</td>
     </tr>`;
   }).join('');
 }

--- a/crates/tetra-entities/src/net_dashboard/mod.rs
+++ b/crates/tetra-entities/src/net_dashboard/mod.rs
@@ -1,3 +1,4 @@
+pub mod callsign;
 pub mod html;
 pub mod server;
 pub mod state;

--- a/crates/tetra-entities/src/net_dashboard/server.rs
+++ b/crates/tetra-entities/src/net_dashboard/server.rs
@@ -426,6 +426,8 @@ pub struct DashboardServer {
     sessions: SharedSessionStore,
     /// Last time a ts_voice WS message was broadcast per TS (indexed 0..3 for TS1..TS4)
     ts_last_broadcast: std::sync::Mutex<[std::time::Instant; 4]>,
+    /// RadioID callsign database — resolves ISSI → amateur callsign.
+    callsign_db: crate::net_dashboard::callsign::CallsignDb,
 }
 
 impl DashboardServer {
@@ -434,7 +436,7 @@ impl DashboardServer {
         Self {
             state: Arc::new(RwLock::new(DashboardStateInner::new(config_path.clone()))),
             clients: Arc::new(Mutex::new(Vec::new())),
-            config_path,
+            config_path: config_path.clone(),
             shared_config: None,
             cmd_tx: None,
             update_state: Arc::new(Mutex::new(UpdateState::new())),
@@ -442,6 +444,13 @@ impl DashboardServer {
             auth: None,
             sessions: Arc::new(Mutex::new(SessionStore::new())),
             ts_last_broadcast: std::sync::Mutex::new([now; 4]),
+            callsign_db: {
+                let data_dir = std::path::Path::new(&config_path)
+                    .parent()
+                    .unwrap_or(std::path::Path::new("."))
+                    .to_path_buf();
+                crate::net_dashboard::callsign::CallsignDb::new(&data_dir)
+            },
         }
     }
 
@@ -484,6 +493,7 @@ impl DashboardServer {
         let auth = self.auth.clone();
         let shared_config = self.shared_config.clone();
         let sessions = Arc::clone(&self.sessions);
+        let callsign_db = self.callsign_db.clone();
 
         std::thread::Builder::new()
             .name("dashboard-server".into())
@@ -503,9 +513,10 @@ impl DashboardServer {
                     let auth = auth.clone();
                     let shared_config = shared_config.clone();
                     let sessions = Arc::clone(&sessions);
+                    let callsign_db = callsign_db.clone();
                     std::thread::Builder::new()
                         .name("dashboard-conn".into())
-                        .spawn(move || handle_connection(stream, state, clients, config_path, cmd_tx, update_state, source_dir_override, auth, shared_config, sessions))
+                        .spawn(move || handle_connection(stream, state, clients, config_path, cmd_tx, update_state, source_dir_override, auth, shared_config, sessions, callsign_db))
                         .ok();
                 }
             })
@@ -880,6 +891,7 @@ fn handle_connection(
     auth: Option<(String, String)>,
     shared_config: Option<tetra_config::bluestation::SharedConfig>,
     sessions: SharedSessionStore,
+    callsign_db: crate::net_dashboard::callsign::CallsignDb,
 ) {
     let _ = stream.set_read_timeout(Some(std::time::Duration::from_millis(500)));
 
@@ -1312,6 +1324,15 @@ fn handle_connection(
     // All paths under /api/wifi/* are GET (read) or POST (mutate). We keep
     // the handlers small and delegate to the `wifi` module — see that for
     // docs on what each operation does. Responses are JSON.
+    } else if req_line.contains("GET /api/callsign") {
+        // GET /api/callsign?issi=<n>  — resolve ISSI to amateur callsign via RadioID.
+        let mut buf = BufReader::new(stream);
+        loop {
+            let mut line = String::new();
+            let _ = buf.read_line(&mut line);
+            if line == "\r\n" || line.is_empty() || line == "\n" { break; }
+        }
+        serve_callsign(buf.into_inner(), &req_line, &callsign_db);
     } else if req_line.contains("GET /api/wifi/status") {
         drain_http_headers(&mut stream);
         let body = match crate::wifi::status() {
@@ -2120,6 +2141,59 @@ fn activate_config_profile(config_path: &str, profile_name: &str) -> Result<(), 
     std::fs::copy(&profile_path, config_path)
         .map(|_| ())
         .map_err(|e| format!("failed to copy profile: {}", e))
+}
+
+/// GET /api/callsign?issi=<n>
+///
+/// Resolves an ISSI to an amateur radio callsign using the RadioID database.
+/// Returns JSON: `{"issi":12345,"callsign":"M0XYZ"}` on success,
+/// or `{"issi":12345,"callsign":null}` when the ISSI is not found.
+///
+/// The lookup is backed by a local dmrids.dat bulk cache (refreshed every 24 h)
+/// with a per-ISSI REST API fallback, so most requests are served from memory.
+fn serve_callsign(
+    mut stream: TcpStream,
+    req_line: &str,
+    db: &crate::net_dashboard::callsign::CallsignDb,
+) {
+    // Parse issi= query parameter from the request line.
+    // Request line format: "GET /api/callsign?issi=12345 HTTP/1.1"
+    let issi: Option<u32> = req_line
+        .split_whitespace()
+        .nth(1)
+        .and_then(|path| path.split('?').nth(1))
+        .and_then(|qs| {
+            qs.split('&').find_map(|kv| {
+                let mut parts = kv.splitn(2, '=');
+                if parts.next() == Some("issi") {
+                    parts.next().and_then(|v| v.parse().ok())
+                } else {
+                    None
+                }
+            })
+        });
+
+    let body = match issi {
+        None => r#"{"error":"missing issi parameter"}"#.to_string(),
+        Some(id) => {
+            match db.lookup(id) {
+                Some(cs) => format!(r#"{{"issi":{},"callsign":"{}"}}"#, id, cs),
+                None     => format!(r#"{{"issi":{},"callsign":null}}"#, id),
+            }
+        }
+    };
+
+    let header = format!(
+        "HTTP/1.1 200 OK
+Content-Type: application/json
+Content-Length: {}
+Connection: close
+
+",
+        body.len()
+    );
+    let _ = stream.write_all(header.as_bytes());
+    let _ = stream.write_all(body.as_bytes());
 }
 
 fn serve_html(mut stream: TcpStream) {


### PR DESCRIPTION
Adds a Callsign column to the three live monitor tables, resolving ISSI numbers 
to amateur radio callsigns via the RadioID database.

Resolution strategy (in priority order):
1. In-memory cache — free on repeat lookups
2. Local dmrids.dat bulk DB — downloaded from RadioID on first run, refreshed 
   every 24h by a background thread, stored alongside the config file
3. Per-ISSI REST API fallback via radioid.net

A new server-side proxy endpoint GET /api/callsign?issi=<n> handles all 
outbound RadioID requests server-side, avoiding CORS issues in the browser.

Tested on a live FlowStation with a registered TETRA radio.