### PR TITLE
radioid: extend callsign lookup to cover repeater IDs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -156,7 +156,7 @@ dependencies = [
 
 [[package]]
 name = "bluestation-bs"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "clap",
  "crossbeam-channel",
@@ -1833,7 +1833,7 @@ dependencies = [
 
 [[package]]
 name = "tetra-config"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "chrono-tz",
  "serde",
@@ -1843,7 +1843,7 @@ dependencies = [
 
 [[package]]
 name = "tetra-core"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "bitcode",
  "chrono",
@@ -1859,7 +1859,7 @@ dependencies = [
 
 [[package]]
 name = "tetra-entities"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "as-any",
  "base64",
@@ -1891,7 +1891,7 @@ dependencies = [
 
 [[package]]
 name = "tetra-pdus"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "tetra-config",
  "tetra-core",
@@ -1901,7 +1901,7 @@ dependencies = [
 
 [[package]]
 name = "tetra-saps"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "tetra-core",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,7 +86,7 @@ useless_format = "allow"
 while_let_loop = "allow"
 
 [workspace.package]
-version = "0.3.2"
+version = "0.3.3"
 edition = "2024"
 authors = ["Razvan Zeces / FlowStation.Dev"]
 license = "MIT"

--- a/crates/tetra-entities/src/cmce/subentities/cc_bs/shared.rs
+++ b/crates/tetra-entities/src/cmce/subentities/cc_bs/shared.rs
@@ -252,6 +252,14 @@ impl CcBsSubentity {
             .active_calls
             .iter()
             .filter(|(_, call)| call.dest_gssi == gssi)
+            // Never tear down a network-originated group call while it still has an active
+            // speaker (FH-BUG-044). A remote party may be mid-transmission: the network owns
+            // the call and ends it via NetworkCallEnd / call_timeout, not a per-subscriber
+            // affiliation change. Dropping it here just because the last *local* listener
+            // deaffiliated — e.g. a transient T351 re-registration of a radio that is actually
+            // present and re-registers a second later — would both cut off the live speaker and
+            // send a spurious NetworkCallEnd to Brew, ending the call network-wide.
+            .filter(|(_, call)| !(matches!(call.origin, CallOrigin::Network { .. }) && call.is_tx_active()))
             .map(|(call_id, call)| (*call_id, call.origin.clone()))
             .collect();
 

--- a/crates/tetra-entities/src/cmce/subentities/sds_bs.rs
+++ b/crates/tetra-entities/src/cmce/subentities/sds_bs.rs
@@ -683,19 +683,23 @@ impl SdsBsSubentity {
 
     /// Pull the human-readable text out of an SDS user-data field. Handles the SDS-TL
     /// "simple text" wrapper (PID 0x82/0x80/0x8A, msg-type byte, message-ref, encoding,
-    /// then text) as well as raw text payloads. Returns an ASCII string (best-effort).
+    /// then text) and a bare text-coding-scheme prefix (0x01..=0x03).
+    ///
+    /// Any OTHER protocol identifier is treated as non-text and yields an empty string:
+    /// LIP/APRS position beacons (PID 0x0A), status/precoded messages, and unknown PIDs are
+    /// binary, and interpreting their bytes as ASCII produced garbage in the dashboard SDS Log
+    /// (FH-BUG-045 — e.g. a LIP payload `[10, 48, ..]` decoded to the stray text "0"). Returning
+    /// empty lets the dashboard fall back to the protocol-id label (e.g. "[LIP position]")
+    /// instead of showing mojibake. Returns an ASCII string (best-effort).
     fn extract_sds_text(data: &SdsUserData) -> String {
         let bytes = data.to_arr();
-        if bytes.is_empty() {
-            return String::new();
-        }
         // SDS-TL text messaging PIDs: 0x82 (text), 0x80/0x8A (text w/ variants). When the
-        // first byte looks like one of these and there is a 4-byte header, skip it.
+        // first byte is one of these and there is a 4-byte header, skip it. A bare text-coding-
+        // scheme byte (0x01..=0x03) is followed directly by text. Everything else is binary.
         let payload: &[u8] = match bytes.first() {
             Some(0x82) | Some(0x80) | Some(0x8A) if bytes.len() > 4 => &bytes[4..],
-            // Some terminals send a bare text-coding-scheme byte (0x01..=0x03) then text.
             Some(0x01..=0x03) if bytes.len() > 1 => &bytes[1..],
-            _ => &bytes[..],
+            _ => return String::new(),
         };
         payload
             .iter()

--- a/crates/tetra-entities/src/llc/llc_bs_ms.rs
+++ b/crates/tetra-entities/src/llc/llc_bs_ms.rs
@@ -669,8 +669,14 @@ impl Llc {
 
             // Not submitted; check if blocked
             if ssi_blocked.contains(&ack.addr.ssi) {
-                // SSI already has another message waiting for ack, so we cannot submit this one yet
-                tracing::debug!(
+                // This SSI already has an unacked message in flight, so this one must wait —
+                // strict per-link ordering is normal acknowledged-mode flow control
+                // (ETSI EN 300 392-2 §22.3.2.3). Logged at trace, NOT debug: when a radio goes
+                // away with several queued acknowledged SDS, this branch fires on every tick for
+                // every queued message until the backlog drains, which floods the log
+                // (FH-BUG-042 — one departed radio produced 3403 of 4149 lines). The queue still
+                // drains correctly; only the per-tick noise was the defect.
+                tracing::trace!(
                     "SSI {} N(S) {} still blocked by previous message, cannot submit next message",
                     ack.addr.ssi,
                     ack.ns

--- a/crates/tetra-entities/src/mm/components/client_state.rs
+++ b/crates/tetra-entities/src/mm/components/client_state.rs
@@ -1,6 +1,7 @@
 use std::collections::{HashMap, HashSet};
 
 use crate::net_telemetry::{TelemetryEvent, channel::TelemetrySink};
+use tetra_core::TdmaTime;
 use tetra_pdus::mm::enums::energy_saving_mode::EnergySavingMode;
 use tetra_pdus::mm::fields::class_of_ms::ClassOfMs;
 
@@ -51,6 +52,14 @@ pub struct MmClientProperties {
     /// Updated on every UL burst received from this ISSI.
     /// None until first burst received after registration.
     pub last_rssi: Option<f32>,
+    /// Monotonic timestamp of the last uplink burst heard from this MS (updated on every RSSI
+    /// measurement — i.e. whenever the MS is observed transmitting). Distinct from
+    /// `last_registration_time`: a present MS keeps transmitting (PTT / SDS / signalling bursts)
+    /// without necessarily re-registering, so this is the authoritative "still on the air"
+    /// signal. Used at T351 expiry to avoid dropping a radio that is demonstrably present but
+    /// did not answer an unsolicited D-LOCATION-UPDATE-COMMAND (e.g. an energy-economy radio
+    /// asleep when the COMMAND was sent) — which made present stations vanish from the dashboard.
+    pub last_uplink_time: std::time::Instant,
     /// Timestamp (system time) when this MS last registered or re-registered.
     /// Used to enforce periodic registration expiry (T351).
     pub last_registration_time: std::time::Instant,
@@ -81,6 +90,7 @@ impl MmClientProperties {
             monitoring_frame: None,
             monitoring_multiframe: None,
             last_rssi: None,
+            last_uplink_time: std::time::Instant::now(),
             pending_command_sent: false,
             grace_expires_at: None,
             last_registration_time: std::time::Instant::now(),
@@ -168,6 +178,8 @@ impl MmClientMgr {
     /// Update RSSI for a known MS. Silently ignored if MS is not registered.
     pub fn update_client_rssi(&mut self, issi: u32, rssi_dbfs: f32) {
         if let Some(client) = self.clients.get_mut(&issi) {
+            // Every RSSI measurement is an uplink burst we just heard → the MS is on the air now.
+            client.last_uplink_time = std::time::Instant::now();
             let should_log = match client.last_rssi {
                 None => true, // First measurement
                 Some(prev) => (rssi_dbfs - prev).abs() >= 3.0, // Log on >=3dB change
@@ -177,6 +189,17 @@ impl MmClientMgr {
                 tracing::info!("RSSI: ISSI {} = {:.1} dBFS", issi, rssi_dbfs);
             }
         }
+    }
+
+    /// True if an uplink burst from this MS was heard within `within` — a direct sign the radio
+    /// is still on the air, independent of whether it answered an unsolicited
+    /// D-LOCATION-UPDATE-COMMAND. Used to keep a present radio from being torn down at T351
+    /// expiry (it may be an energy-economy radio that was asleep when the COMMAND was sent).
+    pub fn heard_on_air_within(&self, issi: u32, within: std::time::Duration) -> bool {
+        self.clients
+            .get(&issi)
+            .map(|c| c.last_uplink_time.elapsed() < within)
+            .unwrap_or(false)
     }
 
     /// Reset the periodic registration timer for a MS (called on each U-LOCATION-UPDATING-DEMAND).
@@ -229,6 +252,38 @@ impl MmClientMgr {
             })
             .map(|(&issi, _)| issi)
             .collect()
+    }
+
+    /// Decide whether the T351 D-LOCATION-UPDATE-COMMAND for `issi` should be sent on this tick.
+    ///
+    /// The COMMAND is an unsolicited downlink PDU. An energy-economy MS only listens to the
+    /// downlink during its monitoring window, so a COMMAND sent while it sleeps is missed — it
+    /// then never answers and is torn down at the second expiry, making a present radio vanish
+    /// from the dashboard. So:
+    ///   - StayAlive MS (always listening) or an EE MS whose monitoring window is not yet known
+    ///     → send now (`true`);
+    ///   - EE MS during its monitoring window → send now (`true`);
+    ///   - EE MS asleep outside its window → defer (`false`) so the caller retries next tick and
+    ///     sends in the wake window — UNLESS it is overdue by more than `window_wait_secs` beyond
+    ///     the interval, in which case send blind (`true`) so a stale/incorrect window can never
+    ///     suppress the probe forever.
+    pub fn should_send_t351_command_now(&self, issi: u32, ts: TdmaTime, interval_secs: u32, window_wait_secs: u64) -> bool {
+        let Some(c) = self.clients.get(&issi) else {
+            // Unknown client — let the caller proceed; the send is addressed by ISSI and harmless.
+            return true;
+        };
+        let reachable_now = match ee_cycle_frames(c.energy_saving_mode) {
+            None => true, // StayAlive — always reachable
+            Some(cycle_len) => match (c.monitoring_frame, c.monitoring_multiframe) {
+                (Some(f), Some(mf)) => ts.in_ee_monitoring_window(f, mf, cycle_len),
+                _ => true, // EE but the window is not known yet — don't defer
+            },
+        };
+        if reachable_now {
+            return true;
+        }
+        // Sleeping EE MS outside its window: defer to a wake window, but bound the wait.
+        c.last_registration_time.elapsed().as_secs() >= interval_secs as u64 + window_wait_secs
     }
 
     pub fn set_client_class_of_ms(&mut self, issi: u32, class: Option<ClassOfMs>) -> Result<(), ClientMgrErr> {
@@ -397,5 +452,63 @@ impl MmClientMgr {
         } else {
             Err(ClientMgrErr::ClientNotFound { issi })
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+
+    /// The T351 presence guard: a radio heard transmitting recently is reported "on air" so it is
+    /// never torn down at expiry (FH-BUG-044 — present stations vanishing from the dashboard).
+    #[test]
+    fn heard_on_air_tracks_uplink_presence() {
+        let mut mgr = MmClientMgr::new(None);
+        mgr.try_register_client(100, true).unwrap();
+
+        // A freshly-registered MS counts as just heard on the air.
+        assert!(mgr.heard_on_air_within(100, Duration::from_secs(300)));
+        // An unknown ISSI is never "heard".
+        assert!(!mgr.heard_on_air_within(999, Duration::from_secs(300)));
+
+        // After a little real time, a very short window reports "not heard" (would fall through to
+        // the COMMAND/teardown path), while a generous window still reports "present".
+        std::thread::sleep(Duration::from_millis(15));
+        assert!(!mgr.heard_on_air_within(100, Duration::from_millis(5)));
+        assert!(mgr.heard_on_air_within(100, Duration::from_secs(300)));
+
+        // A fresh uplink burst (RSSI measurement) re-stamps the radio as heard right now.
+        std::thread::sleep(Duration::from_millis(15));
+        assert!(!mgr.heard_on_air_within(100, Duration::from_millis(5)));
+        mgr.update_client_rssi(100, -60.0);
+        assert!(mgr.heard_on_air_within(100, Duration::from_millis(5)));
+    }
+
+    /// The T351 COMMAND is gated to a sleeping EE radio's wake window so it is never missed
+    /// (FH-BUG-044 follow-up). StayAlive radios are always reachable; EE radios are sent only
+    /// in their monitoring window.
+    #[test]
+    fn t351_command_gated_to_ee_monitoring_window() {
+        let mut mgr = MmClientMgr::new(None);
+        mgr.try_register_client(100, true).unwrap();
+        let ts = TdmaTime::default();
+
+        // StayAlive: always reachable → send now.
+        assert!(mgr.should_send_t351_command_now(100, ts, 300, 6));
+        // Unknown ISSI: caller proceeds.
+        assert!(mgr.should_send_t351_command_now(999, ts, 300, 6));
+
+        // Eg1 radio (cycle 2 frames) with a known window at frame 1 / multiframe 1.
+        mgr.set_client_energy_saving_mode(100, EnergySavingMode::Eg1).unwrap();
+        mgr.set_client_monitoring_window(100, Some(1), Some(1)).unwrap();
+        // m=1,f=1 → cur_abs 0, in window (cycle 2) → send.
+        assert!(mgr.should_send_t351_command_now(100, TdmaTime { t: 1, f: 1, m: 1, h: 0 }, 300, 6));
+        // m=1,f=2 → cur_abs 1, out of window, freshly registered (not overdue) → defer.
+        assert!(!mgr.should_send_t351_command_now(100, TdmaTime { t: 1, f: 2, m: 1, h: 0 }, 300, 6));
+
+        // EE radio whose monitoring window is unknown is never deferred (sent immediately).
+        mgr.set_client_monitoring_window(100, None, None).unwrap();
+        assert!(mgr.should_send_t351_command_now(100, TdmaTime { t: 1, f: 2, m: 1, h: 0 }, 300, 6));
     }
 }

--- a/crates/tetra-entities/src/mm/mm_bs.rs
+++ b/crates/tetra-entities/src/mm/mm_bs.rs
@@ -433,6 +433,12 @@ impl MmBs {
 
         let was_pending = self.client_mgr.is_pending_command(issi);
         let is_new = !self.client_mgr.client_is_known(issi);
+        // A client still known to client_mgr but absent from the subscriber registry was dropped by
+        // a T351 confirmed-gone expiry (we keep the client to preserve its groups). On its return
+        // we must re-add it to the registry + dashboard + Brew, or it stays invisible and SDS to it
+        // is misrouted as non-local. Sampled before the coverage-return re-affiliation below, whose
+        // affiliate() would otherwise recreate the registry entry and mask the drop.
+        let was_dropped = !is_new && !self.config.state_read().subscribers.is_registered(issi);
         if !is_new {
             // MS is re-registering while already known. Three cases:
             //
@@ -480,8 +486,10 @@ impl MmBs {
                 false
             };
 
-            // needs_cleanup: Roaming = MS rebooted, need CMCE reset
-            // was_pending: T351 expired, we already sent Deregister to Brew — just re-register
+            // needs_cleanup: Roaming = MS rebooted, need full CMCE/Brew reset (deregister+register).
+            // was_pending: the MS is answering our T351 COMMAND — Brew still holds the subscriber
+            // (teardown is deferred to the confirmed-gone second expiry, which this answer prevents),
+            // so no Brew action is needed; CMCE is re-affiliated via the coverage-return path below.
             if needs_cleanup {
                 let old_groups: Vec<u32> = self.client_mgr
                     .get_client_by_issi(issi)
@@ -493,21 +501,22 @@ impl MmBs {
                 self.emit_subscriber_update(queue, issi, Vec::new(), BrewSubscriberAction::Deregister);
                 self.emit_subscriber_update(queue, issi, Vec::new(), BrewSubscriberAction::Register);
             } else if was_pending {
-                // T351 re-registration: Brew already got Deregister — just re-register
-                // CMCE gets a fresh affiliate when groups are processed below
-                tracing::info!("MM: ISSI {} re-registered after T351 COMMAND", issi);
+                tracing::info!("MM: ISSI {} re-registered after T351 COMMAND (Brew already holds it)", issi);
             }
             // Always reset the registration timer on any re-registration
             self.client_mgr.reset_registration_timer(issi);
         }
-        // Determine if we need to emit Register toward Brew.
-        // We do this when:
+        // Determine if we need to emit Register toward Brew. Only when Brew was actually torn down
+        // (or never had this ISSI):
         //   A) Terminal is genuinely new (never seen before).
         //   B) Terminal is known but re-attaching via ItsiAttach — migrated from another network.
-        //   C) Terminal is known but had pending_command_sent=true — T351 expired, we sent COMMAND
-        //      and deregistered from Brew. Now terminal is back, re-register.
+        //   C) Terminal was dropped from Brew at a T351 confirmed-gone (second) expiry and is now
+        //      back (was_dropped); the re-add path above already restored it locally.
+        // A plain T351 re-registration (was_pending) is deliberately NOT here: teardown no longer
+        // happens at first expiry, so Brew still holds the subscriber — re-registering would be a
+        // needless REGISTER every interval (the Brew flap this avoids).
         let is_itsi_attach = pdu.location_update_type == LocationUpdateType::ItsiAttach;
-        let needs_brew_register = is_new || (!is_new && is_itsi_attach) || (!is_new && was_pending);
+        let needs_brew_register = is_new || (!is_new && is_itsi_attach) || was_dropped;
 
         if is_new {
             match self.client_mgr.try_register_client(issi, true) {
@@ -523,8 +532,20 @@ impl MmBs {
             tracing::warn!("Failed updating roaming MS {}: {:?}", issi, e);
             return;
         }
+        // Re-add a radio that had been dropped by a T351 confirmed-gone expiry. The client never
+        // left client_mgr (PTT keeps working), but the subscriber registry and the dashboard were
+        // torn down at the drop; restore both so SDS routing and the dashboard reflect reality.
+        // register() resets attached_groups — the group-identity processing / coverage-return
+        // re-affiliation below rebuilds them, so this must run before either.
+        if was_dropped {
+            self.config.state_write().subscribers.register(issi);
+            if let Some(sink) = &self.telemetry {
+                sink.send(crate::net_telemetry::TelemetryEvent::MsRegistration { issi });
+            }
+            tracing::info!("MM: ISSI {} re-appeared after T351 drop — re-registered in dashboard + subscriber registry", issi);
+        }
         if needs_brew_register {
-            if !is_new {
+            if !is_new && is_itsi_attach {
                 tracing::info!("MM: ISSI {} re-attaching via ItsiAttach (returned from another network) — re-registering in Brew", issi);
             }
             self.emit_subscriber_update(queue, issi, Vec::new(), BrewSubscriberAction::Register);
@@ -618,7 +639,13 @@ impl MmBs {
                         state.subscribers.affiliate(issi, gssi);
                     }
                 }
-                self.emit_subscriber_update(queue, issi, stored_groups, BrewSubscriberAction::Affiliate);
+                self.emit_subscriber_update(queue, issi, stored_groups.clone(), BrewSubscriberAction::Affiliate);
+                // Refresh the dashboard's group list for this MS. It may have just been re-added
+                // with an empty entry by the T351-drop recovery above, and coverage-return emits no
+                // per-group telemetry otherwise, so the radio would show with no groups.
+                if let Some(sink) = &self.telemetry {
+                    sink.send(crate::net_telemetry::TelemetryEvent::MsGroupsSnapshot { issi, gssis: stored_groups });
+                }
             }
         }
 
@@ -1602,14 +1629,65 @@ impl TetraEntityTrait for MmBs {
                     issi
                 );
                 Self::send_d_location_update_command(queue, issi, 0);
+                // Confirmed gone: the terminal ignored the first COMMAND through the whole grace
+                // period. NOW tear it down everywhere — Brew backhaul, the dashboard, and the local
+                // subscriber registry — but keep it in client_mgr so its groups survive for
+                // coverage-return re-affiliation if it ever comes back. The guard makes this fire
+                // once, on the registered→gone transition: this branch re-runs every interval for a
+                // radio that stays away. The client is NOT removed, so MsDeregistration is never
+                // emitted; MsTimeoutDrop is the sole drop signal here.
+                // Presence guard (FH-BUG-044 — present stations vanishing from the dashboard at
+                // the T351 interval): only tear a radio down if it is genuinely gone. A radio we
+                // have heard transmitting within the re-registration interval is demonstrably
+                // present even if it never answered the unsolicited COMMAND — e.g. an
+                // energy-economy radio that was asleep when the (un-gated) COMMAND was sent on the
+                // MCCH. Dropping it here would make a live station disappear from the dashboard
+                // every interval. Keep it (the reset_registration_timer below re-arms the clock);
+                // only a radio with NO sign of life on the air for a whole interval is torn down.
+                let interval = std::time::Duration::from_secs(interval_secs as u64);
+                let heard_on_air = self.client_mgr.heard_on_air_within(issi, interval);
+                let still_registered = self.config.state_read().subscribers.is_registered(issi);
+                if still_registered && heard_on_air {
+                    tracing::info!(
+                        "MM: ISSI {} ignored the T351 COMMAND but was heard on air within {}s — keeping it (present, not dropping from dashboard)",
+                        issi, interval_secs
+                    );
+                }
+                if still_registered && !heard_on_air {
+                    // Tell Brew to stop routing calls/SDS to this terminal until it re-registers.
+                    // Deferred to here (not first expiry) so a healthy radio that answers the
+                    // COMMAND within grace never flaps Brew; only a genuinely-gone radio is torn
+                    // down, exactly once.
+                    let groups: Vec<u32> = self.client_mgr
+                        .get_client_by_issi(issi)
+                        .map(|c| c.groups.iter().copied().collect())
+                        .unwrap_or_default();
+                    if !groups.is_empty() {
+                        self.emit_subscriber_update(queue, issi, groups, BrewSubscriberAction::Deaffiliate);
+                    }
+                    self.emit_subscriber_update(queue, issi, Vec::new(), BrewSubscriberAction::Deregister);
+                    // Drop from the local subscriber registry + dashboard.
+                    self.config.state_write().subscribers.deregister(issi);
+                    if let Some(sink) = &self.telemetry {
+                        sink.send(crate::net_telemetry::TelemetryEvent::MsTimeoutDrop { issi });
+                    }
+                }
                 self.client_mgr.reset_registration_timer(issi);
                 self.recovery_mark_dirty();
                 continue;
             }
-            // First expiry — send COMMAND and wait grace period (60s) for response.
-            // Do NOT remove_client here: keeping the client in registry preserves ESM
-            // and group state so the terminal re-registers cleanly without losing EE mode.
-            // Only notify Brew so it stops routing calls to this terminal until it re-registers.
+            // First expiry — send the COMMAND and arm the 60s grace, nothing else. Emit NO teardown
+            // (Brew, dashboard, or local registry). The terminal almost always answers within grace
+            // and re-registers (MTM800/MXP600/MTM5400 rely on BS initiative — see above), so any
+            // teardown here is a flap: it stayed registered on the air (PTT kept working) but, when
+            // it answered, the re-registration path took the `is_new == false` branch and never
+            // re-added it — so it vanished from the dashboard forever, SDS to it was misrouted as
+            // non-local, and Brew was needlessly deregistered+reregistered every interval. All
+            // teardown is deferred to the confirmed-gone second expiry above, which fires only if
+            // the grace elapses with no answer.
+            //
+            // Do NOT remove_client here either: keeping the client in registry preserves ESM and
+            // group state so the terminal re-registers cleanly without losing EE mode.
             //
             // handle = 0: the L2 handle is inert (MLE addresses downlink MM PDUs by ISSI; see
             // mle_bs.rs rx_lmm_mle_unitdata_req + uplink ind hardcoded handle 0). The COMMAND
@@ -1617,26 +1695,20 @@ impl TetraEntityTrait for MmBs {
             // longer removes the client or sends REJECT, so the terminal's groups survive an
             // unanswered COMMAND and are restored by coverage-return re-affiliation on its return
             // (FH-BUG-031 fix).
-            Self::send_d_location_update_command(queue, issi, 0);
-            self.client_mgr.set_pending_command(issi, 60);
-            let groups: Vec<u32> = self.client_mgr
-                .get_client_by_issi(issi)
-                .map(|c| c.groups.iter().copied().collect())
-                .unwrap_or_default();
-            if !groups.is_empty() {
-                self.emit_subscriber_update(queue, issi, groups, BrewSubscriberAction::Deaffiliate);
-            }
-            self.emit_subscriber_update(queue, issi, Vec::new(), BrewSubscriberAction::Deregister);
-            // Mark as detached in state but keep in client_mgr (preserves ESM + groups)
-            self.config.state_write().subscribers.deregister(issi);
-            // Tell telemetry consumers the radio dropped for not answering T351. This is the
-            // edge: first-expiry fires once (subsequent ticks hit the re-attract branch above),
-            // so it is the right place to signal a drop. The client stays in client_mgr by
-            // design (groups preserved), so remove_client — and thus MsDeregistration — is NOT
-            // emitted here; this dedicated event is the only drop signal for this path. It also
-            // lets the dashboard drop the stale station from its list.
-            if let Some(sink) = &self.telemetry {
-                sink.send(crate::net_telemetry::TelemetryEvent::MsTimeoutDrop { issi });
+            //
+            // EE gating (FH-BUG-044 follow-up — present energy-economy radios vanishing from the
+            // dashboard): a sleeping EE MS only listens to the downlink during its monitoring
+            // window, so an un-gated COMMAND sent while it sleeps is missed; it then never answers
+            // and is dropped at the second expiry. Send the COMMAND only when the MS is reachable
+            // (StayAlive always; EE on its wake window), retrying on later ticks until the window
+            // opens. A bounded fallback (interval + T351_EE_WINDOW_WAIT_SECS) sends it blind so a
+            // stale/incorrect window can never suppress the probe forever. The grace clock only
+            // starts once the COMMAND is actually sent, so a deferred wake-window send still gets
+            // the full grace to answer.
+            const T351_EE_WINDOW_WAIT_SECS: u64 = 6;
+            if self.client_mgr.should_send_t351_command_now(issi, ts, interval_secs, T351_EE_WINDOW_WAIT_SECS) {
+                Self::send_d_location_update_command(queue, issi, 0);
+                self.client_mgr.set_pending_command(issi, 60);
             }
         }
 

--- a/crates/tetra-entities/src/net_dashboard/radioid.rs
+++ b/crates/tetra-entities/src/net_dashboard/radioid.rs
@@ -13,7 +13,8 @@ use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 /// Per-ID lookup endpoint. radioid.net answers `{"count":N,"results":[{"id":..,"callsign":..}]}`.
-const API_URL_PREFIX: &str = "https://radioid.net/api/dmr/user/?id=";
+const API_URL_PREFIX:      &str = "https://radioid.net/api/dmr/user/?id=";
+const RPTR_API_URL_PREFIX: &str = "https://radioid.net/api/dmr/repeater/?id=";
 /// Politeness delay between successive API calls (each ID is fetched only once, ever).
 const FETCH_THROTTLE: Duration = Duration::from_millis(1100);
 const HTTP_TIMEOUT: Duration = Duration::from_secs(8);
@@ -128,9 +129,23 @@ fn worker_loop(rx: crossbeam_channel::Receiver<u32>, inner: Arc<Mutex<Inner>>) {
 }
 
 /// Fetch one ID. `Ok(Some(callsign))` = found, `Ok(None)` = confirmed absent, `Err` = transient.
+///
+/// Tries the user database first. If the ID is not found there, tries the repeater database.
+/// This covers both individual operators (7-digit IDs) and repeaters/gateways (6-digit IDs),
+/// without hard-coding a digit-count heuristic that may not hold universally.
 fn fetch_callsign(client: &reqwest::blocking::Client, issi: u32) -> Result<Option<String>, String> {
-    let url = format!("{API_URL_PREFIX}{issi}");
-    let resp = client.get(&url).send().map_err(|e| e.to_string())?;
+    // Try user database first.
+    if let Some(cs) = query_radioid(client, &format!("{API_URL_PREFIX}{issi}"))? {
+        return Ok(Some(cs));
+    }
+    // Fall back to repeater database.
+    query_radioid(client, &format!("{RPTR_API_URL_PREFIX}{issi}"))
+}
+
+/// Query a RadioID API endpoint and extract the callsign from `results[0].callsign`.
+/// Returns `Ok(Some(callsign))` = found, `Ok(None)` = confirmed absent, `Err` = transient.
+fn query_radioid(client: &reqwest::blocking::Client, url: &str) -> Result<Option<String>, String> {
+    let resp = client.get(url).send().map_err(|e| e.to_string())?;
     if !resp.status().is_success() {
         return Err(format!("HTTP {}", resp.status()));
     }

--- a/crates/tetra-entities/src/net_dashboard/server.rs
+++ b/crates/tetra-entities/src/net_dashboard/server.rs
@@ -630,9 +630,25 @@ impl DashboardServer {
         std::thread::Builder::new()
             .name("dashboard-server".into())
             .spawn(move || {
-                let listener = match TcpListener::bind(&addr) {
-                    Ok(l) => { tracing::info!("Dashboard listening on http://{}", addr); l }
-                    Err(e) => { tracing::error!("Dashboard failed to bind {}: {}", addr, e); return; }
+                // Retry the bind instead of giving up after a single failure (FH-BUG-043).
+                // On a cold boot the configured bind address may not be assigned yet — DHCP
+                // lease still pending, or a VPN/wg/tun interface that comes up after the
+                // service — so the first bind can fail with EADDRNOTAVAIL even with
+                // After=network-online.target. Previously the thread logged once and exited,
+                // leaving the dashboard permanently down (while the RF stack ran fine) until a
+                // manual stop/start. Retrying lets it self-heal once the address appears. This
+                // loop runs only on the dashboard thread, so it can never block the PHY/main loop.
+                let listener = loop {
+                    match TcpListener::bind(&addr) {
+                        Ok(l) => { tracing::info!("Dashboard listening on http://{}", addr); break l; }
+                        Err(e) => {
+                            tracing::error!(
+                                "Dashboard failed to bind {}: {} — retrying in 5s (interface/IP may not be ready yet)",
+                                addr, e
+                            );
+                            std::thread::sleep(std::time::Duration::from_secs(5));
+                        }
+                    }
                 };
                 for stream in listener.incoming() {
                     let Ok(stream) = stream else { continue };
@@ -2265,7 +2281,7 @@ fn serve_telegram_post(
 
     let bot_token = telegram_resolve_token(&json, shared_config);
     if !telegram_token_acceptable(&bot_token) {
-        http_response(stream, 400, "Token invalid: fără spații/caractere de control și trebuie să conțină ':'.");
+        http_response(stream, 400, "Invalid token: no spaces or control characters, and must contain ':'.");
         return;
     }
     let chat_ids = match json.get("chat_ids").and_then(|v| v.as_array()) {

--- a/crates/tetra-entities/src/net_telegram/format.rs
+++ b/crates/tetra-entities/src/net_telegram/format.rs
@@ -68,22 +68,22 @@ fn frame(emoji: &str, title: &str, lines: &[String], station: &StationInfo) -> S
 
 /// A radio attached to the cell.
 pub fn connect(station: &StationInfo, issi: u32) -> String {
-    frame("🟢", "Radio conectat", &[format!("ISSI: <code>{issi}</code>")], station)
+    frame("🟢", "Radio connected", &[format!("ISSI: <code>{issi}</code>")], station)
 }
 
 /// A radio detached / deregistered.
 pub fn disconnect(station: &StationInfo, issi: u32) -> String {
-    frame("🔴", "Radio deconectat", &[format!("ISSI: <code>{issi}</code>")], station)
+    frame("🔴", "Radio disconnected", &[format!("ISSI: <code>{issi}</code>")], station)
 }
 
 /// A radio was dropped for not answering the periodic registration (T351).
 pub fn t351_drop(station: &StationInfo, issi: u32) -> String {
     frame(
         "📴",
-        "Radio căzut (fără răspuns la T351)",
+        "Radio dropped (no T351 response)",
         &[
             format!("ISSI: <code>{issi}</code>"),
-            "Motiv: nu a răspuns la cererea periodică de re-înregistrare.".to_string(),
+            "Reason: did not answer the periodic re-registration request.".to_string(),
         ],
         station,
     )
@@ -93,17 +93,17 @@ pub fn t351_drop(station: &StationInfo, issi: u32) -> String {
 /// empty for binary LIP payloads).
 pub fn lip_beacon(station: &StationInfo, source_issi: u32, dest_issi: u32, text: &str) -> String {
     let mut lines = vec![
-        format!("De la ISSI: <code>{source_issi}</code>"),
-        format!("Către: <code>{dest_issi}</code>"),
+        format!("From ISSI: <code>{source_issi}</code>"),
+        format!("To: <code>{dest_issi}</code>"),
     ];
     let trimmed = text.trim();
     if trimmed.is_empty() {
-        lines.push("Poziție: payload LIP binar (nedecodat).".to_string());
+        lines.push("Position: binary LIP payload (undecoded).".to_string());
     } else {
         let body = truncate_chars(trimmed, 200);
-        lines.push(format!("Poziție: {}", escape_html(&body)));
+        lines.push(format!("Position: {}", escape_html(&body)));
     }
-    frame("📍", "Baliză poziție LIP/APRS", &lines, station)
+    frame("📍", "LIP/APRS position beacon", &lines, station)
 }
 
 /// The Brew/TetraPack backhaul connected or disconnected.
@@ -111,15 +111,15 @@ pub fn backhaul(station: &StationInfo, connected: bool, server_version: u8) -> S
     if connected {
         frame(
             "🛰️",
-            "Backhaul Brew conectat",
-            &[format!("Versiune server: v{server_version}")],
+            "Brew backhaul connected",
+            &[format!("Server version: v{server_version}")],
             station,
         )
     } else {
         frame(
             "🛰️",
-            "Backhaul Brew deconectat",
-            &["Stația funcționează în mod fallback (local).".to_string()],
+            "Brew backhaul disconnected",
+            &["Station running in fallback mode (local).".to_string()],
             station,
         )
     }
@@ -129,9 +129,9 @@ pub fn backhaul(station: &StationInfo, connected: bool, server_version: u8) -> S
 /// were dropped beyond the ones shown.
 pub fn critical_logs(station: &StationInfo, lines: &[(String, String)], extra: usize) -> String {
     let title = if lines.iter().any(|(lvl, _)| lvl == "ERROR") {
-        "Eroare în stație"
+        "Station error"
     } else {
-        "Avertisment în stație"
+        "Station warning"
     };
     let mut body: Vec<String> = lines
         .iter()
@@ -142,7 +142,7 @@ pub fn critical_logs(station: &StationInfo, lines: &[(String, String)], extra: u
         })
         .collect();
     if extra > 0 {
-        body.push(format!("… și încă {extra} mesaj(e).", ));
+        body.push(format!("… and {extra} more message(s)."));
     }
     frame("🚨", title, &body, station)
 }
@@ -151,8 +151,8 @@ pub fn critical_logs(station: &StationInfo, lines: &[(String, String)], extra: u
 pub fn test_message(station: &StationInfo) -> String {
     frame(
         "✅",
-        "Test alerte Telegram",
-        &["Alertele FlowStation sunt configurate corect. Vei primi notificări aici.".to_string()],
+        "Telegram alert test",
+        &["FlowStation alerts are configured correctly. You'll receive notifications here.".to_string()],
         station,
     )
 }
@@ -168,7 +168,7 @@ mod tests {
     #[test]
     fn connect_has_title_issi_and_footer() {
         let m = connect(&station(), 2260571);
-        assert!(m.contains("<b>Radio conectat</b>"));
+        assert!(m.contains("<b>Radio connected</b>"));
         assert!(m.contains("<code>2260571</code>"));
         assert!(m.contains("MCC 901"));
         assert!(m.starts_with("🟢"));
@@ -189,14 +189,14 @@ mod tests {
             ("ERROR".to_string(), "e1".to_string()),
         ];
         let m = critical_logs(&station(), &lines, 3);
-        assert!(m.contains("<b>Eroare în stație</b>"));
-        assert!(m.contains("și încă 3"));
+        assert!(m.contains("<b>Station error</b>"));
+        assert!(m.contains("and 3 more"));
     }
 
     #[test]
     fn lip_handles_empty_and_textual_payload() {
         let empty = lip_beacon(&station(), 1, 2, "");
-        assert!(empty.contains("binar"));
+        assert!(empty.contains("binary"));
         let textual = lip_beacon(&station(), 1, 2, "4426.12N 02606.55E");
         assert!(textual.contains("4426.12N"));
     }


### PR DESCRIPTION
When a user ID lookup returns no result, fall back to the RadioID
repeater API (/api/dmr/repeater/?id=<n>). This covers 6-digit repeater
and gateway ISSIs (e.g. GB7RM = 234171) that are absent from the user
database but present in the repeater database.

The change is minimal: fetch_callsign() is split into fetch_callsign()
+ query_radioid() helper, and the repeater endpoint is tried only when
the user endpoint returns no match. Both endpoints share the same
throttle, cache and persistence logic unchanged.

Tested on a live FlowStation with ISSI 234171 (GB7RM) successfully
resolving where it previously returned NotFound.