### PR TITLE
v0.3.6 — DJ2TH external integrations (Asterisk, DAPNET, Snom, GeoAlarm, TPG2200) + dashboard

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -156,7 +156,7 @@ dependencies = [
 
 [[package]]
 name = "bluestation-bs"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "clap",
  "crossbeam-channel",
@@ -1833,7 +1833,7 @@ dependencies = [
 
 [[package]]
 name = "tetra-config"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "chrono-tz",
  "serde",
@@ -1843,7 +1843,7 @@ dependencies = [
 
 [[package]]
 name = "tetra-core"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "bitcode",
  "chrono",
@@ -1859,7 +1859,7 @@ dependencies = [
 
 [[package]]
 name = "tetra-entities"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "as-any",
  "base64",
@@ -1891,7 +1891,7 @@ dependencies = [
 
 [[package]]
 name = "tetra-pdus"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "tetra-config",
  "tetra-core",
@@ -1901,7 +1901,7 @@ dependencies = [
 
 [[package]]
 name = "tetra-saps"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "tetra-core",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,7 +86,7 @@ useless_format = "allow"
 while_let_loop = "allow"
 
 [workspace.package]
-version = "0.3.5"
+version = "0.3.6"
 edition = "2024"
 authors = ["Razvan Zeces / FlowStation.Dev"]
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -255,6 +255,7 @@ Available at `http://<bts-ip>:8080` when `[dashboard]` is configured.
 ## Credits
 
 - **Mihajlo YU4MSH** ([misadeks](https://github.com/misadeks)) for contributions to full-duplex (P2P) calls and the Home Mode Display feature + all the continued support.
+- **Torben DJ2TH** ([Torben-DJ2TH](https://github.com/Torben-DJ2TH)) for the external integrations: DAPNET paging, Asterisk SIP/PSTN telephony, Snom desk-phone notifications, and GeoAlarm geofencing.
 - **Harald Welte** and the **osmocom** team for foundational osmocom-tetra work
 - **Tatu Peltola** for rust-soapysdr timestamping and the native Rust Viterbi encoder/decoder used in LMAC
 - **MidnightBlueLabs** for [tetra-bluestation](https://github.com/MidnightBlueLabs/tetra-bluestation), the base this project builds on

--- a/bins/bluestation-bs/Cargo.toml
+++ b/bins/bluestation-bs/Cargo.toml
@@ -7,6 +7,12 @@ edition.workspace = true
 name = "bluestation-bs"
 path = "src/main.rs"
 
+[features]
+# Compile the Asterisk SIP/RTP bridge (and link the native TETRA codec) into the
+# device binary. Off by default so the standard build needs no codec.
+default = []
+asterisk = ["tetra-entities/asterisk"]
+
 [dependencies]
 tetra-core = { workspace = true }
 tetra-config = { workspace = true }

--- a/bins/bluestation-bs/src/main.rs
+++ b/bins/bluestation-bs/src/main.rs
@@ -12,13 +12,18 @@ use tetra_entities::net_control::{
 use tetra_config::bluestation::{PhyBackend, SharedConfig, StackConfig, parsing};
 use tetra_core::{TdmaTime, debug};
 use tetra_entities::MessageRouter;
+#[cfg(feature = "asterisk")]
+use tetra_entities::net_asterisk::entity::AsteriskEntity;
 use tetra_entities::net_brew::entity::BrewEntity;
 use tetra_entities::net_brew::new_websocket_transport;
+use tetra_entities::net_dapnet::spawn_dapnet_worker;
 use tetra_entities::net_dashboard::DashboardServer;
-use tetra_entities::net_telegram::{TelegramAlerter, telegram_alert_channel};
+use tetra_entities::net_geoalarm::{GeoAlarmSink, spawn_geoalarm_worker};
+use tetra_entities::net_snom::{snom_notify_channel, spawn_snom_notify_worker};
+use tetra_entities::net_telegram::{TelegramAlertSink, TelegramAlerter, telegram_alert_channel};
 use tetra_entities::net_telemetry::worker::TelemetryWorker;
 use tetra_entities::net_telemetry::{
-    TELEMETRY_HEARTBEAT_INTERVAL, TELEMETRY_HEARTBEAT_TIMEOUT, TELEMETRY_PROTOCOL_VERSION, TelemetrySource, telemetry_channel,
+    TELEMETRY_HEARTBEAT_INTERVAL, TELEMETRY_HEARTBEAT_TIMEOUT, TELEMETRY_PROTOCOL_VERSION, TelemetrySink, TelemetrySource, telemetry_channel,
 };
 use tetra_entities::network::transports::websocket::{WebSocketTransport, WebSocketTransportConfig};
 use tetra_entities::{
@@ -139,13 +144,18 @@ fn start_control_worker(cfg: SharedConfig, command_dispatchers: HashMap<TetraEnt
 }
 
 /// Start base station stack
-fn build_bs_stack(cfg: &mut SharedConfig, config_path: &str) -> (MessageRouter, Option<TelemetrySource>, HashMap<TetraEntity, CommandDispatcher>) {
+fn build_bs_stack(
+    cfg: &mut SharedConfig,
+    config_path: &str,
+) -> (MessageRouter, Option<TelemetrySource>, HashMap<TetraEntity, CommandDispatcher>, Option<TelemetrySink>) {
     let mut router = MessageRouter::new(cfg.clone());
 
     // Build telemetry sink/source — always create if either telemetry or dashboard is enabled
     let needs_telemetry = cfg.config().telemetry.is_some()
         || cfg.config().dashboard.is_some()
-        || cfg.config().telegram.is_some();
+        || cfg.config().telegram.is_some()
+        || cfg.config().geoalarm.enabled
+        || cfg.effective_snom_notify().enabled;
     let (tsink, tsource) = if needs_telemetry {
         let (a, b) = telemetry_channel();
         (Some(a), Some(b))
@@ -260,10 +270,25 @@ fn build_bs_stack(cfg: &mut SharedConfig, config_path: &str) -> (MessageRouter, 
         eprintln!(" -> Brew/TetraPack integration enabled");
     }
 
+    // Register Asterisk SIP/RTP entity if enabled. Only compiled in with the
+    // `asterisk` feature, which links the native TETRA codec.
+    #[cfg(feature = "asterisk")]
+    if cfg.config().asterisk.enabled {
+        match AsteriskEntity::new(cfg.clone()) {
+            Ok(asterisk_entity) => {
+                router.register_entity(Box::new(asterisk_entity));
+                eprintln!(" -> Asterisk SIP integration enabled");
+            }
+            Err(err) => {
+                panic!("Failed to start Asterisk SIP integration: {}", err);
+            }
+        }
+    }
+
     // Init network time
     router.set_dl_time(TdmaTime::default());
 
-    (router, tsource, c_d)
+    (router, tsource, c_d, tsink)
 }
 
 #[derive(Parser, Debug)]
@@ -329,7 +354,28 @@ fn main() {
         );
     }
 
-    let (mut router, tsource, cdispatchers) = build_bs_stack(&mut cfg, &args.config);
+    let (mut router, tsource, cdispatchers, dapnet_telemetry_sink) =
+        build_bs_stack(&mut cfg, &args.config);
+    let dapnet_cmd_tx = cdispatchers
+        .get(&TetraEntity::Cmce)
+        .map(|dispatcher| dispatcher.clone_sender());
+    let mut dapnet_telegram_sink: Option<TelegramAlertSink> = None;
+    #[allow(unused_assignments)]
+    let mut geoalarm_sink: Option<GeoAlarmSink> = None;
+
+    // Snom XML NOTIFY worker — off-path; idles when disabled and reads settings live.
+    let (snom_sink, snom_source) = snom_notify_channel();
+    spawn_snom_notify_worker(cfg.clone(), snom_source);
+    let snom_notify_sink = Some(snom_sink);
+    if cfg.effective_snom_notify().enabled {
+        let snom = cfg.effective_snom_notify();
+        eprintln!(
+            " -> Snom NOTIFY integration enabled (AMI {}:{}, endpoints={})",
+            snom.ami_host,
+            snom.ami_port,
+            snom.endpoints.join(",")
+        );
+    }
 
     // Start Telemetry and Control threads, if enabled
     // If dashboard is also enabled, tee the telemetry events to both.
@@ -344,13 +390,24 @@ fn main() {
         let alert_sink = if has_telegram {
             let (sink, alert_source) = telegram_alert_channel();
             let alert_cfg = cfg.clone();
+            let snom_for_alerts = snom_notify_sink.clone();
             thread::Builder::new().name("telegram-alerter".into()).spawn(move || {
-                TelegramAlerter::new(alert_cfg, alert_source).run();
+                TelegramAlerter::new(alert_cfg, alert_source)
+                    .with_snom_sink(snom_for_alerts)
+                    .run();
             }).expect("failed to spawn telegram-alerter thread");
             Some(sink)
         } else {
             None
         };
+        dapnet_telegram_sink = alert_sink.clone();
+        // GeoAlarm worker — fed TETRA LIP positions from the telemetry fan-out below.
+        geoalarm_sink = spawn_geoalarm_worker(
+            cfg.clone(),
+            dapnet_cmd_tx.clone(),
+            alert_sink.clone(),
+            snom_notify_sink.clone(),
+        );
 
         // Optional dashboard HTTP server.
         let dashboard: Option<std::sync::Arc<DashboardServer>> = if has_dashboard {
@@ -441,6 +498,8 @@ fn main() {
         {
             let dash = dashboard.clone();
             let alert = alert_sink.clone();
+            let snom = snom_notify_sink.clone();
+            let geoalarm = geoalarm_sink.clone();
             thread::Builder::new().name("telemetry-fanout".into()).spawn(move || {
                 use tetra_entities::health::registry as health_registry;
                 use tetra_entities::net_telemetry::TelemetryEvent;
@@ -466,8 +525,24 @@ fn main() {
                                 TelemetryEvent::MsRssi { .. } => health_registry().note_radio_activity(),
                                 _ => {}
                             }
+                            // Feed decoded TETRA LIP positions (SDS protocol-id 10, inbound from
+                            // a radio) to the GeoAlarm worker so it can geofence them.
+                            if let Some(g) = &geoalarm
+                                && let TelemetryEvent::SdsLog {
+                                    direction,
+                                    source_issi,
+                                    protocol_id,
+                                    text,
+                                    ..
+                                } = &event
+                                && *protocol_id == 10
+                                && direction == "rx"
+                            {
+                                g.send_tetra_lip(*source_issi, text);
+                            }
                             if let Some(d) = &dash { d.handle_telemetry(event.clone()); }
                             if let Some(s) = &alert { s.send_event(event.clone()); }
+                            if let Some(s) = &snom { s.send_event(event.clone()); }
                             if let Some(t) = &tee_sink { t.send(event); }
                         }
                         None => break,
@@ -483,6 +558,9 @@ fn main() {
     if cfg.config().control.is_some() {
         start_control_worker(cfg.clone(), cdispatchers);
     };
+
+    // DAPNET worker — off-path; idles when disabled and reads settings live.
+    spawn_dapnet_worker(cfg.clone(), dapnet_cmd_tx, dapnet_telegram_sink, dapnet_telemetry_sink);
 
     // Set up Ctrl+C handler for graceful shutdown.
     // Also installs lifecycle control so RestartService / ShutdownService commands

--- a/crates/tetra-config/src/bluestation/config.rs
+++ b/crates/tetra-config/src/bluestation/config.rs
@@ -2,7 +2,11 @@ use serde::Deserialize;
 use std::sync::{Arc, RwLock};
 use tetra_core::freqs::FreqInfo;
 
-use crate::bluestation::{CfgCellInfo, CfgControl, CfgEmergency, CfgHealth, CfgNetInfo, CfgPhyIo, CfgRecovery, CfgSecurity, CfgWxService, PhyBackend, StackState};
+use crate::bluestation::{
+    CfgAsterisk, CfgCellInfo, CfgControl, CfgDapnet, CfgEmergency, CfgHealth, CfgGeoalarm,
+    CfgNetInfo, CfgPhyIo, CfgRecovery, CfgSecurity, CfgSnomNotify, CfgTpg2200Action, CfgWxService,
+    PhyBackend, StackState,
+};
 
 use super::sec_dashboard::CfgDashboard;
 use super::sec_brew::CfgBrew;
@@ -71,6 +75,21 @@ pub struct StackConfig {
 
     /// Brew protocol (TetraPack/BrandMeister) configuration
     pub brew: Option<CfgBrew>,
+
+    /// Asterisk SIP/RTP bridge configuration.
+    pub asterisk: CfgAsterisk,
+
+    /// DAPNET inbound-message forwarding configuration.
+    pub dapnet: CfgDapnet,
+
+    /// Geo-fence alarm configuration for TETRA/MeshCom positions.
+    pub geoalarm: CfgGeoalarm,
+
+    /// Token-protected ActionURL trigger for Motorola TPG2200 Call-Out.
+    pub tpg2200_action: CfgTpg2200Action,
+
+    /// Snom XML minibrowser notifications via Asterisk AMI PJSIPNotify.
+    pub snom_notify: CfgSnomNotify,
 
     /// Dashboard HTTP server configuration (None = disabled)
     pub dashboard: Option<CfgDashboard>,
@@ -301,6 +320,119 @@ impl SharedConfig {
                 // Health alerts aren't part of the dashboard live-edit override yet — take the
                 // base config value so the field is always populated.
                 alert_health: base.alert_health,
+            }
+        } else {
+            base
+        }
+    }
+
+    /// Effective DAPNET settings: the dashboard runtime override if present, otherwise the config
+    /// file values. Returns an owned [`CfgDapnet`] so callers don't hold the state lock.
+    pub fn effective_dapnet(&self) -> crate::bluestation::CfgDapnet {
+        let base = self.cfg.dapnet.clone();
+        if let Some(o) = self.state_read().dapnet_override.as_ref() {
+            crate::bluestation::CfgDapnet {
+                enabled: o.enabled,
+                api_url: o.api_url.clone(),
+                username: o.username.clone(),
+                password: crate::bluestation::SecretField::from(o.password.clone()),
+                poll_interval_secs: o.poll_interval_secs.max(1),
+                forward_sds: o.forward_sds,
+                forward_callout: o.forward_callout,
+                forward_telegram: o.forward_telegram,
+                sds_source_issi: o.sds_source_issi,
+                sds_dest_issi: o.sds_dest_issi,
+                sds_dest_is_group: o.sds_dest_is_group,
+                ric_issi_routes: o.ric_issi_routes.clone(),
+                ric_gssi_routes: o.ric_gssi_routes.clone(),
+                sds_allowed_rics: o.sds_allowed_rics.clone(),
+                callout_allowed_rics: o.callout_allowed_rics.clone(),
+                telegram_allowed_rics: o.telegram_allowed_rics.clone(),
+                callout_source_issi: o.callout_source_issi,
+                callout_dest_issi: o.callout_dest_issi,
+                callout_incident_base: o.callout_incident_base.clamp(1, 256),
+                callout_text_prefix: o.callout_text_prefix.clone(),
+                telegram_prefix: o.telegram_prefix.clone(),
+                rwth_core_enabled: o.rwth_core_enabled,
+                rwth_core_host: o.rwth_core_host.clone(),
+                rwth_core_port: o.rwth_core_port,
+                rwth_core_device: o.rwth_core_device.clone(),
+                rwth_core_version: o.rwth_core_version.clone(),
+                rwth_core_callsign: o.rwth_core_callsign.clone(),
+                rwth_core_authkey: crate::bluestation::SecretField::from(o.rwth_core_authkey.clone()),
+                rwth_messages_limit: o.rwth_messages_limit.max(1),
+            }
+        } else {
+            base
+        }
+    }
+
+    /// Effective GeoAlarm settings: the dashboard runtime override if present, otherwise the
+    /// config file values. Returns an owned [`CfgGeoalarm`] so callers don't hold the state lock.
+    pub fn effective_geoalarm(&self) -> crate::bluestation::CfgGeoalarm {
+        let base = self.cfg.geoalarm.clone();
+        if let Some(o) = self.state_read().geoalarm_override.as_ref() {
+            crate::bluestation::CfgGeoalarm {
+                enabled: o.enabled,
+                flowstation_lat: o.flowstation_lat,
+                flowstation_lon: o.flowstation_lon,
+                radius_m: if o.radius_m.is_finite() && o.radius_m > 0.0 {
+                    o.radius_m
+                } else {
+                    base.radius_m
+                },
+                cooldown_secs: o.cooldown_secs.clamp(1, 86_400),
+                trigger_tetra: o.trigger_tetra,
+                trigger_meshcom: o.trigger_meshcom,
+                forward_tpg2200: o.forward_tpg2200,
+                forward_sds: o.forward_sds,
+                forward_sip: o.forward_sip,
+                forward_telegram: o.forward_telegram,
+                tetra_issi_whitelist: o.tetra_issi_whitelist.clone(),
+                tetra_issi_blacklist: o.tetra_issi_blacklist.clone(),
+                meshcom_source_whitelist: o.meshcom_source_whitelist.clone(),
+                meshcom_source_blacklist: o.meshcom_source_blacklist.clone(),
+                sds_source_issi: o.sds_source_issi.max(1),
+                sds_dest_issi: o.sds_dest_issi,
+                sds_dest_is_group: o.sds_dest_is_group,
+                tpg2200_source_issi: o.tpg2200_source_issi.max(1),
+                tpg2200_dest_issi: o.tpg2200_dest_issi,
+                tpg2200_incident_base: o.tpg2200_incident_base.clamp(1, 256),
+                tpg2200_text_prefix: o.tpg2200_text_prefix.clone(),
+                tpg2200_max_text_chars: o.tpg2200_max_text_chars.clamp(8, 160),
+                sip_title_prefix: o.sip_title_prefix.clone(),
+                telegram_prefix: o.telegram_prefix.clone(),
+            }
+        } else {
+            base
+        }
+    }
+
+    /// Effective Snom XML NOTIFY settings: the dashboard runtime override if present, otherwise
+    /// the config file values. Returns an owned [`CfgSnomNotify`] so callers don't hold the
+    /// state lock while sending AMI requests.
+    pub fn effective_snom_notify(&self) -> crate::bluestation::CfgSnomNotify {
+        let base = self.cfg.snom_notify.clone();
+        if let Some(o) = self.state_read().snom_notify_override.as_ref() {
+            crate::bluestation::CfgSnomNotify {
+                enabled: o.enabled,
+                ami_host: o.ami_host.clone(),
+                ami_port: o.ami_port,
+                ami_username: o.ami_username.clone(),
+                ami_password: crate::bluestation::SecretField::from(o.ami_password.clone()),
+                endpoints: o.endpoints.clone(),
+                notify_sds: o.notify_sds,
+                notify_dapnet: o.notify_dapnet,
+                notify_telegram: o.notify_telegram,
+                sds_directions: o.sds_directions.clone(),
+                dapnet_allowed_rics: o.dapnet_allowed_rics.clone(),
+                sds_allowed_issis: o.sds_allowed_issis.clone(),
+                title_prefix: o.title_prefix.clone(),
+                notify_event: o.notify_event.clone(),
+                content_type: o.content_type.clone(),
+                subscription_state: o.subscription_state.clone(),
+                max_text_chars: o.max_text_chars.clamp(40, 2000),
+                connect_timeout_secs: o.connect_timeout_secs.clamp(1, 30),
             }
         } else {
             base

--- a/crates/tetra-config/src/bluestation/mod.rs
+++ b/crates/tetra-config/src/bluestation/mod.rs
@@ -19,6 +19,21 @@ pub use sec_phy_soapy::*;
 pub mod sec_brew;
 pub use sec_brew::*;
 
+pub mod sec_asterisk;
+pub use sec_asterisk::*;
+
+pub mod sec_dapnet;
+pub use sec_dapnet::*;
+
+pub mod sec_geoalarm;
+pub use sec_geoalarm::*;
+
+pub mod sec_tpg2200_action;
+pub use sec_tpg2200_action::*;
+
+pub mod sec_snom_notify;
+pub use sec_snom_notify::*;
+
 pub mod sec_dashboard;
 pub use sec_dashboard::*;
 

--- a/crates/tetra-config/src/bluestation/parsing.rs
+++ b/crates/tetra-config/src/bluestation/parsing.rs
@@ -11,6 +11,11 @@ use crate::bluestation::{CellInfoDto, CfgControlDto, NetInfoDto, apply_control_p
 
 use super::config::{StackConfig, StackMode};
 use super::sec_brew::{CfgBrewDto, apply_brew_patch};
+use super::sec_asterisk::{CfgAsteriskDto, apply_asterisk_patch};
+use super::sec_dapnet::{CfgDapnetDto, apply_dapnet_patch};
+use super::sec_geoalarm::{CfgGeoalarmDto, apply_geoalarm_patch};
+use super::sec_tpg2200_action::{CfgTpg2200ActionDto, apply_tpg2200_action_patch};
+use super::sec_snom_notify::{CfgSnomNotifyDto, apply_snom_notify_patch};
 use super::sec_dashboard::{CfgDashboardDto, apply_dashboard_patch};
 use super::sec_emergency::{CfgEmergencyDto, apply_emergency_patch};
 use super::sec_health::{CfgHealthDto, apply_health_patch};
@@ -117,6 +122,41 @@ pub fn from_toml_str(toml_str: &str) -> Result<StackConfig, Box<dyn std::error::
         return Err(format!("Unrecognized fields in brew config: {:?}", sorted_keys(&brew.extra)).into());
     }
 
+    // Optional asterisk section
+    if let Some(ref asterisk) = root.asterisk
+        && !asterisk.extra.is_empty()
+    {
+        return Err(format!("Unrecognized fields in asterisk config: {:?}", sorted_keys(&asterisk.extra)).into());
+    }
+
+    // Optional dapnet section
+    if let Some(ref dapnet) = root.dapnet
+        && !dapnet.extra.is_empty()
+    {
+        return Err(format!("Unrecognized fields in dapnet config: {:?}", sorted_keys(&dapnet.extra)).into());
+    }
+
+    // Optional geoalarm section
+    if let Some(ref geoalarm) = root.geoalarm
+        && !geoalarm.extra.is_empty()
+    {
+        return Err(format!("Unrecognized fields in geoalarm config: {:?}", sorted_keys(&geoalarm.extra)).into());
+    }
+
+    // Optional tpg2200_action section
+    if let Some(ref action) = root.tpg2200_action
+        && !action.extra.is_empty()
+    {
+        return Err(format!("Unrecognized fields in tpg2200_action config: {:?}", sorted_keys(&action.extra)).into());
+    }
+
+    // Optional snom_notify section
+    if let Some(ref snom) = root.snom_notify
+        && !snom.extra.is_empty()
+    {
+        return Err(format!("Unrecognized fields in snom_notify config: {:?}", sorted_keys(&snom.extra)).into());
+    }
+
     // Optional telemetry section
     if let Some(ref telemetry) = root.telemetry
         && !telemetry.extra.is_empty()
@@ -189,6 +229,11 @@ pub fn from_toml_str(toml_str: &str) -> Result<StackConfig, Box<dyn std::error::
         net: net_dto_to_cfg(root.net_info),
         cell: cell_cfg,
         brew: None,
+        asterisk: apply_asterisk_patch(root.asterisk.unwrap_or_default())?,
+        dapnet: apply_dapnet_patch(root.dapnet.unwrap_or_default())?,
+        geoalarm: apply_geoalarm_patch(root.geoalarm.unwrap_or_default())?,
+        tpg2200_action: apply_tpg2200_action_patch(root.tpg2200_action.unwrap_or_default())?,
+        snom_notify: apply_snom_notify_patch(root.snom_notify.unwrap_or_default())?,
         dashboard: None,
         telemetry: None,
         control: None,
@@ -260,6 +305,11 @@ struct TomlConfigRoot {
     cell_info: CellInfoDto,
 
     brew: Option<CfgBrewDto>,
+    asterisk: Option<CfgAsteriskDto>,
+    dapnet: Option<CfgDapnetDto>,
+    geoalarm: Option<CfgGeoalarmDto>,
+    tpg2200_action: Option<CfgTpg2200ActionDto>,
+    snom_notify: Option<CfgSnomNotifyDto>,
     dashboard: Option<CfgDashboardDto>,
     telemetry: Option<CfgTelemetryDto>,
     command: Option<CfgControlDto>,
@@ -367,6 +417,90 @@ ca_cert = "/tmp/ca.der"
 username = "station"
 password = "x"
 
+[asterisk]
+enabled = true
+outbound_prefix = "91"
+strip_outbound_prefix = true
+inbound_prefix = "T"
+register = true
+codec = "PCMU"
+service_numbers = ["600", "601"]
+rtp_port_min = 30000
+rtp_port_max = 30100
+bind_addr = "0.0.0.0"
+bind_port = 5062
+remote_host = "127.0.0.1"
+remote_port = 5060
+contact_host = "127.0.0.1"
+from_domain = "127.0.0.1"
+local_user = "flowstation"
+auth_user = "flowstation"
+password = ""
+realm = "asterisk"
+
+[dapnet]
+enabled = true
+api_url = "https://hampager.de/api/calls"
+username = "dl1abc"
+password = "example"
+poll_interval_secs = 30
+forward_sds = true
+forward_callout = true
+forward_telegram = true
+sds_source_issi = 9999
+sds_dest_issi = 1234567
+sds_dest_is_group = false
+ric_issi_routes = { "0632585" = 2632585, "0x9A70A" = 2632586 }
+ric_gssi_routes = { "0004520" = 80 }
+sds_allowed_rics = ["0632585", "0004520"]
+callout_allowed_rics = ["0004520"]
+telegram_allowed_rics = ["0000200", "0x1C40"]
+callout_source_issi = 9999
+callout_dest_issi = 1234567
+callout_incident_base = 2
+callout_text_prefix = "DAPNET"
+telegram_prefix = "DAPNET"
+rwth_core_enabled = true
+rwth_core_host = "dapnet.afu.rwth-aachen.de"
+rwth_core_port = 43434
+rwth_core_device = "FlowStation"
+rwth_core_version = "1.0"
+rwth_core_callsign = "DL1ABC"
+rwth_core_authkey = "example"
+rwth_messages_limit = 100
+
+[geoalarm]
+enabled = true
+
+[tpg2200_action]
+enabled = true
+token = "example-token"
+source_issi = 9999
+dest_issi = 1234567
+incident_base = 1
+default_text = "ALARM"
+max_text_chars = 80
+
+[snom_notify]
+enabled = true
+ami_host = "127.0.0.1"
+ami_port = 5038
+ami_username = "flowstation"
+ami_password = "example"
+endpoints = ["385"]
+notify_sds = true
+notify_dapnet = true
+notify_telegram = true
+sds_directions = ["rx", "net", "tx"]
+dapnet_allowed_rics = ["0632585", "0000200"]
+sds_allowed_issis = [2632585, 9999]
+title_prefix = "FlowStation"
+notify_event = "xml"
+content_type = "application/snomxml"
+subscription_state = "active;expires=30000"
+max_text_chars = 240
+connect_timeout_secs = 3
+
 [recovery]
 enabled = true
 issi_allowlist = []
@@ -390,9 +524,32 @@ sds_queue_critical = 128
 "#;
         let cfg = from_toml_str(toml).unwrap_or_else(|e| panic!("documented optional blocks must parse when uncommented: {e}"));
         assert!(cfg.recovery.enabled);
+        assert!(cfg.tpg2200_action.enabled);
+        assert_eq!(cfg.tpg2200_action.dest_issi, 1234567);
+        assert!(cfg.snom_notify.enabled);
+        assert_eq!(cfg.snom_notify.endpoints, vec!["385"]);
+        assert!(cfg.snom_notify.notify_sds);
+        assert!(cfg.snom_notify.sds_directions.iter().any(|d| d == "tx"));
+        assert!(cfg.snom_notify.dapnet_allowed_rics.contains(&632585));
+        assert!(cfg.snom_notify.sds_allowed_issis.contains(&2632585));
+        assert_eq!(cfg.snom_notify.content_type, "application/snomxml");
         assert_eq!(cfg.recovery.max_replay_attempts, 150);
         assert!(cfg.health.enabled);
         assert_eq!(cfg.health.core_stall_secs, 10);
+        assert!(cfg.asterisk.enabled);
+        assert_eq!(cfg.asterisk.service_numbers, vec!["600".to_string(), "601".to_string()]);
+        assert!(cfg.dapnet.enabled);
+        assert!(cfg.dapnet.rwth_core_enabled);
+        assert_eq!(cfg.dapnet.callout_incident_base, 2);
+        assert_eq!(cfg.dapnet.ric_issi_routes.get(&632585), Some(&2632585));
+        assert_eq!(cfg.dapnet.ric_issi_routes.get(&632586), Some(&2632586));
+        assert_eq!(cfg.dapnet.ric_gssi_routes.get(&4520), Some(&80));
+        assert!(cfg.dapnet.sds_allowed_rics.contains(&632585));
+        assert!(cfg.dapnet.sds_allowed_rics.contains(&4520));
+        assert!(cfg.dapnet.callout_allowed_rics.contains(&4520));
+        assert!(cfg.dapnet.telegram_allowed_rics.contains(&200));
+        assert!(cfg.dapnet.telegram_allowed_rics.contains(&0x1C40));
+        assert!(cfg.geoalarm.enabled);
     }
 
     fn minimal_toml(extra_cell: &str) -> String {

--- a/crates/tetra-config/src/bluestation/sec_asterisk.rs
+++ b/crates/tetra-config/src/bluestation/sec_asterisk.rs
@@ -1,0 +1,241 @@
+use std::collections::HashMap;
+
+use serde::Deserialize;
+use toml::Value;
+
+use crate::bluestation::SecretField;
+
+/// Asterisk SIP/RTP bridge configuration.
+#[derive(Debug, Clone)]
+pub struct CfgAsterisk {
+    pub enabled: bool,
+    pub outbound_prefix: String,
+    pub strip_outbound_prefix: bool,
+    pub inbound_prefix: String,
+    pub register: bool,
+    pub codec: String,
+    pub service_numbers: Vec<String>,
+    pub rtp_port_min: u16,
+    pub rtp_port_max: u16,
+    pub bind_addr: String,
+    pub bind_port: u16,
+    pub remote_host: String,
+    pub remote_port: u16,
+    pub contact_host: String,
+    pub from_domain: String,
+    pub local_user: String,
+    pub auth_user: String,
+    pub password: SecretField,
+    pub realm: String,
+    pub options_interval_secs: u64,
+}
+
+impl Default for CfgAsterisk {
+    fn default() -> Self {
+        apply_asterisk_patch(CfgAsteriskDto::default()).expect("default asterisk config must be valid")
+    }
+}
+
+#[derive(Deserialize)]
+pub struct CfgAsteriskDto {
+    #[serde(default)]
+    pub enabled: bool,
+    #[serde(default = "default_outbound_prefix")]
+    pub outbound_prefix: String,
+    #[serde(default = "default_strip_outbound_prefix")]
+    pub strip_outbound_prefix: bool,
+    #[serde(default = "default_inbound_prefix")]
+    pub inbound_prefix: String,
+    #[serde(default = "default_register")]
+    pub register: bool,
+    #[serde(default = "default_codec")]
+    pub codec: String,
+    #[serde(default)]
+    pub service_numbers: Vec<String>,
+    #[serde(default = "default_rtp_port_min")]
+    pub rtp_port_min: u16,
+    #[serde(default = "default_rtp_port_max")]
+    pub rtp_port_max: u16,
+    #[serde(default = "default_bind_addr")]
+    pub bind_addr: String,
+    #[serde(default = "default_bind_port")]
+    pub bind_port: u16,
+    #[serde(default = "default_remote_host")]
+    pub remote_host: String,
+    #[serde(default = "default_remote_port")]
+    pub remote_port: u16,
+    #[serde(default = "default_contact_host")]
+    pub contact_host: String,
+    #[serde(default = "default_from_domain")]
+    pub from_domain: String,
+    #[serde(default = "default_local_user")]
+    pub local_user: String,
+    #[serde(default = "default_auth_user")]
+    pub auth_user: String,
+    #[serde(default)]
+    pub password: String,
+    #[serde(default = "default_realm")]
+    pub realm: String,
+    #[serde(default = "default_options_interval_secs")]
+    pub options_interval_secs: u64,
+
+    #[serde(flatten)]
+    pub extra: HashMap<String, Value>,
+}
+
+impl Default for CfgAsteriskDto {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            outbound_prefix: default_outbound_prefix(),
+            strip_outbound_prefix: default_strip_outbound_prefix(),
+            inbound_prefix: default_inbound_prefix(),
+            register: default_register(),
+            codec: default_codec(),
+            service_numbers: Vec::new(),
+            rtp_port_min: default_rtp_port_min(),
+            rtp_port_max: default_rtp_port_max(),
+            bind_addr: default_bind_addr(),
+            bind_port: default_bind_port(),
+            remote_host: default_remote_host(),
+            remote_port: default_remote_port(),
+            contact_host: default_contact_host(),
+            from_domain: default_from_domain(),
+            local_user: default_local_user(),
+            auth_user: default_auth_user(),
+            password: String::new(),
+            realm: default_realm(),
+            options_interval_secs: default_options_interval_secs(),
+            extra: HashMap::new(),
+        }
+    }
+}
+
+fn default_outbound_prefix() -> String {
+    "91".to_string()
+}
+
+fn default_strip_outbound_prefix() -> bool {
+    true
+}
+
+fn default_inbound_prefix() -> String {
+    "T".to_string()
+}
+
+fn default_register() -> bool {
+    true
+}
+
+fn default_codec() -> String {
+    "PCMU".to_string()
+}
+
+fn default_rtp_port_min() -> u16 {
+    30000
+}
+
+fn default_rtp_port_max() -> u16 {
+    30100
+}
+
+fn default_bind_addr() -> String {
+    "0.0.0.0".to_string()
+}
+
+fn default_bind_port() -> u16 {
+    5062
+}
+
+fn default_remote_host() -> String {
+    "127.0.0.1".to_string()
+}
+
+fn default_remote_port() -> u16 {
+    5060
+}
+
+fn default_contact_host() -> String {
+    "127.0.0.1".to_string()
+}
+
+fn default_from_domain() -> String {
+    "127.0.0.1".to_string()
+}
+
+fn default_local_user() -> String {
+    "flowstation".to_string()
+}
+
+fn default_auth_user() -> String {
+    "flowstation".to_string()
+}
+
+fn default_realm() -> String {
+    "asterisk".to_string()
+}
+
+fn default_options_interval_secs() -> u64 {
+    30
+}
+
+pub fn apply_asterisk_patch(src: CfgAsteriskDto) -> Result<CfgAsterisk, String> {
+    if src.enabled {
+        if src.bind_port == 0 {
+            return Err("asterisk: bind_port cannot be 0".to_string());
+        }
+        if src.remote_port == 0 {
+            return Err("asterisk: remote_port cannot be 0".to_string());
+        }
+        if src.rtp_port_min == 0 || src.rtp_port_max == 0 || src.rtp_port_min > src.rtp_port_max {
+            return Err("asterisk: rtp_port_min/rtp_port_max must define a valid non-zero range".to_string());
+        }
+        if src.remote_host.trim().is_empty() {
+            return Err("asterisk: remote_host cannot be empty when enabled".to_string());
+        }
+        if src.contact_host.trim().is_empty() {
+            return Err("asterisk: contact_host cannot be empty when enabled".to_string());
+        }
+        if src.local_user.trim().is_empty() {
+            return Err("asterisk: local_user cannot be empty when enabled".to_string());
+        }
+        if src.auth_user.trim().is_empty() {
+            return Err("asterisk: auth_user cannot be empty when enabled".to_string());
+        }
+    }
+
+    let codec = src.codec.trim().to_ascii_uppercase();
+    if codec != "PCMU" {
+        return Err("asterisk: only codec = \"PCMU\" is currently supported".to_string());
+    }
+
+    let service_numbers = src
+        .service_numbers
+        .into_iter()
+        .map(|n| n.trim().to_string())
+        .filter(|n| !n.is_empty())
+        .collect();
+
+    Ok(CfgAsterisk {
+        enabled: src.enabled,
+        outbound_prefix: src.outbound_prefix,
+        strip_outbound_prefix: src.strip_outbound_prefix,
+        inbound_prefix: src.inbound_prefix,
+        register: src.register,
+        codec,
+        service_numbers,
+        rtp_port_min: src.rtp_port_min,
+        rtp_port_max: src.rtp_port_max,
+        bind_addr: src.bind_addr,
+        bind_port: src.bind_port,
+        remote_host: src.remote_host,
+        remote_port: src.remote_port,
+        contact_host: src.contact_host,
+        from_domain: src.from_domain,
+        local_user: src.local_user,
+        auth_user: src.auth_user,
+        password: SecretField::from(src.password),
+        realm: src.realm,
+        options_interval_secs: src.options_interval_secs,
+    })
+}

--- a/crates/tetra-config/src/bluestation/sec_dapnet.rs
+++ b/crates/tetra-config/src/bluestation/sec_dapnet.rs
@@ -1,0 +1,371 @@
+use serde::Deserialize;
+use std::collections::{BTreeMap, BTreeSet, HashMap};
+
+use crate::bluestation::SecretField;
+
+/// DAPNET receiver/forwarder configuration.
+///
+/// Disabled by default. When enabled, the worker receives DAPNET calls from the RWTH core
+/// transmitter TCP feed and can forward each normalized message to local SDS, TPG2200 Call-Out,
+/// and/or the existing Telegram alerter.
+#[derive(Debug, Clone)]
+pub struct CfgDapnet {
+    pub enabled: bool,
+    pub api_url: String,
+    pub username: String,
+    pub password: SecretField,
+    pub poll_interval_secs: u64,
+
+    pub forward_sds: bool,
+    pub forward_callout: bool,
+    pub forward_telegram: bool,
+
+    pub sds_source_issi: u32,
+    pub sds_dest_issi: u32,
+    pub sds_dest_is_group: bool,
+    /// Optional incoming DAPNET RIC/CAP-code to TETRA ISSI routes.
+    ///
+    /// Config keys may use decimal RICs with leading zeros (e.g. "0632585") or hex with a
+    /// `0x` prefix. Internally the key is normalized to the numeric RIC received from the core.
+    pub ric_issi_routes: BTreeMap<u32, u32>,
+    /// Optional incoming DAPNET RIC/CAP-code to TETRA group GSSI routes.
+    pub ric_gssi_routes: BTreeMap<u32, u32>,
+    /// Optional per-path RIC allowlists. Empty means "allow all RICs" for that path.
+    pub sds_allowed_rics: BTreeSet<u32>,
+    pub callout_allowed_rics: BTreeSet<u32>,
+    pub telegram_allowed_rics: BTreeSet<u32>,
+
+    pub callout_source_issi: u32,
+    pub callout_dest_issi: u32,
+    pub callout_incident_base: u16,
+    pub callout_text_prefix: String,
+
+    pub telegram_prefix: String,
+
+    pub rwth_core_enabled: bool,
+    pub rwth_core_host: String,
+    pub rwth_core_port: u16,
+    pub rwth_core_device: String,
+    pub rwth_core_version: String,
+    pub rwth_core_callsign: String,
+    pub rwth_core_authkey: SecretField,
+    pub rwth_messages_limit: usize,
+}
+
+impl Default for CfgDapnet {
+    fn default() -> Self {
+        CfgDapnet {
+            enabled: false,
+            api_url: default_api_url(),
+            username: String::new(),
+            password: SecretField::from(String::new()),
+            poll_interval_secs: 30,
+
+            forward_sds: false,
+            forward_callout: false,
+            forward_telegram: false,
+
+            sds_source_issi: 9999,
+            sds_dest_issi: 0,
+            sds_dest_is_group: false,
+            ric_issi_routes: BTreeMap::new(),
+            ric_gssi_routes: BTreeMap::new(),
+            sds_allowed_rics: BTreeSet::new(),
+            callout_allowed_rics: BTreeSet::new(),
+            telegram_allowed_rics: BTreeSet::new(),
+
+            callout_source_issi: 9999,
+            callout_dest_issi: 0,
+            callout_incident_base: 2,
+            callout_text_prefix: "DAPNET".to_string(),
+
+            telegram_prefix: "DAPNET".to_string(),
+
+            rwth_core_enabled: true,
+            rwth_core_host: "dapnet.afu.rwth-aachen.de".to_string(),
+            rwth_core_port: 43434,
+            rwth_core_device: "FlowStation".to_string(),
+            rwth_core_version: "1.0".to_string(),
+            rwth_core_callsign: String::new(),
+            rwth_core_authkey: SecretField::from(String::new()),
+            rwth_messages_limit: 100,
+        }
+    }
+}
+
+impl CfgDapnet {
+    pub fn effective_poll_interval_secs(&self) -> u64 {
+        self.poll_interval_secs.max(1)
+    }
+
+    pub fn effective_messages_limit(&self) -> usize {
+        self.rwth_messages_limit.max(1)
+    }
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct CfgDapnetDto {
+    #[serde(default)]
+    pub enabled: bool,
+    #[serde(default = "default_api_url")]
+    pub api_url: String,
+    #[serde(default)]
+    pub username: String,
+    #[serde(default)]
+    pub password: String,
+    #[serde(default = "default_poll_interval_secs")]
+    pub poll_interval_secs: u64,
+
+    #[serde(default)]
+    pub forward_sds: bool,
+    #[serde(default)]
+    pub forward_callout: bool,
+    #[serde(default)]
+    pub forward_telegram: bool,
+
+    #[serde(default = "default_source_issi")]
+    pub sds_source_issi: u32,
+    #[serde(default)]
+    pub sds_dest_issi: u32,
+    #[serde(default)]
+    pub sds_dest_is_group: bool,
+    #[serde(default)]
+    pub ric_issi_routes: HashMap<String, u32>,
+    #[serde(default)]
+    pub ric_gssi_routes: HashMap<String, u32>,
+    #[serde(default)]
+    pub sds_allowed_rics: Vec<toml::Value>,
+    #[serde(default)]
+    pub callout_allowed_rics: Vec<toml::Value>,
+    #[serde(default)]
+    pub telegram_allowed_rics: Vec<toml::Value>,
+
+    #[serde(default = "default_source_issi")]
+    pub callout_source_issi: u32,
+    #[serde(default)]
+    pub callout_dest_issi: u32,
+    #[serde(default = "default_callout_incident_base")]
+    pub callout_incident_base: u16,
+    #[serde(default = "default_dapnet_prefix")]
+    pub callout_text_prefix: String,
+
+    #[serde(default = "default_dapnet_prefix")]
+    pub telegram_prefix: String,
+
+    #[serde(default = "default_true")]
+    pub rwth_core_enabled: bool,
+    #[serde(default = "default_rwth_core_host")]
+    pub rwth_core_host: String,
+    #[serde(default = "default_rwth_core_port")]
+    pub rwth_core_port: u16,
+    #[serde(default = "default_rwth_core_device")]
+    pub rwth_core_device: String,
+    #[serde(default = "default_rwth_core_version")]
+    pub rwth_core_version: String,
+    #[serde(default)]
+    pub rwth_core_callsign: String,
+    #[serde(default)]
+    pub rwth_core_authkey: String,
+    #[serde(default = "default_rwth_messages_limit")]
+    pub rwth_messages_limit: usize,
+
+    #[serde(flatten)]
+    pub extra: std::collections::HashMap<String, toml::Value>,
+}
+
+impl Default for CfgDapnetDto {
+    fn default() -> Self {
+        CfgDapnetDto {
+            enabled: false,
+            api_url: default_api_url(),
+            username: String::new(),
+            password: String::new(),
+            poll_interval_secs: default_poll_interval_secs(),
+            forward_sds: false,
+            forward_callout: false,
+            forward_telegram: false,
+            sds_source_issi: default_source_issi(),
+            sds_dest_issi: 0,
+            sds_dest_is_group: false,
+            ric_issi_routes: HashMap::new(),
+            ric_gssi_routes: HashMap::new(),
+            sds_allowed_rics: Vec::new(),
+            callout_allowed_rics: Vec::new(),
+            telegram_allowed_rics: Vec::new(),
+            callout_source_issi: default_source_issi(),
+            callout_dest_issi: 0,
+            callout_incident_base: default_callout_incident_base(),
+            callout_text_prefix: default_dapnet_prefix(),
+            telegram_prefix: default_dapnet_prefix(),
+            rwth_core_enabled: true,
+            rwth_core_host: default_rwth_core_host(),
+            rwth_core_port: default_rwth_core_port(),
+            rwth_core_device: default_rwth_core_device(),
+            rwth_core_version: default_rwth_core_version(),
+            rwth_core_callsign: String::new(),
+            rwth_core_authkey: String::new(),
+            rwth_messages_limit: default_rwth_messages_limit(),
+            extra: std::collections::HashMap::new(),
+        }
+    }
+}
+
+fn default_true() -> bool {
+    true
+}
+
+fn default_api_url() -> String {
+    "https://hampager.de/api/calls".to_string()
+}
+
+fn default_poll_interval_secs() -> u64 {
+    30
+}
+
+fn default_source_issi() -> u32 {
+    9999
+}
+
+fn default_callout_incident_base() -> u16 {
+    2
+}
+
+fn default_dapnet_prefix() -> String {
+    "DAPNET".to_string()
+}
+
+fn default_rwth_core_host() -> String {
+    "dapnet.afu.rwth-aachen.de".to_string()
+}
+
+fn default_rwth_core_port() -> u16 {
+    43434
+}
+
+fn default_rwth_core_device() -> String {
+    "FlowStation".to_string()
+}
+
+fn default_rwth_core_version() -> String {
+    "1.0".to_string()
+}
+
+fn default_rwth_messages_limit() -> usize {
+    100
+}
+
+pub fn apply_dapnet_patch(dto: CfgDapnetDto) -> Result<CfgDapnet, String> {
+    let ric_issi_routes = normalize_ric_ssi_routes("dapnet.ric_issi_routes", dto.ric_issi_routes)?;
+    let ric_gssi_routes = normalize_ric_ssi_routes("dapnet.ric_gssi_routes", dto.ric_gssi_routes)?;
+    ensure_no_route_conflicts(&ric_issi_routes, &ric_gssi_routes)?;
+    Ok(CfgDapnet {
+        enabled: dto.enabled,
+        api_url: dto.api_url,
+        username: dto.username,
+        password: SecretField::from(dto.password),
+        poll_interval_secs: dto.poll_interval_secs.max(1),
+        forward_sds: dto.forward_sds,
+        forward_callout: dto.forward_callout,
+        forward_telegram: dto.forward_telegram,
+        sds_source_issi: dto.sds_source_issi,
+        sds_dest_issi: dto.sds_dest_issi,
+        sds_dest_is_group: dto.sds_dest_is_group,
+        ric_issi_routes,
+        ric_gssi_routes,
+        sds_allowed_rics: normalize_ric_value_list(
+            "dapnet.sds_allowed_rics",
+            dto.sds_allowed_rics,
+        )?,
+        callout_allowed_rics: normalize_ric_value_list(
+            "dapnet.callout_allowed_rics",
+            dto.callout_allowed_rics,
+        )?,
+        telegram_allowed_rics: normalize_ric_value_list(
+            "dapnet.telegram_allowed_rics",
+            dto.telegram_allowed_rics,
+        )?,
+        callout_source_issi: dto.callout_source_issi,
+        callout_dest_issi: dto.callout_dest_issi,
+        callout_incident_base: dto.callout_incident_base.clamp(1, 256),
+        callout_text_prefix: dto.callout_text_prefix,
+        telegram_prefix: dto.telegram_prefix,
+        rwth_core_enabled: dto.rwth_core_enabled,
+        rwth_core_host: dto.rwth_core_host,
+        rwth_core_port: dto.rwth_core_port,
+        rwth_core_device: dto.rwth_core_device,
+        rwth_core_version: dto.rwth_core_version,
+        rwth_core_callsign: dto.rwth_core_callsign,
+        rwth_core_authkey: SecretField::from(dto.rwth_core_authkey),
+        rwth_messages_limit: dto.rwth_messages_limit.max(1),
+    })
+}
+
+pub fn parse_ric_route_key(raw: &str) -> Result<u32, String> {
+    let key = raw.trim();
+    if key.is_empty() {
+        return Err("empty RIC route key".to_string());
+    }
+    if let Some(hex) = key.strip_prefix("0x").or_else(|| key.strip_prefix("0X")) {
+        return u32::from_str_radix(hex, 16)
+            .map_err(|_| format!("invalid hex RIC route key '{raw}'"));
+    }
+    if key.chars().all(|c| c.is_ascii_digit()) {
+        return key
+            .parse::<u32>()
+            .map_err(|_| format!("invalid decimal RIC route key '{raw}'"));
+    }
+    Err(format!("invalid RIC route key '{raw}'"))
+}
+
+pub fn format_ric_route_key(ric: u32) -> String {
+    format!("{ric:07}")
+}
+
+fn normalize_ric_ssi_routes(
+    field: &str,
+    routes: HashMap<String, u32>,
+) -> Result<BTreeMap<u32, u32>, String> {
+    let mut out = BTreeMap::new();
+    for (raw_ric, issi) in routes {
+        let ric = parse_ric_route_key(&raw_ric)?;
+        if issi == 0 {
+            return Err(format!("{field}: SSI for RIC {raw_ric} cannot be 0"));
+        }
+        if issi > 16_777_215 {
+            return Err(format!("{field}: SSI for RIC {raw_ric} exceeds 16777215"));
+        }
+        out.insert(ric, issi);
+    }
+    Ok(out)
+}
+
+fn normalize_ric_value_list(
+    field: &str,
+    values: Vec<toml::Value>,
+) -> Result<BTreeSet<u32>, String> {
+    let mut out = BTreeSet::new();
+    for value in values {
+        let ric = match value {
+            toml::Value::String(s) => parse_ric_route_key(&s)?,
+            toml::Value::Integer(n) if n >= 0 && n <= u32::MAX as i64 => n as u32,
+            _ => return Err(format!("{field}: RIC values must be strings or positive integers")),
+        };
+        out.insert(ric);
+    }
+    Ok(out)
+}
+
+fn ensure_no_route_conflicts(
+    issi_routes: &BTreeMap<u32, u32>,
+    gssi_routes: &BTreeMap<u32, u32>,
+) -> Result<(), String> {
+    for ric in issi_routes.keys() {
+        if gssi_routes.contains_key(ric) {
+            return Err(format!(
+                "dapnet RIC {} is configured as both ISSI and GSSI route",
+                format_ric_route_key(*ric)
+            ));
+        }
+    }
+    Ok(())
+}

--- a/crates/tetra-config/src/bluestation/sec_geoalarm.rs
+++ b/crates/tetra-config/src/bluestation/sec_geoalarm.rs
@@ -1,0 +1,291 @@
+use serde::Deserialize;
+use std::collections::{BTreeSet, HashMap};
+use toml::Value;
+
+/// Geo-fence alarm configuration.
+///
+/// Disabled by default. When enabled, FlowStation watches decoded TETRA LIP positions and
+/// MeshCom position packets. Devices entering the configured radius around the station can be
+/// forwarded to the existing TPG2200, SDS, Snom/SIP and Telegram paths.
+#[derive(Debug, Clone)]
+pub struct CfgGeoalarm {
+    pub enabled: bool,
+    pub flowstation_lat: f64,
+    pub flowstation_lon: f64,
+    pub radius_m: f64,
+    pub cooldown_secs: u64,
+    pub trigger_tetra: bool,
+    pub trigger_meshcom: bool,
+    pub forward_tpg2200: bool,
+    pub forward_sds: bool,
+    pub forward_sip: bool,
+    pub forward_telegram: bool,
+    pub tetra_issi_whitelist: BTreeSet<u32>,
+    pub tetra_issi_blacklist: BTreeSet<u32>,
+    pub meshcom_source_whitelist: BTreeSet<String>,
+    pub meshcom_source_blacklist: BTreeSet<String>,
+    pub sds_source_issi: u32,
+    pub sds_dest_issi: u32,
+    pub sds_dest_is_group: bool,
+    pub tpg2200_source_issi: u32,
+    pub tpg2200_dest_issi: u32,
+    pub tpg2200_incident_base: u16,
+    pub tpg2200_text_prefix: String,
+    pub tpg2200_max_text_chars: usize,
+    pub sip_title_prefix: String,
+    pub telegram_prefix: String,
+}
+
+impl Default for CfgGeoalarm {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            flowstation_lat: 0.0,
+            flowstation_lon: 0.0,
+            radius_m: 500.0,
+            cooldown_secs: 300,
+            trigger_tetra: true,
+            trigger_meshcom: true,
+            forward_tpg2200: false,
+            forward_sds: false,
+            forward_sip: false,
+            forward_telegram: false,
+            tetra_issi_whitelist: BTreeSet::new(),
+            tetra_issi_blacklist: BTreeSet::new(),
+            meshcom_source_whitelist: BTreeSet::new(),
+            meshcom_source_blacklist: BTreeSet::new(),
+            sds_source_issi: default_source_issi(),
+            sds_dest_issi: 0,
+            sds_dest_is_group: false,
+            tpg2200_source_issi: default_source_issi(),
+            tpg2200_dest_issi: 0,
+            tpg2200_incident_base: 1,
+            tpg2200_text_prefix: default_geoalarm_prefix(),
+            tpg2200_max_text_chars: 80,
+            sip_title_prefix: default_geoalarm_prefix(),
+            telegram_prefix: default_geoalarm_prefix(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct CfgGeoalarmDto {
+    #[serde(default)]
+    pub enabled: bool,
+    #[serde(default)]
+    pub flowstation_lat: f64,
+    #[serde(default)]
+    pub flowstation_lon: f64,
+    #[serde(default = "default_radius_m")]
+    pub radius_m: f64,
+    #[serde(default = "default_cooldown_secs")]
+    pub cooldown_secs: u64,
+    #[serde(default = "default_true")]
+    pub trigger_tetra: bool,
+    #[serde(default = "default_true")]
+    pub trigger_meshcom: bool,
+    #[serde(default)]
+    pub forward_tpg2200: bool,
+    #[serde(default)]
+    pub forward_sds: bool,
+    #[serde(default)]
+    pub forward_sip: bool,
+    #[serde(default)]
+    pub forward_telegram: bool,
+    #[serde(default)]
+    pub tetra_issi_whitelist: Vec<u32>,
+    #[serde(default)]
+    pub tetra_issi_blacklist: Vec<u32>,
+    #[serde(default)]
+    pub meshcom_source_whitelist: Vec<String>,
+    #[serde(default)]
+    pub meshcom_source_blacklist: Vec<String>,
+    #[serde(default = "default_source_issi")]
+    pub sds_source_issi: u32,
+    #[serde(default)]
+    pub sds_dest_issi: u32,
+    #[serde(default)]
+    pub sds_dest_is_group: bool,
+    #[serde(default = "default_source_issi")]
+    pub tpg2200_source_issi: u32,
+    #[serde(default)]
+    pub tpg2200_dest_issi: u32,
+    #[serde(default = "default_incident_base")]
+    pub tpg2200_incident_base: u16,
+    #[serde(default = "default_geoalarm_prefix")]
+    pub tpg2200_text_prefix: String,
+    #[serde(default = "default_tpg2200_max_text_chars")]
+    pub tpg2200_max_text_chars: usize,
+    #[serde(default = "default_geoalarm_prefix")]
+    pub sip_title_prefix: String,
+    #[serde(default = "default_geoalarm_prefix")]
+    pub telegram_prefix: String,
+
+    #[serde(flatten)]
+    pub extra: HashMap<String, Value>,
+}
+
+impl Default for CfgGeoalarmDto {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            flowstation_lat: 0.0,
+            flowstation_lon: 0.0,
+            radius_m: default_radius_m(),
+            cooldown_secs: default_cooldown_secs(),
+            trigger_tetra: true,
+            trigger_meshcom: true,
+            forward_tpg2200: false,
+            forward_sds: false,
+            forward_sip: false,
+            forward_telegram: false,
+            tetra_issi_whitelist: Vec::new(),
+            tetra_issi_blacklist: Vec::new(),
+            meshcom_source_whitelist: Vec::new(),
+            meshcom_source_blacklist: Vec::new(),
+            sds_source_issi: default_source_issi(),
+            sds_dest_issi: 0,
+            sds_dest_is_group: false,
+            tpg2200_source_issi: default_source_issi(),
+            tpg2200_dest_issi: 0,
+            tpg2200_incident_base: default_incident_base(),
+            tpg2200_text_prefix: default_geoalarm_prefix(),
+            tpg2200_max_text_chars: default_tpg2200_max_text_chars(),
+            sip_title_prefix: default_geoalarm_prefix(),
+            telegram_prefix: default_geoalarm_prefix(),
+            extra: HashMap::new(),
+        }
+    }
+}
+
+fn default_true() -> bool {
+    true
+}
+
+fn default_radius_m() -> f64 {
+    500.0
+}
+
+fn default_cooldown_secs() -> u64 {
+    300
+}
+
+fn default_source_issi() -> u32 {
+    9999
+}
+
+fn default_incident_base() -> u16 {
+    1
+}
+
+fn default_tpg2200_max_text_chars() -> usize {
+    80
+}
+
+fn default_geoalarm_prefix() -> String {
+    "GeoAlarm".to_string()
+}
+
+pub fn apply_geoalarm_patch(src: CfgGeoalarmDto) -> Result<CfgGeoalarm, String> {
+    if src.enabled {
+        validate_lat_lon(src.flowstation_lat, src.flowstation_lon)?;
+        if !src.radius_m.is_finite() || src.radius_m <= 0.0 {
+            return Err("geoalarm: radius_m must be greater than 0".to_string());
+        }
+        if src.forward_sds {
+            validate_issi("geoalarm: sds_source_issi", src.sds_source_issi, true)?;
+            validate_issi("geoalarm: sds_dest_issi", src.sds_dest_issi, false)?;
+        }
+        if src.forward_tpg2200 {
+            validate_issi("geoalarm: tpg2200_source_issi", src.tpg2200_source_issi, true)?;
+            validate_issi("geoalarm: tpg2200_dest_issi", src.tpg2200_dest_issi, false)?;
+        }
+    }
+
+    let tetra_issi_whitelist = normalize_issi_set(src.tetra_issi_whitelist)?;
+    let tetra_issi_blacklist = normalize_issi_set(src.tetra_issi_blacklist)?;
+
+    Ok(CfgGeoalarm {
+        enabled: src.enabled,
+        flowstation_lat: src.flowstation_lat,
+        flowstation_lon: src.flowstation_lon,
+        radius_m: if src.radius_m.is_finite() && src.radius_m > 0.0 {
+            src.radius_m
+        } else {
+            default_radius_m()
+        },
+        cooldown_secs: src.cooldown_secs.clamp(1, 86_400),
+        trigger_tetra: src.trigger_tetra,
+        trigger_meshcom: src.trigger_meshcom,
+        forward_tpg2200: src.forward_tpg2200,
+        forward_sds: src.forward_sds,
+        forward_sip: src.forward_sip,
+        forward_telegram: src.forward_telegram,
+        tetra_issi_whitelist,
+        tetra_issi_blacklist,
+        meshcom_source_whitelist: normalize_source_list(src.meshcom_source_whitelist),
+        meshcom_source_blacklist: normalize_source_list(src.meshcom_source_blacklist),
+        sds_source_issi: src.sds_source_issi.max(1),
+        sds_dest_issi: src.sds_dest_issi,
+        sds_dest_is_group: src.sds_dest_is_group,
+        tpg2200_source_issi: src.tpg2200_source_issi.max(1),
+        tpg2200_dest_issi: src.tpg2200_dest_issi,
+        tpg2200_incident_base: src.tpg2200_incident_base.clamp(1, 256),
+        tpg2200_text_prefix: non_empty_or(src.tpg2200_text_prefix, "GeoAlarm"),
+        tpg2200_max_text_chars: src.tpg2200_max_text_chars.clamp(8, 160),
+        sip_title_prefix: non_empty_or(src.sip_title_prefix, "GeoAlarm"),
+        telegram_prefix: non_empty_or(src.telegram_prefix, "GeoAlarm"),
+    })
+}
+
+fn validate_lat_lon(lat: f64, lon: f64) -> Result<(), String> {
+    if !lat.is_finite() || !(-90.0..=90.0).contains(&lat) {
+        return Err("geoalarm: flowstation_lat must be -90..=90".to_string());
+    }
+    if !lon.is_finite() || !(-180.0..=180.0).contains(&lon) {
+        return Err("geoalarm: flowstation_lon must be -180..=180".to_string());
+    }
+    Ok(())
+}
+
+fn validate_issi(label: &str, value: u32, nonzero: bool) -> Result<(), String> {
+    if nonzero && value == 0 {
+        return Err(format!("{label} must be non-zero"));
+    }
+    if value > 16_777_215 {
+        return Err(format!("{label} must be <= 16777215"));
+    }
+    Ok(())
+}
+
+fn normalize_issi_set(values: Vec<u32>) -> Result<BTreeSet<u32>, String> {
+    let mut out = BTreeSet::new();
+    for value in values {
+        validate_issi("geoalarm: ISSI list entry", value, false)?;
+        out.insert(value);
+    }
+    Ok(out)
+}
+
+fn normalize_source_list(values: Vec<String>) -> BTreeSet<String> {
+    values
+        .into_iter()
+        .flat_map(|value| {
+            value
+                .split(|c: char| c == ',' || c.is_whitespace())
+                .map(str::trim)
+                .filter(|part| !part.is_empty())
+                .map(|part| part.to_ascii_uppercase())
+                .collect::<Vec<_>>()
+        })
+        .collect()
+}
+
+fn non_empty_or(value: String, fallback: &str) -> String {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        fallback.to_string()
+    } else {
+        trimmed.to_string()
+    }
+}

--- a/crates/tetra-config/src/bluestation/sec_snom_notify.rs
+++ b/crates/tetra-config/src/bluestation/sec_snom_notify.rs
@@ -1,0 +1,253 @@
+use std::collections::{BTreeSet, HashMap};
+
+use serde::Deserialize;
+use toml::Value;
+
+use crate::bluestation::{SecretField, parse_ric_route_key};
+
+/// Snom XML minibrowser notification bridge (`[snom_notify]`).
+///
+/// Sends FlowStation message events to one or more Asterisk PJSIP endpoints via AMI
+/// `PJSIPNotify`. The generated SIP NOTIFY uses Snom's XML minibrowser format:
+/// `Event: xml`, `Content-Type: application/snomxml`, body `SnomIPPhoneText`.
+#[derive(Debug, Clone)]
+pub struct CfgSnomNotify {
+    pub enabled: bool,
+    pub ami_host: String,
+    pub ami_port: u16,
+    pub ami_username: String,
+    pub ami_password: SecretField,
+    pub endpoints: Vec<String>,
+    pub notify_sds: bool,
+    pub notify_dapnet: bool,
+    pub notify_telegram: bool,
+    pub sds_directions: Vec<String>,
+    /// Optional DAPNET RIC allowlist for Snom notifications. Empty means all RICs.
+    pub dapnet_allowed_rics: BTreeSet<u32>,
+    /// Optional SDS ISSI allowlist for Snom notifications. Empty means all SDS.
+    pub sds_allowed_issis: BTreeSet<u32>,
+    pub title_prefix: String,
+    pub notify_event: String,
+    pub content_type: String,
+    pub subscription_state: String,
+    pub max_text_chars: usize,
+    pub connect_timeout_secs: u64,
+}
+
+impl Default for CfgSnomNotify {
+    fn default() -> Self {
+        apply_snom_notify_patch(CfgSnomNotifyDto::default())
+            .expect("default snom_notify config must be valid")
+    }
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct CfgSnomNotifyDto {
+    #[serde(default)]
+    pub enabled: bool,
+    #[serde(default = "default_ami_host")]
+    pub ami_host: String,
+    #[serde(default = "default_ami_port")]
+    pub ami_port: u16,
+    #[serde(default)]
+    pub ami_username: String,
+    #[serde(default)]
+    pub ami_password: String,
+    #[serde(default)]
+    pub endpoints: Vec<String>,
+    #[serde(default = "default_true")]
+    pub notify_sds: bool,
+    #[serde(default = "default_true")]
+    pub notify_dapnet: bool,
+    #[serde(default = "default_true")]
+    pub notify_telegram: bool,
+    #[serde(default = "default_sds_directions")]
+    pub sds_directions: Vec<String>,
+    #[serde(default)]
+    pub dapnet_allowed_rics: Vec<Value>,
+    #[serde(default)]
+    pub sds_allowed_issis: Vec<u32>,
+    #[serde(default = "default_title_prefix")]
+    pub title_prefix: String,
+    #[serde(default = "default_notify_event")]
+    pub notify_event: String,
+    #[serde(default = "default_content_type")]
+    pub content_type: String,
+    #[serde(default = "default_subscription_state")]
+    pub subscription_state: String,
+    #[serde(default = "default_max_text_chars")]
+    pub max_text_chars: usize,
+    #[serde(default = "default_connect_timeout_secs")]
+    pub connect_timeout_secs: u64,
+
+    #[serde(flatten)]
+    pub extra: HashMap<String, Value>,
+}
+
+impl Default for CfgSnomNotifyDto {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            ami_host: default_ami_host(),
+            ami_port: default_ami_port(),
+            ami_username: String::new(),
+            ami_password: String::new(),
+            endpoints: Vec::new(),
+            notify_sds: true,
+            notify_dapnet: true,
+            notify_telegram: true,
+            sds_directions: default_sds_directions(),
+            dapnet_allowed_rics: Vec::new(),
+            sds_allowed_issis: Vec::new(),
+            title_prefix: default_title_prefix(),
+            notify_event: default_notify_event(),
+            content_type: default_content_type(),
+            subscription_state: default_subscription_state(),
+            max_text_chars: default_max_text_chars(),
+            connect_timeout_secs: default_connect_timeout_secs(),
+            extra: HashMap::new(),
+        }
+    }
+}
+
+fn default_ami_host() -> String {
+    "127.0.0.1".to_string()
+}
+fn default_ami_port() -> u16 {
+    5038
+}
+fn default_sds_directions() -> Vec<String> {
+    vec!["rx".to_string(), "net".to_string(), "tx".to_string()]
+}
+fn default_true() -> bool {
+    true
+}
+fn default_title_prefix() -> String {
+    "FlowStation".to_string()
+}
+fn default_notify_event() -> String {
+    "xml".to_string()
+}
+fn default_content_type() -> String {
+    "application/snomxml".to_string()
+}
+fn default_subscription_state() -> String {
+    "active;expires=30000".to_string()
+}
+fn default_max_text_chars() -> usize {
+    240
+}
+fn default_connect_timeout_secs() -> u64 {
+    3
+}
+
+pub fn apply_snom_notify_patch(src: CfgSnomNotifyDto) -> Result<CfgSnomNotify, String> {
+    if src.ami_port == 0 {
+        return Err("snom_notify: ami_port cannot be 0".to_string());
+    }
+    let ami_host = src.ami_host.trim().to_string();
+    if src.enabled && ami_host.is_empty() {
+        return Err("snom_notify: ami_host cannot be empty when enabled=true".to_string());
+    }
+
+    let endpoints: Vec<String> = src
+        .endpoints
+        .into_iter()
+        .map(|e| e.trim().to_string())
+        .filter(|e| !e.is_empty())
+        .collect();
+
+    let sds_directions: Vec<String> = src
+        .sds_directions
+        .into_iter()
+        .map(|d| d.trim().to_ascii_lowercase())
+        .filter(|d| !d.is_empty())
+        .collect();
+    let dapnet_allowed_rics = normalize_ric_value_list(src.dapnet_allowed_rics)?;
+    let sds_allowed_issis = normalize_issi_list(src.sds_allowed_issis)?;
+
+    Ok(CfgSnomNotify {
+        enabled: src.enabled,
+        ami_host,
+        ami_port: src.ami_port,
+        ami_username: src.ami_username.trim().to_string(),
+        ami_password: SecretField::from(src.ami_password),
+        endpoints,
+        notify_sds: src.notify_sds,
+        notify_dapnet: src.notify_dapnet,
+        notify_telegram: src.notify_telegram,
+        sds_directions,
+        dapnet_allowed_rics,
+        sds_allowed_issis,
+        title_prefix: non_empty_or(src.title_prefix, default_title_prefix()),
+        notify_event: non_empty_or(src.notify_event, default_notify_event()),
+        content_type: non_empty_or(src.content_type, default_content_type()),
+        subscription_state: non_empty_or(src.subscription_state, default_subscription_state()),
+        max_text_chars: src.max_text_chars.clamp(40, 2000),
+        connect_timeout_secs: src.connect_timeout_secs.clamp(1, 30),
+    })
+}
+
+fn normalize_ric_value_list(values: Vec<Value>) -> Result<BTreeSet<u32>, String> {
+    let mut out = BTreeSet::new();
+    for value in values {
+        let ric = match value {
+            Value::String(s) => parse_ric_route_key(&s)?,
+            Value::Integer(n) if n >= 0 => parse_ric_route_key(&n.to_string())?,
+            other => return Err(format!("snom_notify: invalid RIC value {other:?}")),
+        };
+        out.insert(ric);
+    }
+    Ok(out)
+}
+
+fn normalize_issi_list(values: Vec<u32>) -> Result<BTreeSet<u32>, String> {
+    let mut out = BTreeSet::new();
+    for issi in values {
+        if issi > 16_777_215 {
+            return Err(format!("snom_notify: SDS ISSI {} out of range", issi));
+        }
+        out.insert(issi);
+    }
+    Ok(out)
+}
+
+fn non_empty_or(value: String, fallback: String) -> String {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        fallback
+    } else {
+        trimmed.to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn defaults_are_disabled_snom_xml_notify() {
+        let cfg = CfgSnomNotify::default();
+        assert!(!cfg.enabled);
+        assert_eq!(cfg.ami_host, "127.0.0.1");
+        assert_eq!(cfg.ami_port, 5038);
+        assert_eq!(cfg.notify_event, "xml");
+        assert_eq!(cfg.content_type, "application/snomxml");
+    }
+
+    #[test]
+    fn trims_endpoint_and_direction_lists() {
+        let dto = CfgSnomNotifyDto {
+            endpoints: vec![" 385 ".to_string(), "".to_string()],
+            sds_directions: vec![" RX ".to_string(), "net".to_string()],
+            dapnet_allowed_rics: vec![Value::String("0632585".to_string())],
+            sds_allowed_issis: vec![2632585, 9999],
+            ..Default::default()
+        };
+        let cfg = apply_snom_notify_patch(dto).unwrap();
+        assert_eq!(cfg.endpoints, vec!["385"]);
+        assert_eq!(cfg.sds_directions, vec!["rx", "net"]);
+        assert!(cfg.dapnet_allowed_rics.contains(&632585));
+        assert!(cfg.sds_allowed_issis.contains(&2632585));
+    }
+}

--- a/crates/tetra-config/src/bluestation/sec_tpg2200_action.rs
+++ b/crates/tetra-config/src/bluestation/sec_tpg2200_action.rs
@@ -1,0 +1,114 @@
+use serde::Deserialize;
+
+use crate::bluestation::SecretField;
+
+/// Token-protected HTTP ActionURL endpoint for triggering a Motorola TPG2200 Call-Out.
+///
+/// Intended for desk phones such as Snom: a function key calls
+/// `/api/action/tpg2200?token=...`, FlowStation sends a configured Type-4 SDS to the configured
+/// TPG2200 ISSI, and the incident number advances in memory after each successful trigger.
+#[derive(Debug, Clone)]
+pub struct CfgTpg2200Action {
+    pub enabled: bool,
+    pub token: SecretField,
+    pub source_issi: u32,
+    pub dest_issi: u32,
+    pub incident_base: u16,
+    pub default_text: String,
+    pub max_text_chars: usize,
+}
+
+impl Default for CfgTpg2200Action {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            token: SecretField::from(String::new()),
+            source_issi: 9999,
+            dest_issi: 0,
+            incident_base: 1,
+            default_text: "ALARM".to_string(),
+            max_text_chars: 80,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct CfgTpg2200ActionDto {
+    #[serde(default)]
+    pub enabled: bool,
+    #[serde(default)]
+    pub token: String,
+    #[serde(default = "default_source_issi")]
+    pub source_issi: u32,
+    #[serde(default)]
+    pub dest_issi: u32,
+    #[serde(default = "default_incident_base")]
+    pub incident_base: u16,
+    #[serde(default = "default_text")]
+    pub default_text: String,
+    #[serde(default = "default_max_text_chars")]
+    pub max_text_chars: usize,
+
+    #[serde(flatten)]
+    pub extra: std::collections::HashMap<String, toml::Value>,
+}
+
+impl Default for CfgTpg2200ActionDto {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            token: String::new(),
+            source_issi: default_source_issi(),
+            dest_issi: 0,
+            incident_base: default_incident_base(),
+            default_text: default_text(),
+            max_text_chars: default_max_text_chars(),
+            extra: std::collections::HashMap::new(),
+        }
+    }
+}
+
+fn default_source_issi() -> u32 {
+    9999
+}
+
+fn default_incident_base() -> u16 {
+    1
+}
+
+fn default_text() -> String {
+    "ALARM".to_string()
+}
+
+fn default_max_text_chars() -> usize {
+    80
+}
+
+pub fn apply_tpg2200_action_patch(dto: CfgTpg2200ActionDto) -> Result<CfgTpg2200Action, String> {
+    if dto.enabled {
+        if dto.token.trim().is_empty() {
+            return Err("tpg2200_action: token cannot be empty when enabled".to_string());
+        }
+        if dto.source_issi == 0 {
+            return Err("tpg2200_action: source_issi cannot be 0 when enabled".to_string());
+        }
+        if dto.dest_issi == 0 {
+            return Err("tpg2200_action: dest_issi cannot be 0 when enabled".to_string());
+        }
+    }
+    if dto.token.chars().any(|c| c.is_whitespace() || c.is_control()) {
+        return Err(
+            "tpg2200_action: token must not contain spaces or control characters".to_string(),
+        );
+    }
+
+    Ok(CfgTpg2200Action {
+        enabled: dto.enabled,
+        token: SecretField::from(dto.token),
+        source_issi: dto.source_issi,
+        dest_issi: dto.dest_issi,
+        incident_base: dto.incident_base.clamp(1, 256),
+        default_text: dto.default_text.trim().to_string(),
+        max_text_chars: dto.max_text_chars.clamp(1, 240),
+    })
+}

--- a/crates/tetra-config/src/bluestation/state.rs
+++ b/crates/tetra-config/src/bluestation/state.rs
@@ -177,6 +177,228 @@ pub struct TelegramRuntimeOverride {
     pub alert_critical_logs: bool,
 }
 
+/// Runtime override for DAPNET receive/send/forwarding settings, edited from the dashboard.
+///
+/// Mirrors `[dapnet]`. When present, it takes precedence over the config file so routing edits
+/// apply immediately; the dashboard also writes the values back to TOML for persistence.
+#[derive(Debug, Clone, Default)]
+pub struct DapnetRuntimeOverride {
+    pub enabled: bool,
+    pub api_url: String,
+    pub username: String,
+    pub password: String,
+    pub poll_interval_secs: u64,
+    pub forward_sds: bool,
+    pub forward_callout: bool,
+    pub forward_telegram: bool,
+    pub sds_source_issi: u32,
+    pub sds_dest_issi: u32,
+    pub sds_dest_is_group: bool,
+    pub ric_issi_routes: std::collections::BTreeMap<u32, u32>,
+    pub ric_gssi_routes: std::collections::BTreeMap<u32, u32>,
+    pub sds_allowed_rics: std::collections::BTreeSet<u32>,
+    pub callout_allowed_rics: std::collections::BTreeSet<u32>,
+    pub telegram_allowed_rics: std::collections::BTreeSet<u32>,
+    pub callout_source_issi: u32,
+    pub callout_dest_issi: u32,
+    pub callout_incident_base: u16,
+    pub callout_text_prefix: String,
+    pub telegram_prefix: String,
+    pub rwth_core_enabled: bool,
+    pub rwth_core_host: String,
+    pub rwth_core_port: u16,
+    pub rwth_core_device: String,
+    pub rwth_core_version: String,
+    pub rwth_core_callsign: String,
+    pub rwth_core_authkey: String,
+    pub rwth_messages_limit: usize,
+}
+
+/// Runtime override for GeoAlarm settings, edited from the dashboard.
+///
+/// Mirrors `[geoalarm]`. When present, it takes precedence over the config file so radius,
+/// filters and forwarding edits apply immediately; the dashboard also writes the values back to
+/// TOML for persistence.
+#[derive(Debug, Clone, Default)]
+pub struct GeoalarmRuntimeOverride {
+    pub enabled: bool,
+    pub flowstation_lat: f64,
+    pub flowstation_lon: f64,
+    pub radius_m: f64,
+    pub cooldown_secs: u64,
+    pub trigger_tetra: bool,
+    pub trigger_meshcom: bool,
+    pub forward_tpg2200: bool,
+    pub forward_sds: bool,
+    pub forward_sip: bool,
+    pub forward_telegram: bool,
+    pub tetra_issi_whitelist: std::collections::BTreeSet<u32>,
+    pub tetra_issi_blacklist: std::collections::BTreeSet<u32>,
+    pub meshcom_source_whitelist: std::collections::BTreeSet<String>,
+    pub meshcom_source_blacklist: std::collections::BTreeSet<String>,
+    pub sds_source_issi: u32,
+    pub sds_dest_issi: u32,
+    pub sds_dest_is_group: bool,
+    pub tpg2200_source_issi: u32,
+    pub tpg2200_dest_issi: u32,
+    pub tpg2200_incident_base: u16,
+    pub tpg2200_text_prefix: String,
+    pub tpg2200_max_text_chars: usize,
+    pub sip_title_prefix: String,
+    pub telegram_prefix: String,
+}
+
+/// Runtime override for Snom XML NOTIFY settings, edited from the dashboard.
+///
+/// Mirrors `[snom_notify]`. When present, it takes precedence over the config file so
+/// notification routing edits apply immediately; the dashboard also writes the values
+/// back to TOML for persistence.
+#[derive(Debug, Clone, Default)]
+pub struct SnomNotifyRuntimeOverride {
+    pub enabled: bool,
+    pub ami_host: String,
+    pub ami_port: u16,
+    pub ami_username: String,
+    pub ami_password: String,
+    pub endpoints: Vec<String>,
+    pub notify_sds: bool,
+    pub notify_dapnet: bool,
+    pub notify_telegram: bool,
+    pub sds_directions: Vec<String>,
+    pub dapnet_allowed_rics: std::collections::BTreeSet<u32>,
+    pub sds_allowed_issis: std::collections::BTreeSet<u32>,
+    pub title_prefix: String,
+    pub notify_event: String,
+    pub content_type: String,
+    pub subscription_state: String,
+    pub max_text_chars: usize,
+    pub connect_timeout_secs: u64,
+}
+
+#[derive(Debug, Clone)]
+pub struct AsteriskRuntimeStatus {
+    pub configured: bool,
+    pub enabled: bool,
+    pub register_status: String,
+    pub sip_listen: String,
+    pub remote: String,
+    pub rtp_port_range: String,
+    pub codec: String,
+    pub active_dialogs: usize,
+    pub last_rx: Option<String>,
+    pub last_tx: Option<String>,
+    pub last_error: Option<String>,
+}
+
+impl Default for AsteriskRuntimeStatus {
+    fn default() -> Self {
+        Self {
+            configured: false,
+            enabled: false,
+            register_status: "disabled".to_string(),
+            sip_listen: String::new(),
+            remote: String::new(),
+            rtp_port_range: String::new(),
+            codec: "PCMU".to_string(),
+            active_dialogs: 0,
+            last_rx: None,
+            last_tx: None,
+            last_error: None,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct DapnetRuntimeStatus {
+    pub configured: bool,
+    pub enabled: bool,
+    pub rwth_core_enabled: bool,
+    pub rwth_core_status: String,
+    pub endpoint: String,
+    pub callsign: String,
+    pub forward_sds: bool,
+    pub forward_callout: bool,
+    pub forward_telegram: bool,
+    pub seen_messages: usize,
+    pub last_rx: Option<String>,
+    pub last_error: Option<String>,
+}
+
+impl Default for DapnetRuntimeStatus {
+    fn default() -> Self {
+        Self {
+            configured: false,
+            enabled: false,
+            rwth_core_enabled: false,
+            rwth_core_status: "disabled".to_string(),
+            endpoint: String::new(),
+            callsign: String::new(),
+            forward_sds: false,
+            forward_callout: false,
+            forward_telegram: false,
+            seen_messages: 0,
+            last_rx: None,
+            last_error: None,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct GeoalarmEventStatus {
+    pub ts: String,
+    pub source: String,
+    pub device: String,
+    pub lat: f64,
+    pub lon: f64,
+    pub distance_m: f64,
+    pub inside_radius: bool,
+    pub alarmed: bool,
+    pub paths: Vec<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct GeoalarmRuntimeStatus {
+    pub configured: bool,
+    pub enabled: bool,
+    pub center: String,
+    pub radius_m: f64,
+    pub trigger_tetra: bool,
+    pub trigger_meshcom: bool,
+    pub forward_tpg2200: bool,
+    pub forward_sds: bool,
+    pub forward_sip: bool,
+    pub forward_telegram: bool,
+    pub seen_positions: u64,
+    pub alarm_count: u64,
+    pub last_position: Option<String>,
+    pub last_alarm: Option<String>,
+    pub last_error: Option<String>,
+    pub events: Vec<GeoalarmEventStatus>,
+}
+
+impl Default for GeoalarmRuntimeStatus {
+    fn default() -> Self {
+        Self {
+            configured: false,
+            enabled: false,
+            center: String::new(),
+            radius_m: 0.0,
+            trigger_tetra: false,
+            trigger_meshcom: false,
+            forward_tpg2200: false,
+            forward_sds: false,
+            forward_sip: false,
+            forward_telegram: false,
+            seen_positions: 0,
+            alarm_count: 0,
+            last_position: None,
+            last_alarm: None,
+            last_error: None,
+            events: Vec::new(),
+        }
+    }
+}
+
 /// Mutable, stack-editable state (mutex-protected).
 #[derive(Debug, Clone)]
 pub struct StackState {
@@ -201,6 +423,20 @@ pub struct StackState {
     pub wx_override: Option<WxRuntimeOverride>,
     /// Runtime override for Telegram alerts (dashboard editing). See TelegramRuntimeOverride.
     pub telegram_override: Option<TelegramRuntimeOverride>,
+    /// Runtime override for DAPNET settings (dashboard editing). See DapnetRuntimeOverride.
+    pub dapnet_override: Option<DapnetRuntimeOverride>,
+    /// Runtime override for GeoAlarm settings (dashboard editing). See GeoalarmRuntimeOverride.
+    pub geoalarm_override: Option<GeoalarmRuntimeOverride>,
+    /// Runtime override for Snom XML NOTIFY settings. See SnomNotifyRuntimeOverride.
+    pub snom_notify_override: Option<SnomNotifyRuntimeOverride>,
+    /// Next TPG2200 ActionURL incident number. Initialised lazily from `[tpg2200_action]`.
+    pub tpg2200_action_next_incident: Option<u16>,
+    /// Runtime Asterisk SIP/RTP bridge status for `/api/asterisk/status` and the dashboard tab.
+    pub asterisk_status: AsteriskRuntimeStatus,
+    /// Runtime DAPNET receiver/forwarding status for `/api/dapnet` and the Health tab.
+    pub dapnet_status: DapnetRuntimeStatus,
+    /// Runtime GeoAlarm status for `/api/geoalarm`.
+    pub geoalarm_status: GeoalarmRuntimeStatus,
     /// Live map "identity currently reachable on a traffic channel" → (DL timeslot, usage_marker),
     /// republished every tick by CMCE call control from the live call tables (so it is never
     /// stale). Keyed by GSSI for active group calls and by each participant ISSI for connected
@@ -316,6 +552,13 @@ impl Default for StackState {
             issi_whitelist_override: None,
             wx_override: None,
             telegram_override: None,
+            dapnet_override: None,
+            geoalarm_override: None,
+            snom_notify_override: None,
+            tpg2200_action_next_incident: None,
+            asterisk_status: AsteriskRuntimeStatus::default(),
+            dapnet_status: DapnetRuntimeStatus::default(),
+            geoalarm_status: GeoalarmRuntimeStatus::default(),
             active_call_ts: std::collections::HashMap::new(),
             ee_monitoring_windows: std::collections::HashMap::new(),
         }

--- a/crates/tetra-core/src/tetra_entities.rs
+++ b/crates/tetra-core/src/tetra_entities.rs
@@ -26,4 +26,7 @@ pub enum TetraEntity {
 
     /// Brew protocol bridge (TetraPack/BrandMeister integration)
     Brew,
+
+    /// Asterisk SIP/RTP bridge
+    Asterisk,
 }

--- a/crates/tetra-entities/Cargo.toml
+++ b/crates/tetra-entities/Cargo.toml
@@ -3,6 +3,13 @@ name = "tetra-entities"
 version.workspace = true
 edition.workspace = true
 
+[features]
+# Default build excludes the Asterisk SIP/RTP bridge so it needs no native
+# libtetra-codec. Enable with `--features asterisk` to compile net_asterisk and
+# link the TETRA codec.
+default = []
+asterisk = []
+
 [dependencies]
 tetra-core = { workspace = true }
 tetra-config = { workspace = true }

--- a/crates/tetra-entities/build.rs
+++ b/crates/tetra-entities/build.rs
@@ -1,0 +1,22 @@
+use std::process::Command;
+
+fn main() {
+    println!("cargo:rerun-if-changed=build.rs");
+    println!("cargo:rerun-if-env-changed=PKG_CONFIG");
+    println!("cargo:rerun-if-env-changed=PKG_CONFIG_PATH");
+
+    // Only resolve the native TETRA codec link path when the Asterisk SIP/RTP
+    // bridge is compiled in. The default build excludes net_asterisk entirely,
+    // so it must not depend on libtetra-codec being installed.
+    if std::env::var("CARGO_FEATURE_ASTERISK").is_ok()
+        && let Ok(output) = Command::new("pkg-config").args(["--libs", "tetra-codec"]).output()
+        && output.status.success()
+    {
+        let flags = String::from_utf8_lossy(&output.stdout);
+        for flag in flags.split_whitespace() {
+            if let Some(path) = flag.strip_prefix("-L") {
+                println!("cargo:rustc-link-search=native={path}");
+            }
+        }
+    }
+}

--- a/crates/tetra-entities/src/cmce/subentities/cc_bs/lifecycle.rs
+++ b/crates/tetra-entities/src/cmce/subentities/cc_bs/lifecycle.rs
@@ -142,10 +142,16 @@ impl CcBsSubentity {
         Self::push_control(queue, TetraEntity::Brew, CallControl::NetworkCallEnd { brew_uuid });
     }
 
-    pub(super) fn notify_network_circuit_release(&self, queue: &mut MessageQueue, brew_uuid: uuid::Uuid, cause: DisconnectCause) {
+    pub(super) fn notify_network_circuit_release(
+        &self,
+        queue: &mut MessageQueue,
+        network_entity: TetraEntity,
+        brew_uuid: uuid::Uuid,
+        cause: DisconnectCause,
+    ) {
         Self::push_control(
             queue,
-            TetraEntity::Brew,
+            network_entity,
             CallControl::NetworkCircuitRelease {
                 brew_uuid,
                 cause: cause.into_raw() as u8,

--- a/crates/tetra-entities/src/cmce/subentities/cc_bs/pdu.rs
+++ b/crates/tetra-entities/src/cmce/subentities/cc_bs/pdu.rs
@@ -678,6 +678,61 @@ impl CcBsSubentity {
         !network_call.number.is_empty() || pdu.external_subscriber_number.is_some() || pdu.called_party_short_number_address.is_some()
     }
 
+    /// Derive a usable display SSI for an inbound network call's calling party from its
+    /// external (SIP/PBX) number when no real ISSI is available. Accepts a purely numeric
+    /// extension within the 24-bit SSI range; rejects everything else. Mirrors the upstream
+    /// fork's `external_number_as_ssi`.
+    pub(super) fn external_number_as_ssi(number: &str) -> Option<u32> {
+        let digits = number.trim();
+        if digits.is_empty() || !digits.chars().all(|ch| ch.is_ascii_digit()) {
+            return None;
+        }
+        let value = digits.parse::<u32>().ok()?;
+        (value != 0 && value <= 0x00ff_ffff).then_some(value)
+    }
+
+    /// Decide whether a dialed (non-ISSI) number should be routed to the Asterisk SIP/RTP
+    /// bridge instead of Brew. Returns the SIP number to dial (prefix-stripped when configured),
+    /// or `None` to leave the call for Brew. Mirrors the upstream fork's `asterisk_route_number`.
+    #[cfg(feature = "asterisk")]
+    pub(super) fn asterisk_route_number(&self, network_call: &NetworkCircuitCall) -> Option<String> {
+        let cfg = &self.config.config().asterisk;
+        if !cfg.enabled {
+            return None;
+        }
+
+        let raw = if !network_call.number.trim().is_empty() {
+            network_call.number.trim().to_string()
+        } else if network_call.destination != 0 {
+            network_call.destination.to_string()
+        } else {
+            return None;
+        };
+
+        let mut routed = raw.as_str();
+        if !cfg.outbound_prefix.is_empty() && raw.starts_with(&cfg.outbound_prefix) && cfg.strip_outbound_prefix {
+            routed = &raw[cfg.outbound_prefix.len()..];
+        }
+
+        let routed = routed.trim();
+        if routed.is_empty() {
+            return None;
+        }
+
+        if cfg.service_numbers.is_empty() {
+            if !cfg.outbound_prefix.is_empty() && raw.starts_with(&cfg.outbound_prefix) {
+                return Some(routed.to_string());
+            }
+            return None;
+        }
+
+        if cfg.service_numbers.iter().any(|n| n == routed) {
+            Some(routed.to_string())
+        } else {
+            None
+        }
+    }
+
     pub(super) fn signal_umac_circuit_open(
         queue: &mut MessageQueue,
         call: &CmceCircuit,
@@ -983,7 +1038,7 @@ impl CcBsSubentity {
 
         if (call.called_over_brew || call.calling_over_brew) && disconnect_cause != DisconnectCause::SwmiRequestedDisconnection {
             if let Some(brew_uuid) = call.brew_uuid {
-                self.notify_network_circuit_release(queue, brew_uuid, disconnect_cause);
+                self.notify_network_circuit_release(queue, call.network_entity, brew_uuid, disconnect_cause);
             }
         }
 
@@ -1144,6 +1199,122 @@ impl PreemptVictim {
 #[cfg(test)]
 mod tests {
     use super::CcBsSubentity;
+    #[cfg(feature = "asterisk")]
+    use tetra_config::bluestation::{SharedConfig, parsing};
+    #[cfg(feature = "asterisk")]
+    use tetra_saps::control::call_control::NetworkCircuitCall;
+
+    #[cfg(feature = "asterisk")]
+    fn asterisk_test_cc() -> CcBsSubentity {
+        let toml = r#"
+config_version = "0.6"
+stack_mode = "Bs"
+
+[phy_io]
+backend = "None"
+
+[net_info]
+mcc = 901
+mnc = 9999
+
+[cell_info]
+main_carrier = 1584
+freq_band = 4
+freq_offset = 0
+duplex_spacing = 4
+reverse_operation = false
+location_area = 1
+
+[asterisk]
+enabled = true
+outbound_prefix = "91"
+strip_outbound_prefix = true
+codec = "PCMU"
+service_numbers = ["600", "601"]
+"#;
+        let cfg = parsing::from_toml_str(toml).expect("asterisk test config must parse");
+        CcBsSubentity::new(SharedConfig::from_parts(cfg, None))
+    }
+
+    #[cfg(feature = "asterisk")]
+    fn asterisk_open_prefix_test_cc() -> CcBsSubentity {
+        let toml = r#"
+config_version = "0.6"
+stack_mode = "Bs"
+
+[phy_io]
+backend = "None"
+
+[net_info]
+mcc = 901
+mnc = 9999
+
+[cell_info]
+main_carrier = 1584
+freq_band = 4
+freq_offset = 0
+duplex_spacing = 4
+reverse_operation = false
+location_area = 1
+
+[asterisk]
+enabled = true
+outbound_prefix = "91"
+strip_outbound_prefix = true
+codec = "PCMU"
+"#;
+        let cfg = parsing::from_toml_str(toml).expect("asterisk open-prefix test config must parse");
+        CcBsSubentity::new(SharedConfig::from_parts(cfg, None))
+    }
+
+    #[cfg(feature = "asterisk")]
+    fn network_call(destination: u32, number: &str) -> NetworkCircuitCall {
+        NetworkCircuitCall {
+            source_issi: 1000001,
+            destination,
+            number: number.to_string(),
+            priority: 0,
+            service: 0,
+            mode: 0,
+            duplex: 0,
+            method: 0,
+            communication: 0,
+            grant: 0,
+            permission: 0,
+            timeout: 0,
+            ownership: 0,
+            queued: 0,
+        }
+    }
+
+    #[cfg(feature = "asterisk")]
+    #[test]
+    fn asterisk_route_strips_prefix_for_configured_service_numbers() {
+        let cc = asterisk_test_cc();
+
+        assert_eq!(cc.asterisk_route_number(&network_call(91600, "")), Some("600".to_string()));
+        assert_eq!(cc.asterisk_route_number(&network_call(91601, "")), Some("601".to_string()));
+    }
+
+    #[cfg(feature = "asterisk")]
+    #[test]
+    fn asterisk_route_uses_dialed_number_and_leaves_non_matches_for_brew() {
+        let cc = asterisk_test_cc();
+
+        assert_eq!(cc.asterisk_route_number(&network_call(0, "91600")), Some("600".to_string()));
+        assert_eq!(cc.asterisk_route_number(&network_call(91602, "")), None);
+        assert_eq!(cc.asterisk_route_number(&network_call(0, "91234")), None);
+    }
+
+    #[cfg(feature = "asterisk")]
+    #[test]
+    fn asterisk_route_accepts_prefixed_numbers_when_service_list_is_empty() {
+        let cc = asterisk_open_prefix_test_cc();
+
+        assert_eq!(cc.asterisk_route_number(&network_call(91601, "")), Some("601".to_string()));
+        assert_eq!(cc.asterisk_route_number(&network_call(0, "91601")), Some("601".to_string()));
+        assert_eq!(cc.asterisk_route_number(&network_call(601, "")), None);
+    }
 
     #[test]
     fn external_subscriber_number_supports_24_digits() {

--- a/crates/tetra-entities/src/cmce/subentities/cc_bs/procedures/individual.rs
+++ b/crates/tetra-entities/src/cmce/subentities/cc_bs/procedures/individual.rs
@@ -202,7 +202,7 @@ impl CcBsSubentity {
             queue.push_back(SapMsg {
                 sap: Sap::Control,
                 src: TetraEntity::Cmce,
-                dest: TetraEntity::Brew,
+                dest: call_snapshot.network_entity,
                 msg: SapMsgInner::CmceCallControl(CallControl::NetworkCircuitAlert { brew_uuid }),
             });
         } else if !call_snapshot.is_alerted() {
@@ -403,7 +403,7 @@ impl CcBsSubentity {
             queue.push_back(SapMsg {
                 sap: Sap::Control,
                 src: TetraEntity::Cmce,
-                dest: TetraEntity::Brew,
+                dest: call_snapshot.network_entity,
                 msg: SapMsgInner::CmceCallControl(CallControl::NetworkCircuitConnectRequest {
                     brew_uuid,
                     call: call_info.clone(),

--- a/crates/tetra-entities/src/cmce/subentities/cc_bs/procedures/isi.rs
+++ b/crates/tetra-entities/src/cmce/subentities/cc_bs/procedures/isi.rs
@@ -7,17 +7,19 @@ use super::*;
 /// group-call interworking belongs beside CC procedures, while PC remains the
 /// CMCE route discriminator.
 impl CcBsSubentity {
-    /// Handle network-initiated circuit setup request (Brew -> local called MS).
+    /// Handle network-initiated circuit setup request (Brew/Asterisk -> local called MS).
     pub(in crate::cmce::subentities::cc_bs) fn fsm_on_network_circuit_setup_request(
         &mut self,
         queue: &mut MessageQueue,
+        network_entity: TetraEntity,
         brew_uuid: uuid::Uuid,
         call: NetworkCircuitCall,
     ) {
         let called_addr = TetraAddress::new(call.destination, SsiType::Issi);
         if call.destination == 0 {
             tracing::info!(
-                "CMCE: rejecting Brew setup request uuid={} src={} dst=0 number='{}' (missing called ISSI)",
+                "CMCE: rejecting {:?} setup request uuid={} src={} dst=0 number='{}' (missing called ISSI)",
+                network_entity,
                 brew_uuid,
                 call.source_issi,
                 call.number
@@ -25,7 +27,7 @@ impl CcBsSubentity {
             queue.push_back(SapMsg {
                 sap: Sap::Control,
                 src: TetraEntity::Cmce,
-                dest: TetraEntity::Brew,
+                dest: network_entity,
                 msg: SapMsgInner::CmceCallControl(CallControl::NetworkCircuitSetupReject {
                     brew_uuid,
                     cause: DisconnectCause::CalledPartyNotReachable.into_raw() as u8,
@@ -46,7 +48,7 @@ impl CcBsSubentity {
             queue.push_back(SapMsg {
                 sap: Sap::Control,
                 src: TetraEntity::Cmce,
-                dest: TetraEntity::Brew,
+                dest: network_entity,
                 msg: SapMsgInner::CmceCallControl(CallControl::NetworkCircuitSetupReject {
                     brew_uuid,
                     cause: DisconnectCause::CalledPartyNotReachable.into_raw() as u8,
@@ -68,7 +70,7 @@ impl CcBsSubentity {
             queue.push_back(SapMsg {
                 sap: Sap::Control,
                 src: TetraEntity::Cmce,
-                dest: TetraEntity::Brew,
+                dest: network_entity,
                 msg: SapMsgInner::CmceCallControl(CallControl::NetworkCircuitSetupReject {
                     brew_uuid,
                     cause: DisconnectCause::CalledPartyBusy.into_raw() as u8,
@@ -102,7 +104,7 @@ impl CcBsSubentity {
                     queue.push_back(SapMsg {
                         sap: Sap::Control,
                         src: TetraEntity::Cmce,
-                        dest: TetraEntity::Brew,
+                        dest: network_entity,
                         msg: SapMsgInner::CmceCallControl(CallControl::NetworkCircuitSetupReject {
                             brew_uuid,
                             cause: DisconnectCause::CongestionInInfrastructure.into_raw() as u8,
@@ -121,8 +123,20 @@ impl CcBsSubentity {
         let external_subscriber_number = Self::encode_external_subscriber_number(&call.number);
         let calling_party_extension = call.number.trim().parse::<u32>().ok().filter(|value| *value <= 0x00ff_ffff);
 
+        // Asterisk SIP callers often have no real TETRA ISSI; derive a display SSI from the
+        // dialled external number so the local MS sees a sensible calling party. Brew keeps its
+        // original behaviour (always uses source_issi, even when 0).
+        let calling_party_address_ssi = if call.source_issi != 0 {
+            Some(call.source_issi)
+        } else if network_entity == TetraEntity::Asterisk {
+            Self::external_number_as_ssi(&call.number)
+        } else {
+            Some(call.source_issi)
+        };
+
         tracing::info!(
-            "CMCE: accepting Brew setup request uuid={} call_id={} src={} dst={} ts={} duplex={} number='{}'",
+            "CMCE: accepting {:?} setup request uuid={} call_id={} src={} dst={} ts={} duplex={} number='{}'",
+            network_entity,
             brew_uuid,
             call_id,
             call.source_issi,
@@ -132,11 +146,12 @@ impl CcBsSubentity {
             call.number
         );
 
-        // Acknowledge setup to Brew first so network call state progresses while local MS is alerted.
+        // Acknowledge setup to the originating network entity first so network call state
+        // progresses while the local MS is alerted.
         queue.push_back(SapMsg {
             sap: Sap::Control,
             src: TetraEntity::Cmce,
-            dest: TetraEntity::Brew,
+            dest: network_entity,
             msg: SapMsgInner::CmceCallControl(CallControl::NetworkCircuitSetupAccept { brew_uuid }),
         });
 
@@ -163,7 +178,7 @@ impl CcBsSubentity {
             call_priority: call.priority,
             notification_indicator: None,
             temporary_address: None,
-            calling_party_address_ssi: Some(call.source_issi),
+            calling_party_address_ssi,
             calling_party_extension,
             external_subscriber_number,
             facility: None,
@@ -214,6 +229,7 @@ impl CcBsSubentity {
                 call_timeout,
                 called_over_brew: false,
                 calling_over_brew: true,
+                network_entity,
                 brew_uuid: Some(brew_uuid),
                 network_call: Some(call),
                 connect_request_sent: false,
@@ -413,7 +429,7 @@ impl CcBsSubentity {
         queue.push_back(SapMsg {
             sap: Sap::Control,
             src: TetraEntity::Cmce,
-            dest: TetraEntity::Brew,
+            dest: call.network_entity,
             msg: SapMsgInner::CmceCallControl(CallControl::NetworkCircuitConnectConfirm {
                 brew_uuid,
                 grant: remote_grant.into_raw() as u8,
@@ -424,7 +440,7 @@ impl CcBsSubentity {
         queue.push_back(SapMsg {
             sap: Sap::Control,
             src: TetraEntity::Cmce,
-            dest: TetraEntity::Brew,
+            dest: call.network_entity,
             msg: SapMsgInner::CmceCallControl(CallControl::NetworkCircuitMediaReady {
                 brew_uuid,
                 call_id,
@@ -633,7 +649,7 @@ impl CcBsSubentity {
         queue.push_back(SapMsg {
             sap: Sap::Control,
             src: TetraEntity::Cmce,
-            dest: TetraEntity::Brew,
+            dest: call.network_entity,
             msg: SapMsgInner::CmceCallControl(CallControl::NetworkCircuitMediaReady {
                 brew_uuid,
                 call_id,

--- a/crates/tetra-entities/src/cmce/subentities/cc_bs/procedures/setup.rs
+++ b/crates/tetra-entities/src/cmce/subentities/cc_bs/procedures/setup.rs
@@ -320,9 +320,15 @@ impl CcBsSubentity {
             pdu.called_party_type_identifier,
             PartyTypeIdentifier::Ssi | PartyTypeIdentifier::Tsi
         );
-        if !is_issi_address && !brew::is_active(&self.config) {
+        // When the Asterisk feature is off, behave as if Asterisk is disabled: a non-ISSI
+        // destination is only acceptable if Brew is active.
+        #[cfg(feature = "asterisk")]
+        let asterisk_can_route = self.config.config().asterisk.enabled;
+        #[cfg(not(feature = "asterisk"))]
+        let asterisk_can_route = false;
+        if !is_issi_address && !brew::is_active(&self.config) && !asterisk_can_route {
             tracing::warn!(
-                "U-SETUP P2P with non-ISSI called_party_type_identifier={} (rejecting, Brew disabled)",
+                "U-SETUP P2P with non-ISSI called_party_type_identifier={} (rejecting, Brew/Asterisk disabled)",
                 pdu.called_party_type_identifier
             );
             self.reject_setup_request(
@@ -330,7 +336,7 @@ impl CcBsSubentity {
                 message,
                 calling_party,
                 DisconnectCause::RequestedServiceNotAvailable,
-                "non-ISSI destination requires Brew",
+                "non-ISSI destination requires Brew or Asterisk",
             );
             return;
         }
@@ -568,6 +574,9 @@ impl CcBsSubentity {
                 call_timeout: Self::p2p_call_timeout(pdu.simplex_duplex_selection),
                 called_over_brew: false,
                 calling_over_brew: false,
+                // Local-only call: no network leg. Defaults to Brew but is never used
+                // because all network sends are gated on called/calling_over_brew + brew_uuid.
+                network_entity: TetraEntity::Brew,
                 brew_uuid: None,
                 network_call: None,
                 connect_request_sent: false,
@@ -622,9 +631,37 @@ impl CcBsSubentity {
         let SapMsgInner::LcmcMleUnitdataInd(prim) = &message.msg else {
             panic!()
         };
+        #[cfg_attr(not(feature = "asterisk"), allow(unused_mut))]
         let mut network_call = Self::build_network_circuit_call_from_u_setup(pdu, calling_party.ssi);
 
-        if !brew::is_active(&self.config) {
+        // Decide whether this dialed (non-ISSI) number routes to the Asterisk SIP/RTP bridge
+        // instead of Brew. Asterisk takes precedence; otherwise the call falls through to Brew.
+        // Without the asterisk feature there is no SIP bridge, so every call falls through to Brew.
+        #[cfg(feature = "asterisk")]
+        let network_entity = {
+            let asterisk_number = self.asterisk_route_number(&network_call);
+            let entity = if asterisk_number.is_some() {
+                TetraEntity::Asterisk
+            } else {
+                TetraEntity::Brew
+            };
+            if let Some(number) = asterisk_number {
+                tracing::info!(
+                    "CMCE: routing U-SETUP src={} dialed='{}' to Asterisk SIP number='{}'",
+                    calling_party.ssi,
+                    network_call.number,
+                    number
+                );
+                network_call.number = number;
+                network_call.destination = 0;
+                network_call.duplex = 1;
+            }
+            entity
+        };
+        #[cfg(not(feature = "asterisk"))]
+        let network_entity = TetraEntity::Brew;
+
+        if network_entity == TetraEntity::Brew && !brew::is_active(&self.config) {
             tracing::info!(
                 "CMCE: rejecting U-SETUP P2P from ISSI {} (Brew disabled, called_ssi={})",
                 calling_party.ssi,
@@ -652,7 +689,9 @@ impl CcBsSubentity {
             return;
         }
 
-        if !self.config.state_read().network_connected {
+        // The backhaul-connected and ISSI-routability gates are Brew-specific (they check the
+        // Brew websocket state and the Brew ISSI whitelist). Asterisk-bridged calls bypass them.
+        if network_entity == TetraEntity::Brew && !self.config.state_read().network_connected {
             tracing::info!(
                 "CMCE: rejecting U-SETUP over Brew src={} dst={} (backhaul disconnected)",
                 calling_party.ssi,
@@ -668,7 +707,7 @@ impl CcBsSubentity {
             return;
         }
 
-        if !brew::is_brew_issi_routable(&self.config, calling_party.ssi) {
+        if network_entity == TetraEntity::Brew && !brew::is_brew_issi_routable(&self.config, calling_party.ssi) {
             tracing::info!(
                 "CMCE: rejecting U-SETUP P2P over Brew src={} dst={} (source ISSI not routable)",
                 calling_party.ssi,
@@ -685,7 +724,9 @@ impl CcBsSubentity {
         }
 
         let has_external_called_party = Self::has_external_called_party(pdu, &network_call);
-        let destination_routable = network_call.destination == 0 || brew::is_brew_issi_routable(&self.config, network_call.destination);
+        let destination_routable = network_entity == TetraEntity::Asterisk
+            || network_call.destination == 0
+            || brew::is_brew_issi_routable(&self.config, network_call.destination);
 
         if !has_external_called_party && !destination_routable {
             tracing::info!(
@@ -750,7 +791,8 @@ impl CcBsSubentity {
         let brew_uuid = uuid::Uuid::new_v4();
 
         tracing::info!(
-            "CMCE: forwarding U-SETUP over Brew call_id={} src={} dst={} ts={} duplex={} number='{}' uuid={}",
+            "CMCE: forwarding U-SETUP over {:?} call_id={} src={} dst={} ts={} duplex={} number='{}' uuid={}",
+            network_entity,
             call_id,
             calling_party.ssi,
             network_call.destination,
@@ -765,7 +807,7 @@ impl CcBsSubentity {
         queue.push_back(SapMsg {
             sap: Sap::Control,
             src: TetraEntity::Cmce,
-            dest: TetraEntity::Brew,
+            dest: network_entity,
             msg: SapMsgInner::CmceCallControl(CallControl::NetworkCircuitSetupRequest {
                 brew_uuid,
                 call: network_call.clone(),
@@ -797,6 +839,7 @@ impl CcBsSubentity {
                 call_timeout: Self::p2p_call_timeout(pdu.simplex_duplex_selection),
                 called_over_brew: true,
                 calling_over_brew: false,
+                network_entity,
                 brew_uuid: Some(brew_uuid),
                 network_call: Some(network_call),
                 connect_request_sent: false,

--- a/crates/tetra-entities/src/cmce/subentities/cc_bs/procedures/uplink.rs
+++ b/crates/tetra-entities/src/cmce/subentities/cc_bs/procedures/uplink.rs
@@ -155,7 +155,7 @@ impl CcBsSubentity {
             queue.push_back(SapMsg {
                 sap: Sap::Control,
                 src: TetraEntity::Cmce,
-                dest: TetraEntity::Brew,
+                dest: call.network_entity,
                 msg: SapMsgInner::CmceCallControl(CallControl::NetworkCircuitSimplexGranted {
                     brew_uuid,
                     grant: TransmissionGrant::Granted.into_raw() as u8,
@@ -181,7 +181,7 @@ impl CcBsSubentity {
             queue.push_back(SapMsg {
                 sap: Sap::Control,
                 src: TetraEntity::Cmce,
-                dest: TetraEntity::Brew,
+                dest: call.network_entity,
                 msg: SapMsgInner::CmceCallControl(CallControl::NetworkCircuitSimplexIdle {
                     brew_uuid,
                     grant: TransmissionGrant::NotGranted.into_raw() as u8,
@@ -832,7 +832,7 @@ impl CcBsSubentity {
             queue.push_back(SapMsg {
                 sap: Sap::Control,
                 src: TetraEntity::Cmce,
-                dest: TetraEntity::Brew,
+                dest: call.network_entity,
                 msg: SapMsgInner::CmceCallControl(CallControl::NetworkCircuitDtmf {
                     brew_uuid,
                     length_bits: 8,

--- a/crates/tetra-entities/src/cmce/subentities/cc_bs/routes/isi.rs
+++ b/crates/tetra-entities/src/cmce/subentities/cc_bs/routes/isi.rs
@@ -14,8 +14,14 @@ impl CcBsSubentity {
             .map(|(id, call)| (*id, call.clone()))
     }
 
-    pub(super) fn rx_network_circuit_setup_request(&mut self, queue: &mut MessageQueue, brew_uuid: uuid::Uuid, call: NetworkCircuitCall) {
-        self.fsm_on_network_circuit_setup_request(queue, brew_uuid, call);
+    pub(super) fn rx_network_circuit_setup_request(
+        &mut self,
+        queue: &mut MessageQueue,
+        network_entity: TetraEntity,
+        brew_uuid: uuid::Uuid,
+        call: NetworkCircuitCall,
+    ) {
+        self.fsm_on_network_circuit_setup_request(queue, network_entity, brew_uuid, call);
     }
 
     pub(super) fn rx_network_circuit_setup_accept(&mut self, brew_uuid: uuid::Uuid) {

--- a/crates/tetra-entities/src/cmce/subentities/cc_bs/routes/ra.rs
+++ b/crates/tetra-entities/src/cmce/subentities/cc_bs/routes/ra.rs
@@ -2,6 +2,9 @@ use super::*;
 
 impl CcBsSubentity {
     pub fn rx_call_control(&mut self, queue: &mut MessageQueue, message: SapMsg) {
+        // The originating network entity (Brew or Asterisk). Inbound network-initiated setup
+        // requests carry no prior call record, so we route replies back to the sender.
+        let src_entity = message.src;
         let SapMsgInner::CmceCallControl(call_control) = message.msg else {
             tracing::warn!("CMCE CC control ingress received non-call-control message");
             return;
@@ -23,7 +26,7 @@ impl CcBsSubentity {
                 self.handle_ul_inactivity_timeout(queue, ts);
             }
             CallControl::NetworkCircuitSetupRequest { brew_uuid, call } => {
-                self.rx_network_circuit_setup_request(queue, brew_uuid, call);
+                self.rx_network_circuit_setup_request(queue, src_entity, brew_uuid, call);
             }
             CallControl::NetworkCircuitSetupAccept { brew_uuid } => {
                 self.rx_network_circuit_setup_accept(brew_uuid);

--- a/crates/tetra-entities/src/cmce/subentities/cc_bs/state/mod.rs
+++ b/crates/tetra-entities/src/cmce/subentities/cc_bs/state/mod.rs
@@ -402,6 +402,11 @@ pub(super) struct IndividualCall {
     pub(super) called_over_brew: bool,
     /// True when the calling party lives behind Brew/TetraPack.
     pub(super) calling_over_brew: bool,
+    /// Network entity bridging this call (Brew or Asterisk). Call-control messages and
+    /// floor/DTMF signalling for the network leg are routed to this entity rather than
+    /// hardcoding `TetraEntity::Brew`, so Brew calls reach Brew and Asterisk calls reach
+    /// the SIP/RTP bridge.
+    pub(super) network_entity: TetraEntity,
     /// Brew UUID when this call is bridged to TetraPack.
     pub(super) brew_uuid: Option<uuid::Uuid>,
     /// Cached network call metadata for Brew bridged legs.

--- a/crates/tetra-entities/src/cmce/subentities/cc_bs/timers.rs
+++ b/crates/tetra-entities/src/cmce/subentities/cc_bs/timers.rs
@@ -188,7 +188,8 @@ impl CcBsSubentity {
                             if (ind_call.called_over_brew || ind_call.calling_over_brew)
                                 && let Some(brew_uuid) = ind_call.brew_uuid
                             {
-                                self.notify_network_circuit_release(queue, brew_uuid, disconnect_cause);
+                                let network_entity = ind_call.network_entity;
+                                self.notify_network_circuit_release(queue, network_entity, brew_uuid, disconnect_cause);
                             }
                         }
 

--- a/crates/tetra-entities/src/lib.rs
+++ b/crates/tetra-entities/src/lib.rs
@@ -13,16 +13,22 @@ pub mod umac;
 
 pub mod network;
 
+#[cfg(feature = "asterisk")]
+pub mod net_asterisk;
 pub mod net_brew;
 pub mod net_control;
 pub mod net_dashboard;
 pub mod net_telegram;
 pub mod net_telemetry;
+pub mod net_dapnet;
+pub mod net_geoalarm;
+pub mod net_snom;
 
 pub mod backlight;
 pub mod health;
 pub mod service_control;
 pub mod sys_telemetry;
+pub mod tpg2200;
 pub mod wifi;
 
 // Re-export commonly used items from router

--- a/crates/tetra-entities/src/net_asterisk/audio.rs
+++ b/crates/tetra-entities/src/net_asterisk/audio.rs
@@ -1,0 +1,295 @@
+use std::ptr::NonNull;
+
+pub(crate) const PCMU_PAYLOAD_TYPE: u8 = 0;
+
+const TETRA_PCM_SAMPLES_PER_FRAME: usize = 240;
+const TETRA_PCM_SAMPLES_PER_BLOCK: usize = TETRA_PCM_SAMPLES_PER_FRAME * 2;
+const TETRA_CODED_BITS_PER_FRAME: usize = 137;
+const TETRA_CODED_BYTES_PER_FRAME: usize = (TETRA_CODED_BITS_PER_FRAME + 7) / 8;
+const TETRA_TMD_BITS_PER_BLOCK: usize = TETRA_CODED_BITS_PER_FRAME * 2;
+const TETRA_TMD_PACKED_BYTES: usize = (TETRA_TMD_BITS_PER_BLOCK + 7) / 8;
+
+#[repr(C)]
+struct RawTetraCodec {
+    _private: [u8; 0],
+}
+
+#[link(name = "tetra-codec")]
+unsafe extern "C" {
+    fn tetra_encoder_create() -> *mut RawTetraCodec;
+    fn tetra_decoder_create() -> *mut RawTetraCodec;
+    fn tetra_codec_destroy(st: *mut RawTetraCodec);
+    fn tetra_encode(st: *mut RawTetraCodec, pcm: *const i16, coded: *mut u8);
+    fn tetra_decode(st: *mut RawTetraCodec, coded: *const u8, pcm: *mut i16, bfi: i32);
+}
+
+struct CodecHandle {
+    ptr: NonNull<RawTetraCodec>,
+}
+
+// The codec state is owned by one SIP dialog and accessed only through &mut self on the
+// entity thread. Moving that owner between threads is safe; sharing it concurrently is not.
+unsafe impl Send for CodecHandle {}
+
+impl CodecHandle {
+    fn from_raw(ptr: *mut RawTetraCodec) -> Option<Self> {
+        NonNull::new(ptr).map(|ptr| Self { ptr })
+    }
+}
+
+impl Drop for CodecHandle {
+    fn drop(&mut self) {
+        unsafe {
+            tetra_codec_destroy(self.ptr.as_ptr());
+        }
+    }
+}
+
+pub(crate) struct AsteriskAudioTranscoder {
+    encoder: CodecHandle,
+    decoder: CodecHandle,
+    downlink_pcm: Vec<i16>,
+}
+
+impl AsteriskAudioTranscoder {
+    pub(crate) fn new() -> Option<Self> {
+        let encoder = CodecHandle::from_raw(unsafe { tetra_encoder_create() })?;
+        let decoder = CodecHandle::from_raw(unsafe { tetra_decoder_create() })?;
+        Some(Self {
+            encoder,
+            decoder,
+            downlink_pcm: Vec::with_capacity(TETRA_PCM_SAMPLES_PER_BLOCK * 2),
+        })
+    }
+
+    pub(crate) fn decode_tmd_to_pcmu(&mut self, acelp: &[u8]) -> Option<Vec<u8>> {
+        let coded = split_tmd_block_to_codec_frames(acelp)?;
+        let mut out = Vec::with_capacity(TETRA_PCM_SAMPLES_PER_BLOCK);
+
+        for frame in &coded {
+            let mut pcm = [0i16; TETRA_PCM_SAMPLES_PER_FRAME];
+            unsafe {
+                tetra_decode(self.decoder.ptr.as_ptr(), frame.as_ptr(), pcm.as_mut_ptr(), 0);
+            }
+            out.extend(pcm.into_iter().map(linear_to_ulaw));
+        }
+
+        Some(out)
+    }
+
+    pub(crate) fn encode_pcmu_to_tmd(&mut self, payload: &[u8]) -> Vec<Vec<u8>> {
+        self.downlink_pcm.extend(payload.iter().map(|&sample| ulaw_to_linear(sample)));
+
+        let mut out = Vec::new();
+        while self.downlink_pcm.len() >= TETRA_PCM_SAMPLES_PER_BLOCK {
+            let mut pcm_a = [0i16; TETRA_PCM_SAMPLES_PER_FRAME];
+            let mut pcm_b = [0i16; TETRA_PCM_SAMPLES_PER_FRAME];
+            pcm_a.copy_from_slice(&self.downlink_pcm[..TETRA_PCM_SAMPLES_PER_FRAME]);
+            pcm_b.copy_from_slice(
+                &self.downlink_pcm[TETRA_PCM_SAMPLES_PER_FRAME..TETRA_PCM_SAMPLES_PER_BLOCK],
+            );
+            self.downlink_pcm.drain(..TETRA_PCM_SAMPLES_PER_BLOCK);
+
+            let mut coded_a = [0u8; TETRA_CODED_BYTES_PER_FRAME];
+            let mut coded_b = [0u8; TETRA_CODED_BYTES_PER_FRAME];
+            unsafe {
+                tetra_encode(self.encoder.ptr.as_ptr(), pcm_a.as_ptr(), coded_a.as_mut_ptr());
+                tetra_encode(self.encoder.ptr.as_ptr(), pcm_b.as_ptr(), coded_b.as_mut_ptr());
+            }
+            out.push(join_codec_frames_to_tmd_block(&coded_a, &coded_b));
+        }
+
+        out
+    }
+}
+
+pub(crate) fn rtp_payload(packet: &[u8]) -> Option<(u8, &[u8])> {
+    if packet.len() < 12 || packet[0] >> 6 != 2 {
+        return None;
+    }
+
+    let has_padding = packet[0] & 0x20 != 0;
+    let has_extension = packet[0] & 0x10 != 0;
+    let csrc_count = (packet[0] & 0x0f) as usize;
+    let payload_type = packet[1] & 0x7f;
+
+    let mut end = packet.len();
+    if has_padding {
+        let padding = *packet.last()? as usize;
+        if padding == 0 || padding > end {
+            return None;
+        }
+        end -= padding;
+    }
+
+    let mut offset = 12 + csrc_count * 4;
+    if offset > end {
+        return None;
+    }
+
+    if has_extension {
+        if offset + 4 > end {
+            return None;
+        }
+        let extension_words = u16::from_be_bytes([packet[offset + 2], packet[offset + 3]]) as usize;
+        offset += 4 + extension_words * 4;
+        if offset > end {
+            return None;
+        }
+    }
+
+    Some((payload_type, &packet[offset..end]))
+}
+
+fn split_tmd_block_to_codec_frames(data: &[u8]) -> Option<[[u8; TETRA_CODED_BYTES_PER_FRAME]; 2]> {
+    let packed = if data.len() == TETRA_TMD_PACKED_BYTES + 1 {
+        Some(&data[1..])
+    } else if data.len() == TETRA_TMD_PACKED_BYTES {
+        Some(data)
+    } else {
+        None
+    };
+
+    let mut frames = [[0u8; TETRA_CODED_BYTES_PER_FRAME]; 2];
+    if let Some(packed) = packed {
+        for bit_idx in 0..TETRA_TMD_BITS_PER_BLOCK {
+            let bit = get_packed_bit(packed, bit_idx);
+            set_packed_bit(
+                &mut frames[bit_idx / TETRA_CODED_BITS_PER_FRAME],
+                bit_idx % TETRA_CODED_BITS_PER_FRAME,
+                bit,
+            );
+        }
+        return Some(frames);
+    }
+
+    if data.len() < TETRA_TMD_BITS_PER_BLOCK {
+        return None;
+    }
+    for bit_idx in 0..TETRA_TMD_BITS_PER_BLOCK {
+        set_packed_bit(
+            &mut frames[bit_idx / TETRA_CODED_BITS_PER_FRAME],
+            bit_idx % TETRA_CODED_BITS_PER_FRAME,
+            data[bit_idx] & 1,
+        );
+    }
+    Some(frames)
+}
+
+fn join_codec_frames_to_tmd_block(
+    frame_a: &[u8; TETRA_CODED_BYTES_PER_FRAME],
+    frame_b: &[u8; TETRA_CODED_BYTES_PER_FRAME],
+) -> Vec<u8> {
+    let mut out = vec![0u8; TETRA_TMD_PACKED_BYTES];
+    for bit_idx in 0..TETRA_TMD_BITS_PER_BLOCK {
+        let frame = if bit_idx < TETRA_CODED_BITS_PER_FRAME {
+            frame_a
+        } else {
+            frame_b
+        };
+        let frame_bit = bit_idx % TETRA_CODED_BITS_PER_FRAME;
+        set_packed_bit(&mut out, bit_idx, get_packed_bit(frame, frame_bit));
+    }
+    out
+}
+
+fn get_packed_bit(data: &[u8], bit_idx: usize) -> u8 {
+    (data[bit_idx / 8] >> (7 - (bit_idx % 8))) & 1
+}
+
+fn set_packed_bit(data: &mut [u8], bit_idx: usize, bit: u8) {
+    if bit & 1 != 0 {
+        data[bit_idx / 8] |= 1 << (7 - (bit_idx % 8));
+    }
+}
+
+fn ulaw_to_linear(sample: u8) -> i16 {
+    const BIAS: i16 = 0x84;
+
+    let sample = !sample;
+    let mantissa = (sample & 0x0f) as i16;
+    let exponent = ((sample & 0x70) >> 4) as u32;
+    let value = ((mantissa << 3) + BIAS) << exponent;
+
+    if sample & 0x80 != 0 {
+        BIAS - value
+    } else {
+        value - BIAS
+    }
+}
+
+fn linear_to_ulaw(sample: i16) -> u8 {
+    const BIAS: i32 = 0x84;
+    const CLIP: i32 = 32635;
+    const SEG_END: [i32; 8] = [0xff, 0x1ff, 0x3ff, 0x7ff, 0xfff, 0x1fff, 0x3fff, 0x7fff];
+
+    let mut pcm = sample as i32;
+    let mask = if pcm < 0 {
+        pcm = -pcm;
+        0x7f
+    } else {
+        0xff
+    };
+    pcm = pcm.min(CLIP) + BIAS;
+
+    let segment = SEG_END
+        .iter()
+        .position(|&end| pcm <= end)
+        .unwrap_or(SEG_END.len() - 1) as i32;
+    let ulaw = ((segment << 4) | ((pcm >> (segment + 3)) & 0x0f)) as u8;
+
+    ulaw ^ mask
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn packed_tmd_round_trip_keeps_274_bits() {
+        let mut bits = [0u8; TETRA_TMD_BITS_PER_BLOCK];
+        for (idx, bit) in bits.iter_mut().enumerate() {
+            *bit = (idx % 3 == 0) as u8;
+        }
+
+        let frames = split_tmd_block_to_codec_frames(&bits).unwrap();
+        let packed = join_codec_frames_to_tmd_block(&frames[0], &frames[1]);
+        assert_eq!(packed.len(), TETRA_TMD_PACKED_BYTES);
+
+        let frames_again = split_tmd_block_to_codec_frames(&packed).unwrap();
+        assert_eq!(frames, frames_again);
+    }
+
+    #[test]
+    fn rtp_payload_skips_extension_and_padding() {
+        let packet = [
+            0b1011_0000,
+            PCMU_PAYLOAD_TYPE,
+            0,
+            1,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            1,
+            0xab,
+            0xcd,
+            0,
+            1,
+            0xaa,
+            0xbb,
+            0xcc,
+            0xdd,
+            0x11,
+            0x22,
+            2,
+            2,
+        ];
+        let (pt, payload) = rtp_payload(&packet).unwrap();
+        assert_eq!(pt, PCMU_PAYLOAD_TYPE);
+        assert_eq!(payload, &[0x11, 0x22]);
+    }
+}

--- a/crates/tetra-entities/src/net_asterisk/entity.rs
+++ b/crates/tetra-entities/src/net_asterisk/entity.rs
@@ -1,0 +1,1430 @@
+use std::collections::HashMap;
+use std::io;
+use std::net::{IpAddr, SocketAddr, ToSocketAddrs, UdpSocket};
+use std::time::{Duration, Instant};
+
+use tetra_config::bluestation::{AsteriskRuntimeStatus, CfgAsterisk, SharedConfig};
+use tetra_core::{Sap, TdmaTime, tetra_entities::TetraEntity};
+use tetra_pdus::cmce::enums::call_timeout::CallTimeout;
+use tetra_saps::{
+    SapMsg, SapMsgInner,
+    control::call_control::{CallControl, NetworkCircuitCall},
+    tmd::{TmdCircuitDataInd, TmdCircuitDataReq},
+};
+use uuid::Uuid;
+
+use crate::{MessageQueue, TetraEntityTrait};
+
+use super::audio::{AsteriskAudioTranscoder, PCMU_PAYLOAD_TYPE, rtp_payload};
+
+const SIP_MAX_DATAGRAM: usize = 8192;
+
+#[derive(Clone, Debug)]
+struct DigestChallenge {
+    realm: String,
+    nonce: String,
+    qop: Option<String>,
+    opaque: Option<String>,
+    algorithm: Option<String>,
+    proxy: bool,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum DialogState {
+    Inviting,
+    Ringing,
+    Established,
+    Released,
+}
+
+struct RtpSession {
+    socket: UdpSocket,
+    local_port: u16,
+    remote: Option<SocketAddr>,
+    seq: u16,
+    timestamp: u32,
+    ssrc: u32,
+}
+
+struct SipDialog {
+    uuid: Uuid,
+    call: NetworkCircuitCall,
+    number: String,
+    call_id_header: String,
+    local_uri: String,
+    local_tag: String,
+    remote_tag: Option<String>,
+    cseq: u32,
+    auth: Option<DigestChallenge>,
+    auth_retry_sent: bool,
+    state: DialogState,
+    rtp: RtpSession,
+    audio: AsteriskAudioTranscoder,
+    media_ready: Option<(u16, u8)>,
+    inbound: bool,
+    request_context: Option<SipRequestContext>,
+}
+
+#[derive(Debug)]
+struct SipMessage {
+    start_line: String,
+    headers: Vec<(String, String)>,
+    body: String,
+}
+
+impl SipMessage {
+    fn parse(bytes: &[u8]) -> Option<Self> {
+        let text = String::from_utf8_lossy(bytes).replace("\r\n", "\n");
+        let (head, body) = text.split_once("\n\n").unwrap_or((&text, ""));
+        let mut lines = head.lines();
+        let start_line = lines.next()?.trim().to_string();
+        let mut headers = Vec::new();
+        for line in lines {
+            let Some((name, value)) = line.split_once(':') else {
+                continue;
+            };
+            headers.push((name.trim().to_string(), value.trim().to_string()));
+        }
+        Some(Self {
+            start_line,
+            headers,
+            body: body.to_string(),
+        })
+    }
+
+    fn header(&self, name: &str) -> Option<&str> {
+        self.headers
+            .iter()
+            .find(|(n, _)| n.eq_ignore_ascii_case(name))
+            .map(|(_, v)| v.as_str())
+    }
+
+    fn status_code(&self) -> Option<u16> {
+        if !self.start_line.starts_with("SIP/2.0 ") {
+            return None;
+        }
+        self.start_line
+            .split_whitespace()
+            .nth(1)
+            .and_then(|code| code.parse().ok())
+    }
+
+    fn method(&self) -> Option<&str> {
+        if self.start_line.starts_with("SIP/2.0 ") {
+            None
+        } else {
+            self.start_line.split_whitespace().next()
+        }
+    }
+
+    fn request_uri(&self) -> Option<&str> {
+        if self.start_line.starts_with("SIP/2.0 ") {
+            None
+        } else {
+            self.start_line.split_whitespace().nth(1)
+        }
+    }
+
+    fn cseq_method(&self) -> Option<&str> {
+        self.header("CSeq")?.split_whitespace().nth(1)
+    }
+
+    fn call_id(&self) -> Option<&str> {
+        self.header("Call-ID")
+    }
+}
+
+#[derive(Clone)]
+struct SipRequestContext {
+    via: String,
+    from: String,
+    to: String,
+    call_id: String,
+    cseq: String,
+    addr: SocketAddr,
+}
+
+pub struct AsteriskEntity {
+    config: SharedConfig,
+    asterisk_config: CfgAsterisk,
+    sip_socket: UdpSocket,
+    remote: SocketAddr,
+    dialogs: HashMap<Uuid, SipDialog>,
+    rtp_by_ts: HashMap<u8, Uuid>,
+    next_rtp_port: u16,
+    branch_counter: u64,
+    register_call_id: String,
+    register_cseq: u32,
+    register_auth: Option<DigestChallenge>,
+    register_status: String,
+    last_register: Option<Instant>,
+    last_options: Option<Instant>,
+    last_rx: Option<String>,
+    last_tx: Option<String>,
+    last_error: Option<String>,
+}
+
+impl AsteriskEntity {
+    pub fn new(config: SharedConfig) -> io::Result<Self> {
+        let asterisk_config = config.config().asterisk.clone();
+        let bind = format!("{}:{}", asterisk_config.bind_addr, asterisk_config.bind_port);
+        let sip_socket = UdpSocket::bind(bind)?;
+        sip_socket.set_nonblocking(true)?;
+
+        let remote = (asterisk_config.remote_host.as_str(), asterisk_config.remote_port)
+            .to_socket_addrs()?
+            .next()
+            .ok_or_else(|| io::Error::new(io::ErrorKind::AddrNotAvailable, "asterisk remote address did not resolve"))?;
+
+        let entity = Self {
+            config,
+            next_rtp_port: asterisk_config.rtp_port_min,
+            register_call_id: format!("flow-reg-{}@{}", Uuid::new_v4(), asterisk_config.contact_host),
+            asterisk_config,
+            sip_socket,
+            remote,
+            dialogs: HashMap::new(),
+            rtp_by_ts: HashMap::new(),
+            branch_counter: 1,
+            register_cseq: 1,
+            register_auth: None,
+            register_status: "not registered".to_string(),
+            last_register: None,
+            last_options: None,
+            last_rx: None,
+            last_tx: None,
+            last_error: None,
+        };
+        entity.refresh_status();
+        Ok(entity)
+    }
+
+    fn sip_listen(&self) -> String {
+        format!("{}:{}", self.asterisk_config.bind_addr, self.asterisk_config.bind_port)
+    }
+
+    fn remote_display(&self) -> String {
+        format!("{}:{}", self.asterisk_config.remote_host, self.asterisk_config.remote_port)
+    }
+
+    fn rtp_range(&self) -> String {
+        format!("{}-{}", self.asterisk_config.rtp_port_min, self.asterisk_config.rtp_port_max)
+    }
+
+    fn refresh_status(&self) {
+        let mut state = self.config.state_write();
+        state.asterisk_status = AsteriskRuntimeStatus {
+            configured: true,
+            enabled: self.asterisk_config.enabled,
+            register_status: self.register_status.clone(),
+            sip_listen: self.sip_listen(),
+            remote: self.remote_display(),
+            rtp_port_range: self.rtp_range(),
+            codec: self.asterisk_config.codec.clone(),
+            active_dialogs: self
+                .dialogs
+                .values()
+                .filter(|d| d.state != DialogState::Released)
+                .count(),
+            last_rx: self.last_rx.clone(),
+            last_tx: self.last_tx.clone(),
+            last_error: self.last_error.clone(),
+        };
+    }
+
+    fn set_error(&mut self, msg: impl Into<String>) {
+        let msg = msg.into();
+        tracing::warn!("AsteriskEntity: {}", msg);
+        self.last_error = Some(msg);
+    }
+
+    fn next_branch(&mut self) -> String {
+        let branch = format!("z9hG4bKflow{:08x}", self.branch_counter);
+        self.branch_counter = self.branch_counter.wrapping_add(1);
+        branch
+    }
+
+    fn local_uri(&self) -> String {
+        format!("sip:{}@{}", self.asterisk_config.local_user, self.asterisk_config.from_domain)
+    }
+
+    fn uri_for_user(&self, user: &str) -> String {
+        format!("sip:{}@{}", user, self.asterisk_config.from_domain)
+    }
+
+    fn asserted_identity_headers(&self, uri: &str, display: &str) -> String {
+        if display.is_empty() {
+            return String::new();
+        }
+        format!(
+            "P-Asserted-Identity: \"{}\" <{}>\r\nRemote-Party-ID: \"{}\" <{}>;party=calling;screen=yes;privacy=off\r\n",
+            display, uri, display, uri
+        )
+    }
+
+    fn contact_uri(&self) -> String {
+        format!(
+            "sip:{}@{}:{}",
+            self.asterisk_config.local_user, self.asterisk_config.contact_host, self.asterisk_config.bind_port
+        )
+    }
+
+    fn request_uri(&self, number: &str) -> String {
+        format!("sip:{}@{}", number, self.asterisk_config.remote_host)
+    }
+
+    fn send_sip(&mut self, payload: String, summary: impl Into<String>) {
+        let summary = summary.into();
+        match self.sip_socket.send_to(payload.as_bytes(), self.remote) {
+            Ok(_) => {
+                self.last_tx = Some(summary);
+            }
+            Err(err) => {
+                self.set_error(format!("SIP send failed: {}", err));
+            }
+        }
+    }
+
+    fn send_sip_to(&mut self, payload: String, addr: SocketAddr, summary: impl Into<String>) {
+        let summary = summary.into();
+        match self.sip_socket.send_to(payload.as_bytes(), addr) {
+            Ok(_) => {
+                self.last_tx = Some(summary);
+            }
+            Err(err) => {
+                self.set_error(format!("SIP send failed: {}", err));
+            }
+        }
+    }
+
+    fn send_register(&mut self) {
+        if !self.asterisk_config.register {
+            self.register_status = "disabled".to_string();
+            return;
+        }
+
+        let uri = format!("sip:{}", self.asterisk_config.remote_host);
+        let branch = self.next_branch();
+        let cseq = self.register_cseq;
+        self.register_cseq = self.register_cseq.saturating_add(1);
+        let auth = self
+            .register_auth
+            .as_ref()
+            .map(|challenge| self.authorization_header("REGISTER", &uri, challenge));
+        let auth_line = auth.map(|line| format!("{}\r\n", line)).unwrap_or_default();
+        let request = format!(
+            "REGISTER {} SIP/2.0\r\n\
+             Via: SIP/2.0/UDP {}:{};branch={};rport\r\n\
+             Max-Forwards: 70\r\n\
+             From: <{}>;tag=flowreg\r\n\
+             To: <{}>\r\n\
+             Call-ID: {}\r\n\
+             CSeq: {} REGISTER\r\n\
+             Contact: <{}>\r\n\
+             Expires: 120\r\n\
+             {}\
+             User-Agent: FlowStation\r\n\
+             Content-Length: 0\r\n\r\n",
+            uri,
+            self.asterisk_config.contact_host,
+            self.asterisk_config.bind_port,
+            branch,
+            self.local_uri(),
+            self.local_uri(),
+            self.register_call_id,
+            cseq,
+            self.contact_uri(),
+            auth_line
+        );
+        self.register_status = "registering".to_string();
+        self.last_register = Some(Instant::now());
+        self.send_sip(request, "REGISTER");
+    }
+
+    fn send_options(&mut self) {
+        let uri = format!("sip:{}", self.asterisk_config.remote_host);
+        let branch = self.next_branch();
+        let request = format!(
+            "OPTIONS {} SIP/2.0\r\n\
+             Via: SIP/2.0/UDP {}:{};branch={};rport\r\n\
+             Max-Forwards: 70\r\n\
+             From: <{}>;tag=flowopt\r\n\
+             To: <{}>\r\n\
+             Call-ID: flow-options-{}@{}\r\n\
+             CSeq: 1 OPTIONS\r\n\
+             Contact: <{}>\r\n\
+             Accept: application/sdp\r\n\
+             Content-Length: 0\r\n\r\n",
+            uri,
+            self.asterisk_config.contact_host,
+            self.asterisk_config.bind_port,
+            branch,
+            self.local_uri(),
+            uri,
+            Uuid::new_v4(),
+            self.asterisk_config.contact_host,
+            self.contact_uri()
+        );
+        self.last_options = Some(Instant::now());
+        self.send_sip(request, "OPTIONS");
+    }
+
+    fn build_sdp(&self, rtp_port: u16) -> String {
+        format!(
+            "v=0\r\n\
+             o=flowstation 0 0 IN IP4 {}\r\n\
+             s=FlowStation\r\n\
+             c=IN IP4 {}\r\n\
+             t=0 0\r\n\
+             m=audio {} RTP/AVP 0\r\n\
+             a=rtpmap:0 PCMU/8000\r\n\
+             a=ptime:60\r\n\
+             a=maxptime:60\r\n\
+             a=sendrecv\r\n",
+            self.asterisk_config.contact_host, self.asterisk_config.contact_host, rtp_port
+        )
+    }
+
+    fn build_invite(&mut self, uuid: Uuid) -> Option<String> {
+        let snapshot = self.dialogs.get(&uuid).map(SipDialogSnapshot::from_dialog)?;
+        let (rtp_port, auth) = self
+            .dialogs
+            .get(&uuid)
+            .map(|dialog| (dialog.rtp.local_port, dialog.auth.clone()))?;
+        let request_uri = self.request_uri(&snapshot.number);
+        let branch = self.next_branch();
+        let body = self.build_sdp(rtp_port);
+        let auth = auth
+            .as_ref()
+            .map(|challenge| self.authorization_header("INVITE", &request_uri, challenge));
+        let auth_line = auth.map(|line| format!("{}\r\n", line)).unwrap_or_default();
+        let to_uri = request_uri.clone();
+        let from_uri = snapshot.local_uri.clone();
+        let caller_id = snapshot
+            .source_issi
+            .filter(|source| *source != 0)
+            .map(|source| source.to_string())
+            .unwrap_or_else(|| self.asterisk_config.local_user.clone());
+        let identity_uri = snapshot
+            .source_issi
+            .filter(|source| *source != 0)
+            .map(|source| self.uri_for_user(&source.to_string()))
+            .unwrap_or_else(|| from_uri.clone());
+        let identity_headers = self.asserted_identity_headers(&identity_uri, &caller_id);
+        Some(format!(
+            "INVITE {} SIP/2.0\r\n\
+             Via: SIP/2.0/UDP {}:{};branch={};rport\r\n\
+             Max-Forwards: 70\r\n\
+             From: \"{}\" <{}>;tag={}\r\n\
+             To: <{}>\r\n\
+             Call-ID: {}\r\n\
+             CSeq: {} INVITE\r\n\
+             Contact: <{}>\r\n\
+             Allow: INVITE, ACK, CANCEL, OPTIONS, BYE, INFO\r\n\
+             Supported: replaces\r\n\
+             {}\
+             {}\
+             Content-Type: application/sdp\r\n\
+             Content-Length: {}\r\n\r\n{}",
+            request_uri,
+            self.asterisk_config.contact_host,
+            self.asterisk_config.bind_port,
+            branch,
+            caller_id,
+            from_uri,
+            snapshot.local_tag,
+            to_uri,
+            snapshot.call_id_header,
+            snapshot.cseq,
+            self.contact_uri(),
+            identity_headers,
+            auth_line,
+            body.as_bytes().len(),
+            body
+        ))
+    }
+
+    fn send_invite(&mut self, uuid: Uuid) {
+        if let Some(request) = self.build_invite(uuid) {
+            self.send_sip(request, format!("INVITE {}", uuid));
+        }
+    }
+
+    fn send_bye_or_cancel(&mut self, uuid: Uuid, cancel: bool) {
+        let Some(dialog) = self.dialogs.get(&uuid).map(SipDialogSnapshot::from_dialog) else {
+            return;
+        };
+        let method = if cancel { "CANCEL" } else { "BYE" };
+        let request_uri = self.request_uri(&dialog.number);
+        let branch = self.next_branch();
+        let to = if let Some(tag) = &dialog.remote_tag {
+            format!("<{}>;tag={}", request_uri, tag)
+        } else {
+            format!("<{}>", request_uri)
+        };
+        let cseq = if cancel { dialog.cseq } else { dialog.cseq.saturating_add(1) };
+        let request = format!(
+            "{} {} SIP/2.0\r\n\
+             Via: SIP/2.0/UDP {}:{};branch={};rport\r\n\
+             Max-Forwards: 70\r\n\
+             From: <{}>;tag={}\r\n\
+             To: {}\r\n\
+             Call-ID: {}\r\n\
+             CSeq: {} {}\r\n\
+             Contact: <{}>\r\n\
+             Content-Length: 0\r\n\r\n",
+            method,
+            request_uri,
+            self.asterisk_config.contact_host,
+            self.asterisk_config.bind_port,
+            branch,
+            dialog.local_uri,
+            dialog.local_tag,
+            to,
+            dialog.call_id_header,
+            cseq,
+            method,
+            self.contact_uri()
+        );
+        self.send_sip(request, format!("{} {}", method, uuid));
+    }
+
+    fn tagged_to(to: &str, tag: Option<&str>) -> String {
+        let mut to = to.to_string();
+        if let Some(tag) = tag
+            && !to.to_ascii_lowercase().contains(";tag=")
+        {
+            to.push_str(";tag=");
+            to.push_str(tag);
+        }
+        to
+    }
+
+    fn build_response(
+        &self,
+        ctx: &SipRequestContext,
+        code: u16,
+        reason: &str,
+        to_tag: Option<&str>,
+        body: Option<(&str, &str)>,
+    ) -> String {
+        let to = Self::tagged_to(&ctx.to, to_tag);
+        let (content_type, body_text) = body.unwrap_or(("", ""));
+        let content_type_line = if content_type.is_empty() {
+            String::new()
+        } else {
+            format!("Content-Type: {}\r\n", content_type)
+        };
+        let contact_line = if code >= 180 {
+            format!(
+                "Contact: <{}>\r\nAllow: INVITE, ACK, CANCEL, OPTIONS, BYE, INFO\r\n",
+                self.contact_uri()
+            )
+        } else {
+            String::new()
+        };
+        format!(
+            "SIP/2.0 {} {}\r\n\
+             Via: {}\r\n\
+             From: {}\r\n\
+             To: {}\r\n\
+             Call-ID: {}\r\n\
+             CSeq: {}\r\n\
+             {}\
+             {}\
+             Content-Length: {}\r\n\r\n{}",
+            code,
+            reason,
+            ctx.via,
+            ctx.from,
+            to,
+            ctx.call_id,
+            ctx.cseq,
+            contact_line,
+            content_type_line,
+            body_text.as_bytes().len(),
+            body_text
+        )
+    }
+
+    fn request_context(msg: &SipMessage, addr: SocketAddr) -> Option<SipRequestContext> {
+        Some(SipRequestContext {
+            via: msg.header("Via")?.to_string(),
+            from: msg.header("From")?.to_string(),
+            to: msg.header("To")?.to_string(),
+            call_id: msg.header("Call-ID")?.to_string(),
+            cseq: msg.header("CSeq")?.to_string(),
+            addr,
+        })
+    }
+
+    fn answer_request(&mut self, msg: &SipMessage, addr: SocketAddr, code: u16, reason: &str) {
+        let Some(ctx) = Self::request_context(msg, addr) else {
+            return;
+        };
+        let tag = (code != 100).then_some("flowstation");
+        let response = self.build_response(&ctx, code, reason, tag, None);
+        self.send_sip_to(response, addr, format!("{} {}", code, reason));
+    }
+
+    fn send_invite_response(&mut self, uuid: Uuid, code: u16, reason: &str, body: Option<String>) {
+        let Some((ctx, tag)) = self
+            .dialogs
+            .get(&uuid)
+            .and_then(|dialog| dialog.request_context.clone().map(|ctx| (ctx, dialog.local_tag.clone())))
+        else {
+            return;
+        };
+        let body_ref = body.as_deref().map(|b| ("application/sdp", b));
+        let response = self.build_response(&ctx, code, reason, Some(&tag), body_ref);
+        self.send_sip_to(response, ctx.addr, format!("{} {} {}", code, reason, uuid));
+    }
+
+    fn authorization_header(&self, method: &str, uri: &str, challenge: &DigestChallenge) -> String {
+        let username = &self.asterisk_config.auth_user;
+        let password = self.asterisk_config.password.as_ref();
+        let realm = if challenge.realm.is_empty() {
+            &self.asterisk_config.realm
+        } else {
+            &challenge.realm
+        };
+        let ha1 = format!("{:x}", md5::compute(format!("{}:{}:{}", username, realm, password)));
+        let ha2 = format!("{:x}", md5::compute(format!("{}:{}", method, uri)));
+        let cnonce = format!("{:x}", md5::compute(Uuid::new_v4().as_bytes()));
+        let nc = "00000001";
+        let response = if let Some(qop) = challenge.qop.as_deref() {
+            let qop_token = qop.split(',').map(str::trim).find(|v| *v == "auth").unwrap_or(qop);
+            format!(
+                "{:x}",
+                md5::compute(format!("{}:{}:{}:{}:{}:{}", ha1, challenge.nonce, nc, cnonce, qop_token, ha2))
+            )
+        } else {
+            format!("{:x}", md5::compute(format!("{}:{}:{}", ha1, challenge.nonce, ha2)))
+        };
+        let header_name = if challenge.proxy {
+            "Proxy-Authorization"
+        } else {
+            "Authorization"
+        };
+        let mut line = format!(
+            "{}: Digest username=\"{}\", realm=\"{}\", nonce=\"{}\", uri=\"{}\", response=\"{}\"",
+            header_name, username, realm, challenge.nonce, uri, response
+        );
+        if let Some(qop) = challenge.qop.as_deref() {
+            let qop_token = qop.split(',').map(str::trim).find(|v| *v == "auth").unwrap_or(qop);
+            line.push_str(&format!(", qop={}, nc={}, cnonce=\"{}\"", qop_token, nc, cnonce));
+        }
+        if let Some(opaque) = challenge.opaque.as_deref() {
+            line.push_str(&format!(", opaque=\"{}\"", opaque));
+        }
+        if let Some(algorithm) = challenge.algorithm.as_deref() {
+            line.push_str(&format!(", algorithm={}", algorithm));
+        }
+        line
+    }
+
+    fn parse_challenge(msg: &SipMessage) -> Option<DigestChallenge> {
+        let (header, proxy) = msg
+            .header("WWW-Authenticate")
+            .map(|h| (h, false))
+            .or_else(|| msg.header("Proxy-Authenticate").map(|h| (h, true)))?;
+        let mut value = header.trim();
+        if value.to_ascii_lowercase().starts_with("digest") {
+            value = value[6..].trim();
+        }
+        let mut params = HashMap::new();
+        for part in value.split(',') {
+            let Some((key, val)) = part.trim().split_once('=') else {
+                continue;
+            };
+            params.insert(key.trim().to_ascii_lowercase(), val.trim().trim_matches('"').to_string());
+        }
+        Some(DigestChallenge {
+            realm: params.remove("realm").unwrap_or_default(),
+            nonce: params.remove("nonce")?,
+            qop: params.remove("qop"),
+            opaque: params.remove("opaque"),
+            algorithm: params.remove("algorithm"),
+            proxy,
+        })
+    }
+
+    fn parse_to_tag(header: Option<&str>) -> Option<String> {
+        header?.split(';').find_map(|part| {
+            let part = part.trim();
+            part.strip_prefix("tag=").map(|tag| tag.trim_matches('"').to_string())
+        })
+    }
+
+    fn sip_uri_user(value: &str) -> Option<String> {
+        let trimmed = value.trim();
+        let after_scheme = if let Some(idx) = trimmed.to_ascii_lowercase().find("sip:") {
+            &trimmed[idx + 4..]
+        } else {
+            trimmed
+        };
+        let user = after_scheme
+            .split(|c| matches!(c, '@' | ';' | '?' | '>'))
+            .next()?
+            .trim()
+            .trim_matches('"');
+        (!user.is_empty()).then(|| user.to_string())
+    }
+
+    fn inbound_destination_issi(&self, msg: &SipMessage) -> Option<u32> {
+        let prefix = self.asterisk_config.inbound_prefix.trim();
+        [msg.request_uri(), msg.header("To")]
+            .into_iter()
+            .flatten()
+            .filter_map(Self::sip_uri_user)
+            .find_map(|user| {
+                let digits = if !prefix.is_empty() {
+                    user.strip_prefix(prefix).unwrap_or(&user)
+                } else {
+                    user.as_str()
+                };
+                digits
+                    .chars()
+                    .all(|c| c.is_ascii_digit())
+                    .then(|| digits.parse::<u32>().ok())
+                    .flatten()
+            })
+    }
+
+    fn inbound_caller_number(msg: &SipMessage) -> String {
+        ["P-Asserted-Identity", "Remote-Party-ID", "From"]
+            .into_iter()
+            .filter_map(|header| msg.header(header))
+            .filter_map(Self::sip_uri_user)
+            .next()
+            .unwrap_or_else(|| "0".to_string())
+    }
+
+    fn parse_sdp_remote(&self, body: &str) -> Option<SocketAddr> {
+        let mut ip: Option<IpAddr> = None;
+        let mut port: Option<u16> = None;
+        for line in body.lines().map(str::trim) {
+            if let Some(rest) = line.strip_prefix("c=IN IP4 ") {
+                ip = rest.split_whitespace().next().and_then(|s| s.parse().ok());
+            }
+            if let Some(rest) = line.strip_prefix("m=audio ") {
+                port = rest.split_whitespace().next().and_then(|s| s.parse().ok());
+            }
+        }
+        Some(SocketAddr::new(ip.unwrap_or_else(|| self.remote.ip()), port?))
+    }
+
+    fn allocate_rtp(&mut self) -> io::Result<RtpSession> {
+        let min = self.asterisk_config.rtp_port_min;
+        let max = self.asterisk_config.rtp_port_max;
+        let mut port = self.next_rtp_port.max(min);
+        let attempts = max.saturating_sub(min).saturating_add(1);
+        for _ in 0..attempts {
+            if port > max {
+                port = min;
+            }
+            let bind = format!("{}:{}", self.asterisk_config.bind_addr, port);
+            match UdpSocket::bind(&bind) {
+                Ok(socket) => {
+                    socket.set_nonblocking(true)?;
+                    self.next_rtp_port = if port == max { min } else { port + 1 };
+                    let seed = md5::compute(Uuid::new_v4().as_bytes()).0;
+                    let ssrc = u32::from_be_bytes([seed[0], seed[1], seed[2], seed[3]]);
+                    return Ok(RtpSession {
+                        socket,
+                        local_port: port,
+                        remote: None,
+                        seq: 1,
+                        timestamp: 0,
+                        ssrc,
+                    });
+                }
+                Err(_) => {
+                    port = port.saturating_add(1);
+                }
+            }
+        }
+        Err(io::Error::new(io::ErrorKind::AddrNotAvailable, "no RTP port available"))
+    }
+
+    fn start_inbound_call(&mut self, queue: &mut MessageQueue, msg: &SipMessage, addr: SocketAddr) {
+        let Some(ctx) = Self::request_context(msg, addr) else {
+            return;
+        };
+        let Some(destination) = self.inbound_destination_issi(msg) else {
+            tracing::info!("AsteriskEntity: rejecting inbound INVITE without TETRA destination: {}", msg.start_line);
+            let response = self.build_response(&ctx, 404, "Not Found", Some("flowstation"), None);
+            self.send_sip_to(response, addr, "404 Not Found");
+            return;
+        };
+        if self.find_dialog_by_call_id(Some(ctx.call_id.as_str())).is_some() {
+            tracing::info!("AsteriskEntity: rejecting duplicate inbound INVITE call-id={}", ctx.call_id);
+            let response = self.build_response(&ctx, 486, "Busy Here", Some("flowstation"), None);
+            self.send_sip_to(response, addr, "486 Busy Here");
+            return;
+        }
+
+        let Some(remote_rtp) = self.parse_sdp_remote(&msg.body) else {
+            tracing::info!("AsteriskEntity: rejecting inbound INVITE to {} without usable SDP", destination);
+            let response = self.build_response(&ctx, 488, "Not Acceptable Here", Some("flowstation"), None);
+            self.send_sip_to(response, addr, "488 Not Acceptable Here");
+            return;
+        };
+
+        let mut rtp = match self.allocate_rtp() {
+            Ok(rtp) => rtp,
+            Err(err) => {
+                self.set_error(format!("RTP allocation failed for inbound INVITE to {}: {}", destination, err));
+                let response = self.build_response(&ctx, 503, "Service Unavailable", Some("flowstation"), None);
+                self.send_sip_to(response, addr, "503 Service Unavailable");
+                return;
+            }
+        };
+        rtp.remote = Some(remote_rtp);
+        let Some(audio) = AsteriskAudioTranscoder::new() else {
+            self.set_error("TETRA codec allocation failed for inbound Asterisk call".to_string());
+            let response = self.build_response(&ctx, 503, "Service Unavailable", Some("flowstation"), None);
+            self.send_sip_to(response, addr, "503 Service Unavailable");
+            return;
+        };
+
+        let uuid = Uuid::new_v4();
+        let caller_number = Self::inbound_caller_number(msg);
+        let call = NetworkCircuitCall {
+            source_issi: 0,
+            destination,
+            number: caller_number.clone(),
+            priority: 0,
+            service: 0,
+            mode: 0,
+            duplex: 1,
+            method: 0,
+            communication: 0,
+            grant: 0,
+            permission: 0,
+            timeout: CallTimeout::Infinite.into_raw() as u8,
+            ownership: 0,
+            queued: 0,
+        };
+        let local_tag = format!("flow{}", &uuid.to_string()[..8]);
+        let remote_tag = Self::parse_to_tag(msg.header("From"));
+        let dialog = SipDialog {
+            uuid,
+            call: call.clone(),
+            number: caller_number,
+            call_id_header: ctx.call_id.clone(),
+            local_uri: self.local_uri(),
+            local_tag,
+            remote_tag,
+            cseq: 1,
+            auth: None,
+            auth_retry_sent: false,
+            state: DialogState::Inviting,
+            rtp,
+            audio,
+            media_ready: None,
+            inbound: true,
+            request_context: Some(ctx.clone()),
+        };
+        self.dialogs.insert(uuid, dialog);
+
+        let response = self.build_response(&ctx, 100, "Trying", None, None);
+        self.send_sip_to(response, addr, format!("100 Trying {}", uuid));
+        tracing::info!(
+            "AsteriskEntity: inbound INVITE uuid={} caller='{}' -> ISSI {}",
+            uuid,
+            Self::inbound_caller_number(msg),
+            destination
+        );
+        queue.push_back(SapMsg {
+            sap: Sap::Control,
+            src: TetraEntity::Asterisk,
+            dest: TetraEntity::Cmce,
+            msg: SapMsgInner::CmceCallControl(CallControl::NetworkCircuitSetupRequest {
+                brew_uuid: uuid,
+                call,
+            }),
+        });
+    }
+
+    fn handle_inbound_setup_accept(&mut self, uuid: Uuid) {
+        if self.dialogs.get(&uuid).is_some_and(|dialog| dialog.inbound) {
+            tracing::info!("AsteriskEntity: inbound setup accepted by CMCE uuid={}", uuid);
+        }
+    }
+
+    fn handle_inbound_setup_reject(&mut self, uuid: Uuid, cause: u8) {
+        let Some(inbound) = self.dialogs.get(&uuid).map(|dialog| dialog.inbound) else {
+            return;
+        };
+        if !inbound {
+            return;
+        }
+        let (code, reason) = match cause {
+            2 => (486, "Busy Here"),
+            3 => (404, "Not Found"),
+            5 => (503, "Service Unavailable"),
+            _ => (480, "Temporarily Unavailable"),
+        };
+        tracing::info!(
+            "AsteriskEntity: inbound setup rejected by CMCE uuid={} cause={} -> SIP {} {}",
+            uuid,
+            cause,
+            code,
+            reason
+        );
+        self.send_invite_response(uuid, code, reason, None);
+        self.release_dialog(uuid, false);
+    }
+
+    fn handle_inbound_alert(&mut self, uuid: Uuid) {
+        let Some(dialog) = self.dialogs.get_mut(&uuid) else {
+            return;
+        };
+        if !dialog.inbound {
+            return;
+        }
+        dialog.state = DialogState::Ringing;
+        tracing::info!("AsteriskEntity: inbound call ringing uuid={}", uuid);
+        self.send_invite_response(uuid, 180, "Ringing", None);
+    }
+
+    fn handle_inbound_connect_request(&mut self, queue: &mut MessageQueue, uuid: Uuid, call: NetworkCircuitCall) {
+        let Some((inbound, rtp_port)) = self
+            .dialogs
+            .get(&uuid)
+            .map(|dialog| (dialog.inbound, dialog.rtp.local_port))
+        else {
+            return;
+        };
+        if !inbound {
+            return;
+        }
+
+        let body = self.build_sdp(rtp_port);
+        if let Some(dialog) = self.dialogs.get_mut(&uuid) {
+            dialog.call = call;
+            dialog.state = DialogState::Established;
+        }
+        tracing::info!("AsteriskEntity: inbound call answered uuid={} -> SIP 200 OK", uuid);
+        self.send_invite_response(uuid, 200, "OK", Some(body));
+        queue.push_back(SapMsg {
+            sap: Sap::Control,
+            src: TetraEntity::Asterisk,
+            dest: TetraEntity::Cmce,
+            msg: SapMsgInner::CmceCallControl(CallControl::NetworkCircuitConnectConfirm {
+                brew_uuid: uuid,
+                grant: 0,
+                permission: 0,
+            }),
+        });
+    }
+
+    fn start_outbound_call(&mut self, queue: &mut MessageQueue, brew_uuid: Uuid, call: NetworkCircuitCall) {
+        let number = call.number.trim().to_string();
+        if number.is_empty() {
+            self.set_error(format!("empty Asterisk destination for uuid={}", brew_uuid));
+            self.reject_setup(queue, brew_uuid, 34);
+            return;
+        }
+        let rtp = match self.allocate_rtp() {
+            Ok(rtp) => rtp,
+            Err(err) => {
+                self.set_error(format!("RTP allocation failed for uuid={}: {}", brew_uuid, err));
+                self.reject_setup(queue, brew_uuid, 34);
+                return;
+            }
+        };
+        let Some(audio) = AsteriskAudioTranscoder::new() else {
+            self.set_error(format!("TETRA codec allocation failed for uuid={}", brew_uuid));
+            self.reject_setup(queue, brew_uuid, 34);
+            return;
+        };
+
+        let dialog = SipDialog {
+            uuid: brew_uuid,
+            local_uri: self.local_uri(),
+            call,
+            number,
+            call_id_header: format!("flow-{}@{}", brew_uuid, self.asterisk_config.contact_host),
+            local_tag: format!("flow{}", &brew_uuid.to_string()[..8]),
+            remote_tag: None,
+            cseq: 1,
+            auth: None,
+            auth_retry_sent: false,
+            state: DialogState::Inviting,
+            rtp,
+            audio,
+            media_ready: None,
+            inbound: false,
+            request_context: None,
+        };
+        self.dialogs.insert(brew_uuid, dialog);
+        self.send_setup_accept(queue, brew_uuid);
+        self.send_invite(brew_uuid);
+    }
+
+    fn reject_setup(&self, queue: &mut MessageQueue, brew_uuid: Uuid, cause: u8) {
+        queue.push_back(SapMsg {
+            sap: Sap::Control,
+            src: TetraEntity::Asterisk,
+            dest: TetraEntity::Cmce,
+            msg: SapMsgInner::CmceCallControl(CallControl::NetworkCircuitSetupReject { brew_uuid, cause }),
+        });
+    }
+
+    fn send_setup_accept(&self, queue: &mut MessageQueue, brew_uuid: Uuid) {
+        queue.push_back(SapMsg {
+            sap: Sap::Control,
+            src: TetraEntity::Asterisk,
+            dest: TetraEntity::Cmce,
+            msg: SapMsgInner::CmceCallControl(CallControl::NetworkCircuitSetupAccept { brew_uuid }),
+        });
+    }
+
+    fn send_alert(&self, queue: &mut MessageQueue, brew_uuid: Uuid) {
+        queue.push_back(SapMsg {
+            sap: Sap::Control,
+            src: TetraEntity::Asterisk,
+            dest: TetraEntity::Cmce,
+            msg: SapMsgInner::CmceCallControl(CallControl::NetworkCircuitAlert { brew_uuid }),
+        });
+    }
+
+    fn send_release_to_cmce(&self, queue: &mut MessageQueue, brew_uuid: Uuid, cause: u8) {
+        queue.push_back(SapMsg {
+            sap: Sap::Control,
+            src: TetraEntity::Asterisk,
+            dest: TetraEntity::Cmce,
+            msg: SapMsgInner::CmceCallControl(CallControl::NetworkCircuitRelease { brew_uuid, cause }),
+        });
+    }
+
+    fn mark_media_ready(&mut self, brew_uuid: Uuid, call_id: u16, ts: u8) {
+        if let Some(dialog) = self.dialogs.get_mut(&brew_uuid) {
+            dialog.media_ready = Some((call_id, ts));
+            self.rtp_by_ts.insert(ts, brew_uuid);
+            tracing::info!("AsteriskEntity: media ready uuid={} call_id={} ts={}", brew_uuid, call_id, ts);
+        }
+    }
+
+    fn release_dialog(&mut self, brew_uuid: Uuid, from_cmce: bool) {
+        let Some((cancel, media_ready, inbound)) = self
+            .dialogs
+            .get(&brew_uuid)
+            .map(|dialog| {
+                (
+                    !matches!(dialog.state, DialogState::Established),
+                    dialog.media_ready,
+                    dialog.inbound,
+                )
+            })
+        else {
+            return;
+        };
+        if from_cmce {
+            if inbound && cancel {
+                self.send_invite_response(brew_uuid, 480, "Temporarily Unavailable", None);
+            } else {
+                self.send_bye_or_cancel(brew_uuid, cancel);
+            }
+        }
+        if let Some((_, ts)) = media_ready {
+            self.rtp_by_ts.remove(&ts);
+        }
+        if let Some(dialog) = self.dialogs.get_mut(&brew_uuid) {
+            dialog.state = DialogState::Released;
+        }
+        self.dialogs.remove(&brew_uuid);
+    }
+
+    fn handle_ul_voice(&mut self, prim: TmdCircuitDataInd) {
+        let Some(uuid) = self.rtp_by_ts.get(&prim.ts).copied() else {
+            return;
+        };
+        let mut send_result = None;
+        let mut drop_reason = None;
+        'send: {
+            let Some(dialog) = self.dialogs.get_mut(&uuid) else {
+                return;
+            };
+            let Some(remote) = dialog.rtp.remote else {
+                return;
+            };
+            let Some(payload) = dialog.audio.decode_tmd_to_pcmu(&prim.data) else {
+                drop_reason = Some(format!(
+                    "AsteriskEntity: dropping unsupported TETRA audio block uuid={} ts={} len={}",
+                    uuid,
+                    prim.ts,
+                    prim.data.len()
+                ));
+                break 'send;
+            };
+
+            let mut packet = Vec::with_capacity(12 + payload.len());
+            packet.push(0x80);
+            packet.push(PCMU_PAYLOAD_TYPE);
+            packet.extend_from_slice(&dialog.rtp.seq.to_be_bytes());
+            packet.extend_from_slice(&dialog.rtp.timestamp.to_be_bytes());
+            packet.extend_from_slice(&dialog.rtp.ssrc.to_be_bytes());
+            packet.extend_from_slice(&payload);
+            let result = dialog.rtp.socket.send_to(&packet, remote);
+            if result.is_ok() {
+                dialog.rtp.seq = dialog.rtp.seq.wrapping_add(1);
+                dialog.rtp.timestamp = dialog.rtp.timestamp.wrapping_add(payload.len().max(1) as u32);
+            }
+            send_result = Some(result);
+        }
+        if let Some(reason) = drop_reason {
+            self.set_error(reason);
+            return;
+        }
+        if let Some(Err(err)) = send_result {
+            self.set_error(format!("RTP send failed uuid={} ts={}: {}", uuid, prim.ts, err));
+        };
+    }
+
+    fn poll_rtp(&mut self, queue: &mut MessageQueue) {
+        let mut downlink = Vec::new();
+        let mut last_error = None;
+        let mut buf = [0u8; 1720];
+        for dialog in self.dialogs.values_mut() {
+            let Some((_, ts)) = dialog.media_ready else {
+                continue;
+            };
+            for _ in 0..32 {
+                match dialog.rtp.socket.recv_from(&mut buf) {
+                    Ok((len, addr)) => {
+                        let Some((payload_type, payload)) = rtp_payload(&buf[..len]) else {
+                            continue;
+                        };
+                        if payload_type != PCMU_PAYLOAD_TYPE {
+                            tracing::trace!(
+                                "AsteriskEntity: dropping unsupported RTP payload type {} uuid={}",
+                                payload_type,
+                                dialog.uuid
+                            );
+                            continue;
+                        }
+                        dialog.rtp.remote = Some(addr);
+                        for frame in dialog.audio.encode_pcmu_to_tmd(payload) {
+                            downlink.push((ts, frame));
+                        }
+                    }
+                    Err(err) if err.kind() == io::ErrorKind::WouldBlock => break,
+                    Err(err) => {
+                        last_error = Some(format!("RTP receive failed uuid={}: {}", dialog.uuid, err));
+                        break;
+                    }
+                }
+            }
+        }
+        if last_error.is_some() {
+            self.last_error = last_error;
+        }
+
+        for (ts, data) in downlink {
+            queue.push_back(SapMsg {
+                sap: Sap::TmdSap,
+                src: TetraEntity::Asterisk,
+                dest: TetraEntity::Umac,
+                msg: SapMsgInner::TmdCircuitDataReq(TmdCircuitDataReq { ts, data }),
+            });
+        }
+    }
+
+    fn poll_sip(&mut self, queue: &mut MessageQueue) {
+        let mut buf = [0u8; SIP_MAX_DATAGRAM];
+        for _ in 0..32 {
+            match self.sip_socket.recv_from(&mut buf) {
+                Ok((len, addr)) => {
+                    if let Some(msg) = SipMessage::parse(&buf[..len]) {
+                        self.last_rx = Some(format!("{} from {}", msg.start_line, addr));
+                        self.handle_sip_message(queue, msg, addr);
+                    }
+                }
+                Err(err) if err.kind() == io::ErrorKind::WouldBlock => break,
+                Err(err) => {
+                    self.set_error(format!("SIP receive failed: {}", err));
+                    break;
+                }
+            }
+        }
+    }
+
+    fn handle_sip_message(&mut self, queue: &mut MessageQueue, msg: SipMessage, addr: SocketAddr) {
+        if let Some(method) = msg.method() {
+            match method {
+                "INVITE" => self.start_inbound_call(queue, &msg, addr),
+                "OPTIONS" => self.answer_request(&msg, addr, 200, "OK"),
+                "BYE" => {
+                    self.answer_request(&msg, addr, 200, "OK");
+                    if let Some(uuid) = self.find_dialog_by_call_id(msg.call_id()) {
+                        self.send_release_to_cmce(queue, uuid, 16);
+                        self.release_dialog(uuid, false);
+                    }
+                }
+                "CANCEL" => {
+                    self.answer_request(&msg, addr, 200, "OK");
+                    if let Some(uuid) = self.find_dialog_by_call_id(msg.call_id()) {
+                        self.send_release_to_cmce(queue, uuid, 16);
+                        self.release_dialog(uuid, false);
+                    }
+                }
+                "ACK" => {}
+                _ => self.answer_request(&msg, addr, 501, "Not Implemented"),
+            }
+            return;
+        }
+
+        let Some(code) = msg.status_code() else {
+            return;
+        };
+        match msg.cseq_method() {
+            Some("REGISTER") => self.handle_register_response(&msg, code),
+            Some("OPTIONS") => {
+                if (200..300).contains(&code) {
+                    self.last_rx = Some(format!("OPTIONS {} from {}", code, addr));
+                }
+            }
+            Some("INVITE") => self.handle_invite_response(queue, &msg, code),
+            Some("BYE") | Some("CANCEL") => {}
+            _ => {}
+        }
+    }
+
+    fn handle_register_response(&mut self, msg: &SipMessage, code: u16) {
+        match code {
+            200..=299 => {
+                self.register_status = "registered".to_string();
+            }
+            401 | 407 => {
+                if let Some(challenge) = Self::parse_challenge(msg) {
+                    self.register_auth = Some(challenge);
+                    self.register_status = "auth challenge".to_string();
+                    self.send_register();
+                }
+            }
+            _ => {
+                self.register_status = format!("failed {}", code);
+                self.last_error = Some(format!("REGISTER failed with SIP {}", code));
+            }
+        }
+    }
+
+    fn handle_invite_response(&mut self, queue: &mut MessageQueue, msg: &SipMessage, code: u16) {
+        let Some(uuid) = self.find_dialog_by_call_id(msg.call_id()) else {
+            return;
+        };
+
+        match code {
+            100 => {}
+            180 | 183 => {
+                if let Some(dialog) = self.dialogs.get_mut(&uuid) {
+                    dialog.state = DialogState::Ringing;
+                    dialog.remote_tag = Self::parse_to_tag(msg.header("To"));
+                }
+                self.send_alert(queue, uuid);
+            }
+            200..=299 => {
+                let remote_rtp = self.parse_sdp_remote(&msg.body);
+                let connect_call = {
+                    let Some(dialog) = self.dialogs.get_mut(&uuid) else {
+                        return;
+                    };
+                    dialog.remote_tag = Self::parse_to_tag(msg.header("To"));
+                    if let Some(remote_rtp) = remote_rtp {
+                        dialog.rtp.remote = Some(remote_rtp);
+                    }
+                    dialog.state = DialogState::Established;
+                    dialog.call.clone()
+                };
+                let ack_snapshot = self.dialogs.get(&uuid).map(SipDialogSnapshot::from_dialog);
+                if let Some(dialog_for_ack) = ack_snapshot {
+                    let ack_text = self.build_ack_from_snapshot(&dialog_for_ack);
+                    self.send_sip(ack_text, format!("ACK {}", uuid));
+                }
+                let connect_snapshot = self.dialogs.get(&uuid).map(SipDialogSnapshot::from_dialog);
+                if let Some(snapshot) = connect_snapshot {
+                    let mut call = connect_call;
+                    call.grant = 0;
+                    call.permission = 0;
+                    queue.push_back(SapMsg {
+                        sap: Sap::Control,
+                        src: TetraEntity::Asterisk,
+                        dest: TetraEntity::Cmce,
+                        msg: SapMsgInner::CmceCallControl(CallControl::NetworkCircuitConnectRequest {
+                            brew_uuid: snapshot.uuid,
+                            call,
+                        }),
+                    });
+                }
+            }
+            401 | 407 => {
+                if let Some(challenge) = Self::parse_challenge(msg) {
+                    let mut should_retry = false;
+                    if let Some(dialog) = self.dialogs.get_mut(&uuid)
+                        && !dialog.auth_retry_sent
+                    {
+                        dialog.auth = Some(challenge);
+                        dialog.auth_retry_sent = true;
+                        dialog.cseq = dialog.cseq.saturating_add(1);
+                        should_retry = true;
+                    }
+                    let ack_snapshot = self.dialogs.get(&uuid).map(SipDialogSnapshot::from_dialog);
+                    if let Some(snapshot) = ack_snapshot {
+                        let ack_text = self.build_ack_from_snapshot(&snapshot);
+                        self.send_sip(ack_text, format!("ACK auth {}", uuid));
+                    }
+                    if should_retry {
+                        self.send_invite(uuid);
+                    }
+                }
+            }
+            300..=699 => {
+                let ack_snapshot = self.dialogs.get(&uuid).map(SipDialogSnapshot::from_dialog);
+                if let Some(snapshot) = ack_snapshot {
+                    let ack_text = self.build_ack_from_snapshot(&snapshot);
+                    self.send_sip(ack_text, format!("ACK failure {}", uuid));
+                }
+                self.set_error(format!("INVITE uuid={} failed with SIP {}", uuid, code));
+                self.send_release_to_cmce(queue, uuid, 34);
+                self.release_dialog(uuid, false);
+            }
+            _ => {}
+        }
+    }
+
+    fn find_dialog_by_call_id(&self, call_id: Option<&str>) -> Option<Uuid> {
+        let call_id = call_id?;
+        self.dialogs
+            .iter()
+            .find(|(_, dialog)| dialog.call_id_header.eq_ignore_ascii_case(call_id))
+            .map(|(uuid, _)| *uuid)
+    }
+
+    fn maybe_periodic_sip(&mut self) {
+        let now = Instant::now();
+        if self.asterisk_config.register
+            && self
+                .last_register
+                .map(|last| now.duration_since(last) >= Duration::from_secs(60))
+                .unwrap_or(true)
+        {
+            self.send_register();
+        }
+
+        let interval = Duration::from_secs(self.asterisk_config.options_interval_secs.max(5));
+        if self.last_options.map(|last| now.duration_since(last) >= interval).unwrap_or(true) {
+            self.send_options();
+        }
+    }
+}
+
+#[derive(Clone)]
+struct SipDialogSnapshot {
+    uuid: Uuid,
+    number: String,
+    call_id_header: String,
+    local_uri: String,
+    source_issi: Option<u32>,
+    local_tag: String,
+    remote_tag: Option<String>,
+    cseq: u32,
+}
+
+impl SipDialogSnapshot {
+    fn from_dialog(dialog: &SipDialog) -> Self {
+        Self {
+            uuid: dialog.uuid,
+            number: dialog.number.clone(),
+            call_id_header: dialog.call_id_header.clone(),
+            local_uri: dialog.local_uri.clone(),
+            source_issi: Some(dialog.call.source_issi),
+            local_tag: dialog.local_tag.clone(),
+            remote_tag: dialog.remote_tag.clone(),
+            cseq: dialog.cseq,
+        }
+    }
+}
+
+impl AsteriskEntity {
+    fn build_ack_from_snapshot(&mut self, dialog: &SipDialogSnapshot) -> String {
+        let request_uri = self.request_uri(&dialog.number);
+        let branch = self.next_branch();
+        let to = if let Some(tag) = &dialog.remote_tag {
+            format!("<{}>;tag={}", request_uri, tag)
+        } else {
+            format!("<{}>", request_uri)
+        };
+        format!(
+            "ACK {} SIP/2.0\r\n\
+             Via: SIP/2.0/UDP {}:{};branch={};rport\r\n\
+             Max-Forwards: 70\r\n\
+             From: <{}>;tag={}\r\n\
+             To: {}\r\n\
+             Call-ID: {}\r\n\
+             CSeq: {} ACK\r\n\
+             Contact: <{}>\r\n\
+             Content-Length: 0\r\n\r\n",
+            request_uri,
+            self.asterisk_config.contact_host,
+            self.asterisk_config.bind_port,
+            branch,
+            dialog.local_uri,
+            dialog.local_tag,
+            to,
+            dialog.call_id_header,
+            dialog.cseq,
+            self.contact_uri()
+        )
+    }
+}
+
+impl TetraEntityTrait for AsteriskEntity {
+    fn entity(&self) -> TetraEntity {
+        TetraEntity::Asterisk
+    }
+
+    fn rx_prim(&mut self, queue: &mut MessageQueue, message: SapMsg) {
+        match message.msg {
+            SapMsgInner::CmceCallControl(CallControl::NetworkCircuitSetupRequest { brew_uuid, call }) => {
+                self.start_outbound_call(queue, brew_uuid, call);
+            }
+            SapMsgInner::CmceCallControl(CallControl::NetworkCircuitSetupAccept { brew_uuid }) => {
+                self.handle_inbound_setup_accept(brew_uuid);
+            }
+            SapMsgInner::CmceCallControl(CallControl::NetworkCircuitSetupReject { brew_uuid, cause }) => {
+                self.handle_inbound_setup_reject(brew_uuid, cause);
+            }
+            SapMsgInner::CmceCallControl(CallControl::NetworkCircuitAlert { brew_uuid }) => {
+                self.handle_inbound_alert(brew_uuid);
+            }
+            SapMsgInner::CmceCallControl(CallControl::NetworkCircuitConnectRequest { brew_uuid, call }) => {
+                self.handle_inbound_connect_request(queue, brew_uuid, call);
+            }
+            SapMsgInner::CmceCallControl(CallControl::NetworkCircuitConnectConfirm { .. }) => {}
+            SapMsgInner::CmceCallControl(CallControl::NetworkCircuitMediaReady { brew_uuid, call_id, ts }) => {
+                self.mark_media_ready(brew_uuid, call_id, ts);
+            }
+            SapMsgInner::CmceCallControl(CallControl::NetworkCircuitRelease { brew_uuid, .. }) => {
+                self.release_dialog(brew_uuid, true);
+            }
+            SapMsgInner::CmceCallControl(CallControl::NetworkCircuitDtmf { brew_uuid, data, .. }) => {
+                tracing::debug!("AsteriskEntity: DTMF for uuid={} bytes={} currently ignored", brew_uuid, data.len());
+            }
+            SapMsgInner::TmdCircuitDataInd(prim) => {
+                self.handle_ul_voice(prim);
+            }
+            _ => {}
+        }
+        self.refresh_status();
+    }
+
+    fn tick_start(&mut self, queue: &mut MessageQueue, _ts: TdmaTime) {
+        self.maybe_periodic_sip();
+        self.poll_sip(queue);
+        self.poll_rtp(queue);
+        self.refresh_status();
+    }
+}

--- a/crates/tetra-entities/src/net_asterisk/mod.rs
+++ b/crates/tetra-entities/src/net_asterisk/mod.rs
@@ -1,0 +1,4 @@
+//! Asterisk SIP/RTP bridge for circuit-switched individual calls.
+
+mod audio;
+pub mod entity;

--- a/crates/tetra-entities/src/net_control/commands.rs
+++ b/crates/tetra-entities/src/net_control/commands.rs
@@ -21,6 +21,16 @@ pub enum ControlCommand {
         payload: Vec<u8>,
     },
 
+    /// Send an already-built SDS Type-4 payload for local delivery.
+    SendRawSdsType4 {
+        handle: u32,
+        source_ssi: u32,
+        dest_ssi: u32,
+        dest_is_group: bool,
+        len_bits: u16,
+        payload: Vec<u8>,
+    },
+
     /// Forcibly deregister a terminal from the BS
     KickMs { issi: u32 },
 

--- a/crates/tetra-entities/src/net_control/worker.rs
+++ b/crates/tetra-entities/src/net_control/worker.rs
@@ -114,6 +114,7 @@ impl<T: NetworkTransport> ControlWorker<T> {
     fn route_control_command(command: &ControlCommand) -> TetraEntity {
         match command {
             ControlCommand::SendSds { .. } => TetraEntity::Cmce,
+            ControlCommand::SendRawSdsType4 { .. } => TetraEntity::Cmce,
             ControlCommand::KickMs { .. } => TetraEntity::Cmce,
             // DGNA is a Mobility Management procedure: group attach/detach state and the
             // D-ATTACH/DETACH GROUP IDENTITY send path both live in the MM entity.
@@ -194,6 +195,19 @@ mod tests {
             source_ssi: 12345,
             is_group: false,
             payload: vec![],
+        });
+        assert_eq!(target, TetraEntity::Cmce);
+    }
+
+    #[test]
+    fn test_route_raw_sds_type4_to_cmce() {
+        let target = ControlWorker::<MockTransport>::route_control_command(&ControlCommand::SendRawSdsType4 {
+            handle: 3,
+            source_ssi: 9999,
+            dest_ssi: 2260571,
+            dest_is_group: false,
+            len_bits: 16,
+            payload: vec![0xC3, 0x00],
         });
         assert_eq!(target, TetraEntity::Cmce);
     }

--- a/crates/tetra-entities/src/net_dapnet/mod.rs
+++ b/crates/tetra-entities/src/net_dapnet/mod.rs
@@ -1,0 +1,881 @@
+//! DAPNET inbound-message forwarding.
+//!
+//! The receiver uses the DAPNET RWTH core transmitter TCP protocol. It does not transmit POCSAG;
+//! it only consumes incoming calls from the core feed, acknowledges them, normalizes the message,
+//! and forwards it through existing FlowStation paths.
+
+use std::collections::{HashSet, VecDeque};
+use std::io::{BufRead, BufReader, Write};
+use std::net::TcpStream;
+use std::thread;
+use std::time::Duration;
+
+use tetra_config::bluestation::{CfgDapnet, DapnetRuntimeStatus, SharedConfig};
+
+use crate::net_control::commands::ControlCommand;
+use crate::net_telegram::TelegramAlertSink;
+use crate::net_telemetry::{TelemetryEvent, TelemetrySink};
+use crate::tpg2200::{build_sds_text_payload, build_tpg2200_callout_payload, format_hex_bytes};
+
+type CmdSender = crossbeam_channel::Sender<ControlCommand>;
+
+const TCP_READ_TIMEOUT: Duration = Duration::from_secs(30);
+const CALLOUT_TEXT_MAX_CHARS: usize = 80;
+
+#[derive(Debug, Clone)]
+struct DapnetMessage {
+    id: String,
+    callsign: String,
+    recipient: String,
+    text: String,
+    timestamp: String,
+    priority: Option<u8>,
+    msg_type: u8,
+    speed: Option<u8>,
+    ric: Option<u32>,
+    function: Option<u8>,
+}
+
+pub fn spawn_dapnet_worker(
+    cfg: SharedConfig,
+    cmce_cmd_tx: Option<CmdSender>,
+    telegram_sink: Option<TelegramAlertSink>,
+    telemetry_sink: Option<TelemetrySink>,
+) -> Option<thread::JoinHandle<()>> {
+    match thread::Builder::new()
+        .name("dapnet-worker".into())
+        .spawn(move || DapnetWorker::new(cfg, cmce_cmd_tx, telegram_sink, telemetry_sink).run())
+    {
+        Ok(handle) => Some(handle),
+        Err(err) => {
+            tracing::warn!("DAPNET: failed to spawn worker thread: {}", err);
+            None
+        }
+    }
+}
+
+struct DapnetWorker {
+    cfg: SharedConfig,
+    cmce_cmd_tx: Option<CmdSender>,
+    telegram_sink: Option<TelegramAlertSink>,
+    telemetry_sink: Option<TelemetrySink>,
+    seen: HashSet<String>,
+    seen_order: VecDeque<String>,
+    next_callout_incident: u16,
+    last_callout_incident_base: Option<u16>,
+    last_enabled: Option<bool>,
+}
+
+impl DapnetWorker {
+    fn new(
+        cfg: SharedConfig,
+        cmce_cmd_tx: Option<CmdSender>,
+        telegram_sink: Option<TelegramAlertSink>,
+        telemetry_sink: Option<TelemetrySink>,
+    ) -> Self {
+        let next_callout_incident = cfg.effective_dapnet().callout_incident_base.clamp(1, 256);
+        Self {
+            cfg,
+            cmce_cmd_tx,
+            telegram_sink,
+            telemetry_sink,
+            seen: HashSet::new(),
+            seen_order: VecDeque::new(),
+            next_callout_incident,
+            last_callout_incident_base: None,
+            last_enabled: None,
+        }
+    }
+
+    fn refresh_status(
+        &self,
+        dapnet: &CfgDapnet,
+        rwth_core_status: impl Into<String>,
+        last_rx: Option<String>,
+        last_error: Option<String>,
+    ) {
+        let mut state = self.cfg.state_write();
+        let previous_last_rx = state.dapnet_status.last_rx.clone();
+        state.dapnet_status = DapnetRuntimeStatus {
+            configured: true,
+            enabled: dapnet.enabled,
+            rwth_core_enabled: dapnet.rwth_core_enabled,
+            rwth_core_status: rwth_core_status.into(),
+            endpoint: format!("{}:{}", dapnet.rwth_core_host, dapnet.rwth_core_port),
+            callsign: dapnet.rwth_core_callsign.clone(),
+            forward_sds: dapnet.forward_sds,
+            forward_callout: dapnet.forward_callout,
+            forward_telegram: dapnet.forward_telegram,
+            seen_messages: self.seen.len(),
+            last_rx: last_rx.or(previous_last_rx),
+            last_error,
+        };
+    }
+
+    fn run(&mut self) {
+        loop {
+            let dapnet = self.cfg.effective_dapnet();
+            let sleep = Duration::from_secs(dapnet.effective_poll_interval_secs());
+
+            if !dapnet.enabled {
+                self.refresh_status(&dapnet, "disabled", None, None);
+                if self.last_enabled != Some(false) {
+                    tracing::info!("DAPNET integration disabled");
+                    self.last_enabled = Some(false);
+                }
+                thread::sleep(sleep);
+                continue;
+            }
+            if self.last_enabled != Some(true) {
+                tracing::info!(
+                    "DAPNET integration enabled (rwth_core={}, forward_sds={}, forward_callout={}, forward_telegram={})",
+                    dapnet.rwth_core_enabled,
+                    dapnet.forward_sds,
+                    dapnet.forward_callout,
+                    dapnet.forward_telegram
+                );
+                if !(dapnet.forward_sds || dapnet.forward_callout || dapnet.forward_telegram) {
+                    tracing::warn!("DAPNET: enabled but no forwarding target is enabled");
+                }
+                self.last_callout_incident_base = None;
+                self.last_enabled = Some(true);
+            }
+            let incident_base = dapnet.callout_incident_base.clamp(1, 256);
+            if self.last_callout_incident_base != Some(incident_base) {
+                self.next_callout_incident = incident_base;
+                self.last_callout_incident_base = Some(incident_base);
+            }
+
+            if dapnet.rwth_core_enabled {
+                self.refresh_status(&dapnet, "connecting", None, None);
+                if let Err(err) = self.run_rwth_core(&dapnet) {
+                    tracing::warn!("DAPNET: RWTH core receive failed: {}", err);
+                    self.refresh_status(&dapnet, "error", None, Some(err));
+                }
+            } else {
+                tracing::warn!(
+                    "DAPNET: enabled, but rwth_core_enabled=false; no inbound receiver is active (api_url={})",
+                    dapnet.api_url
+                );
+                self.refresh_status(&dapnet, "receive disabled", None, None);
+            }
+
+            thread::sleep(sleep);
+        }
+    }
+
+    fn run_rwth_core(&mut self, dapnet: &CfgDapnet) -> Result<(), String> {
+        let host = dapnet.rwth_core_host.trim();
+        let callsign = dapnet.rwth_core_callsign.trim();
+        let authkey = dapnet.rwth_core_authkey.as_ref().trim();
+        if host.is_empty() {
+            return Err("RWTH core host is empty".to_string());
+        }
+        if callsign.is_empty() {
+            return Err("RWTH core callsign is empty".to_string());
+        }
+        if authkey.is_empty() {
+            return Err("RWTH core authkey is empty".to_string());
+        }
+
+        let addr = format!("{}:{}", host, dapnet.rwth_core_port);
+        tracing::info!("DAPNET: connecting to RWTH core {} as {}", addr, callsign);
+        let mut stream = TcpStream::connect(&addr).map_err(|e| format!("connect {} failed: {}", addr, e))?;
+        self.refresh_status(dapnet, "connected", None, None);
+        if let Err(err) = stream.set_read_timeout(Some(TCP_READ_TIMEOUT)) {
+            tracing::warn!("DAPNET: could not set TCP read timeout: {}", err);
+        }
+
+        self.write_login(&mut stream, dapnet)?;
+        let reader_stream = stream
+            .try_clone()
+            .map_err(|e| format!("failed to clone RWTH core TCP stream: {}", e))?;
+        let mut reader = BufReader::new(reader_stream);
+        let mut logged_in = false;
+
+        loop {
+            let mut line = String::new();
+            match reader.read_line(&mut line) {
+                Ok(0) => return Err("RWTH core closed connection".to_string()),
+                Ok(_) => {
+                    let line = line.trim_end_matches(|c| c == '\r' || c == '\n');
+                    if line.is_empty() {
+                        continue;
+                    }
+                    match self.handle_rwth_line(dapnet, &mut stream, line, &mut logged_in) {
+                        Ok(()) => {}
+                        Err(err) => return Err(err),
+                    }
+                }
+                Err(err)
+                    if err.kind() == std::io::ErrorKind::WouldBlock
+                        || err.kind() == std::io::ErrorKind::TimedOut =>
+                {
+                    continue;
+                }
+                Err(err) => return Err(format!("read failed: {}", err)),
+            }
+        }
+    }
+
+    fn write_login(&self, stream: &mut TcpStream, dapnet: &CfgDapnet) -> Result<(), String> {
+        let device = non_empty_or(&dapnet.rwth_core_device, "FlowStation");
+        let version = dapnet_version(&dapnet.rwth_core_version);
+        let callsign = dapnet.rwth_core_callsign.trim();
+        let authkey = dapnet.rwth_core_authkey.as_ref().trim();
+        let login = format!("[{} {} {} {}]\r\n", device, version, callsign, authkey);
+        write_wire(stream, &login)
+    }
+
+    fn handle_rwth_line(
+        &mut self,
+        dapnet: &CfgDapnet,
+        stream: &mut TcpStream,
+        line: &str,
+        logged_in: &mut bool,
+    ) -> Result<(), String> {
+        if line.starts_with('+') {
+            return Ok(());
+        }
+        if line.starts_with('-') {
+            tracing::warn!("DAPNET: RWTH core reported an error");
+            return Ok(());
+        }
+        if line.starts_with('2') {
+            if !*logged_in {
+                tracing::info!("DAPNET: logged into RWTH core");
+                *logged_in = true;
+                self.refresh_status(dapnet, "logged in", None, None);
+            }
+            write_wire(stream, &format!("{line}:0000\r\n+\r\n"))?;
+            return Ok(());
+        }
+        if line.starts_with('3') {
+            write_wire(stream, "+\r\n")?;
+            return Ok(());
+        }
+        if let Some(schedule) = line.strip_prefix("4:") {
+            tracing::info!("DAPNET: RWTH core schedule received ({})", schedule);
+            write_wire(stream, "+\r\n")?;
+            return Ok(());
+        }
+        if line.starts_with('7') {
+            return Err(format!("login rejected by RWTH core: {}", sanitize_log_line(line)));
+        }
+        if line.starts_with('#') {
+            self.handle_rwth_message(dapnet, stream, line)?;
+            return Ok(());
+        }
+
+        tracing::warn!("DAPNET: unknown RWTH core message type '{}'", sanitize_log_line(line));
+        write_wire(stream, "-\r\n")
+    }
+
+    fn handle_rwth_message(
+        &mut self,
+        dapnet: &CfgDapnet,
+        stream: &mut TcpStream,
+        line: &str,
+    ) -> Result<(), String> {
+        let msg_id = match rwth_line_id(line) {
+            Some(id) => id,
+            None => {
+                tracing::warn!("DAPNET: malformed RWTH core message without valid id");
+                write_wire(stream, "-\r\n")?;
+                return Ok(());
+            }
+        };
+        match parse_rwth_message(line) {
+            Ok(message) => {
+                write_wire(stream, &rwth_ack_line(msg_id, true))?;
+                if message.msg_type != 6 {
+                    tracing::debug!(
+                        "DAPNET: ignoring non-text RWTH core message id={} type={}",
+                        message.id,
+                        message.msg_type
+                    );
+                    return Ok(());
+                }
+                if !self.remember_seen(&message.id, dapnet.effective_messages_limit()) {
+                    tracing::debug!("DAPNET: duplicate message id={} ignored", message.id);
+                    return Ok(());
+                }
+                self.refresh_status(
+                    dapnet,
+                    "logged in",
+                    Some(format!("{} from {}", message.id, message.recipient)),
+                    None,
+                );
+                self.forward_message(dapnet, &message);
+                Ok(())
+            }
+            Err(err) => {
+                tracing::warn!("DAPNET: malformed RWTH core message: {}", err);
+                write_wire(stream, &rwth_ack_line(msg_id, false))
+            }
+        }
+    }
+
+    fn remember_seen(&mut self, id: &str, limit: usize) -> bool {
+        if !self.seen.insert(id.to_string()) {
+            return false;
+        }
+        self.seen_order.push_back(id.to_string());
+        while self.seen_order.len() > limit {
+            if let Some(old) = self.seen_order.pop_front() {
+                self.seen.remove(&old);
+            }
+        }
+        true
+    }
+
+    fn forward_message(&mut self, dapnet: &CfgDapnet, msg: &DapnetMessage) {
+        let mut paths: Vec<&str> = Vec::new();
+        let mut filtered: Vec<&str> = Vec::new();
+
+        if dapnet.forward_sds {
+            if ric_allowed(&dapnet.sds_allowed_rics, msg) {
+                match self.forward_sds(dapnet, msg) {
+                    Ok(()) => paths.push("sds"),
+                    Err(err) => tracing::warn!("DAPNET: SDS forward failed for id={}: {}", msg.id, err),
+                }
+            } else {
+                filtered.push("sds");
+            }
+        }
+
+        if dapnet.forward_callout {
+            if ric_allowed(&dapnet.callout_allowed_rics, msg) {
+                match self.forward_callout(dapnet, msg) {
+                    Ok(()) => paths.push("callout"),
+                    Err(err) => tracing::warn!("DAPNET: Call-Out forward failed for id={}: {}", msg.id, err),
+                }
+            } else {
+                filtered.push("callout");
+            }
+        }
+
+        if dapnet.forward_telegram {
+            if ric_allowed(&dapnet.telegram_allowed_rics, msg) {
+                match self.forward_telegram(dapnet, msg) {
+                    Ok(()) => paths.push("telegram"),
+                    Err(err) => tracing::warn!("DAPNET: Telegram forward failed for id={}: {}", msg.id, err),
+                }
+            } else {
+                filtered.push("telegram");
+            }
+        }
+
+        if paths.is_empty() {
+            if filtered.is_empty() {
+                tracing::info!(
+                    "DAPNET: received id={} recipient={} with no successful forwarding target",
+                    msg.id,
+                    msg.recipient
+                );
+            } else {
+                tracing::debug!(
+                    "DAPNET: received id={} recipient={} filtered out for paths={}",
+                    msg.id,
+                    msg.recipient,
+                    filtered.join(",")
+                );
+            }
+        } else {
+            tracing::info!(
+                "DAPNET: forwarded id={} recipient={} callsign={} paths={} timestamp={} priority={:?}",
+                msg.id,
+                msg.recipient,
+                msg.callsign,
+                paths.join(","),
+                msg.timestamp,
+                msg.priority
+            );
+        }
+        if let Some(sink) = &self.telemetry_sink {
+            sink.send(TelemetryEvent::DapnetLog {
+                direction: "rx".to_string(),
+                id: msg.id.clone(),
+                callsign: msg.callsign.clone(),
+                recipient: msg.recipient.clone(),
+                text: msg.text.clone(),
+                priority: msg.priority,
+                paths: paths.into_iter().map(|p| p.to_string()).collect(),
+            });
+        }
+    }
+
+    fn forward_sds(&self, dapnet: &CfgDapnet, msg: &DapnetMessage) -> Result<(), String> {
+        let (dest_ssi, dest_is_group, route_label) = resolve_sds_destination(dapnet, msg)?;
+        let Some(tx) = &self.cmce_cmd_tx else {
+            return Err("CMCE control sender unavailable".to_string());
+        };
+        let text = format_plain_message(&msg.callsign, &msg.text);
+        let (len_bits, payload) = build_sds_text_payload(&text);
+        tracing::debug!(
+            "DAPNET: SDS route id={} {} dest={} group={}",
+            msg.id,
+            route_label,
+            dest_ssi,
+            dest_is_group
+        );
+        tx.send(ControlCommand::SendSds {
+            handle: 0,
+            source_ssi: dapnet.sds_source_issi,
+            dest_ssi,
+            dest_is_group,
+            len_bits,
+            payload,
+        })
+        .map_err(|e| format!("send to CMCE failed: {}", e))
+    }
+
+    fn forward_callout(&mut self, dapnet: &CfgDapnet, msg: &DapnetMessage) -> Result<(), String> {
+        if dapnet.callout_dest_issi == 0 {
+            return Err("callout_dest_issi is 0".to_string());
+        }
+        let Some(tx) = self.cmce_cmd_tx.clone() else {
+            return Err("CMCE control sender unavailable".to_string());
+        };
+        let incident = self.next_incident();
+        let callout_text = prefixed_text(&dapnet.callout_text_prefix, &msg.text);
+        let (callout_text, truncated) = truncate_chars(&callout_text, CALLOUT_TEXT_MAX_CHARS);
+        if truncated {
+            tracing::warn!(
+                "DAPNET: TPG2200 Call-Out text for id={} truncated to {} chars",
+                msg.id,
+                CALLOUT_TEXT_MAX_CHARS
+            );
+        }
+        let payload = build_tpg2200_callout_payload(incident, &callout_text);
+        if payload.len() > (u16::MAX as usize / 8) {
+            return Err(format!("payload too large ({} bytes)", payload.len()));
+        }
+        tracing::debug!(
+            "DAPNET: TPG2200 Call-Out id={} incident={} dest={} payload=[{}]",
+            msg.id,
+            incident,
+            dapnet.callout_dest_issi,
+            format_hex_bytes(&payload)
+        );
+        tx.send(ControlCommand::SendRawSdsType4 {
+            handle: 0,
+            source_ssi: dapnet.callout_source_issi,
+            dest_ssi: dapnet.callout_dest_issi,
+            dest_is_group: false,
+            len_bits: (payload.len() * 8) as u16,
+            payload,
+        })
+        .map_err(|e| format!("send to CMCE failed: {}", e))
+    }
+
+    fn forward_telegram(&self, dapnet: &CfgDapnet, msg: &DapnetMessage) -> Result<(), String> {
+        let Some(sink) = &self.telegram_sink else {
+            return Err("Telegram alerter unavailable".to_string());
+        };
+        sink.send_dapnet(dapnet.telegram_prefix.clone(), msg.callsign.clone(), msg.text.clone());
+        Ok(())
+    }
+
+    fn next_incident(&mut self) -> u16 {
+        let incident = self.next_callout_incident.clamp(1, 256);
+        self.next_callout_incident = if incident >= 256 { 1 } else { incident + 1 };
+        incident
+    }
+}
+
+fn write_wire(stream: &mut TcpStream, text: &str) -> Result<(), String> {
+    stream
+        .write_all(text.as_bytes())
+        .and_then(|_| stream.flush())
+        .map_err(|e| format!("write failed: {}", e))
+}
+
+fn dapnet_version(version: &str) -> String {
+    let trimmed = version.trim();
+    if trimmed.is_empty() {
+        "v1.0".to_string()
+    } else if trimmed.starts_with('v') || trimmed.starts_with('V') {
+        trimmed.to_string()
+    } else {
+        format!("v{trimmed}")
+    }
+}
+
+fn non_empty_or(value: &str, fallback: &str) -> String {
+    let trimmed = value.trim();
+    if trimmed.is_empty() { fallback.to_string() } else { trimmed.to_string() }
+}
+
+fn rwth_line_id(line: &str) -> Option<u8> {
+    let id = line.get(1..3)?;
+    u8::from_str_radix(id, 16).ok()
+}
+
+fn rwth_ack_line(msg_id: u8, ok: bool) -> String {
+    let ack_id = msg_id.wrapping_add(1);
+    let status = if ok { "+" } else { "-" };
+    format!("#{ack_id:02x} {status}\r\n")
+}
+
+fn resolve_sds_destination(
+    dapnet: &CfgDapnet,
+    msg: &DapnetMessage,
+) -> Result<(u32, bool, String), String> {
+    if let Some(ric) = msg.ric {
+        if let Some(gssi) = dapnet.ric_gssi_routes.get(&ric) {
+            return Ok((
+                *gssi,
+                true,
+                format!(
+                    "ric-group:{}",
+                    tetra_config::bluestation::format_ric_route_key(ric)
+                ),
+            ));
+        }
+        if let Some(issi) = dapnet.ric_issi_routes.get(&ric) {
+            return Ok((
+                *issi,
+                false,
+                format!(
+                    "ric:{}",
+                    tetra_config::bluestation::format_ric_route_key(ric)
+                ),
+            ));
+        }
+    }
+    if dapnet.sds_dest_issi != 0 {
+        return Ok((
+            dapnet.sds_dest_issi,
+            dapnet.sds_dest_is_group,
+            "default".to_string(),
+        ));
+    }
+    if let Some(ric) = msg.ric {
+        Err(format!(
+            "no ISSI route for RIC {} and sds_dest_issi is 0",
+            tetra_config::bluestation::format_ric_route_key(ric)
+        ))
+    } else {
+        Err("message has no RIC and sds_dest_issi is 0".to_string())
+    }
+}
+
+fn ric_allowed(allowed_rics: &std::collections::BTreeSet<u32>, msg: &DapnetMessage) -> bool {
+    if allowed_rics.is_empty() {
+        return true;
+    }
+    match msg.ric {
+        Some(ric) => allowed_rics.contains(&ric),
+        None => false,
+    }
+}
+
+fn parse_rwth_message(line: &str) -> Result<DapnetMessage, String> {
+    let msg_id = rwth_line_id(line).ok_or_else(|| "invalid message id".to_string())?;
+    let body = line
+        .get(4..)
+        .ok_or_else(|| "message line too short".to_string())?;
+    let parts: Vec<&str> = body.splitn(5, ':').collect();
+    if parts.len() != 5 {
+        return Err("expected five colon-separated fields".to_string());
+    }
+    let msg_type = parts[0]
+        .parse::<u8>()
+        .map_err(|_| format!("invalid message type '{}'", parts[0]))?;
+    let speed = parts[1].parse::<u8>().ok();
+    let ric = u32::from_str_radix(parts[2], 16).ok();
+    let function = parts[3].parse::<u8>().ok();
+    let text = decode_dapnet_text(&normalize_text(parts[4]));
+    if text.is_empty() {
+        return Err("empty message text".to_string());
+    }
+    let recipient = match (ric, function) {
+        (Some(ric), Some(function)) => {
+            format!(
+                "RIC {} / func {}",
+                tetra_config::bluestation::format_ric_route_key(ric),
+                function
+            )
+        }
+        (Some(ric), None) => {
+            format!("RIC {}", tetra_config::bluestation::format_ric_route_key(ric))
+        }
+        _ => parts[2].to_string(),
+    };
+    let callsign = extract_callsign(&text).unwrap_or_else(|| recipient.clone());
+    let id = format!("rwth:{msg_id:02X}:{}", stable_hash_hex(body));
+    Ok(DapnetMessage {
+        id,
+        callsign,
+        recipient,
+        text,
+        timestamp: chrono::Utc::now().to_rfc3339(),
+        priority: None,
+        msg_type,
+        speed,
+        ric,
+        function,
+    })
+}
+
+fn stable_hash_hex(input: &str) -> String {
+    let digest = md5::compute(input.as_bytes());
+    format!("{digest:x}")
+}
+
+fn normalize_text(text: &str) -> String {
+    text.chars()
+        .filter(|c| !c.is_control() || matches!(c, '\t'))
+        .collect::<String>()
+        .trim()
+        .to_string()
+}
+
+fn decode_dapnet_text(text: &str) -> String {
+    let decoded = rot1_decode(text);
+    if should_decode_rot1(text, &decoded) {
+        clean_rot1_text(&decoded)
+    } else {
+        text.to_string()
+    }
+}
+
+fn rot1_decode(text: &str) -> String {
+    text.chars()
+        .map(|c| {
+            if ('!'..='~').contains(&c) {
+                ((c as u8) - 1) as char
+            } else {
+                c
+            }
+        })
+        .collect()
+}
+
+fn clean_rot1_text(decoded: &str) -> String {
+    let stripped = strip_skyper_rubric_prefix(decoded.trim()).unwrap_or_else(|| decoded.trim());
+    skyper_charset_to_unicode(stripped.trim())
+}
+
+fn strip_skyper_rubric_prefix(text: &str) -> Option<&str> {
+    let mut chars = text.char_indices();
+    let (_, first) = chars.next()?;
+    let (_, second) = chars.next()?;
+    let (third_idx, third) = chars.next()?;
+
+    if !third.is_ascii_alphanumeric() {
+        return None;
+    }
+
+    if first == ':' && second == ' ' {
+        return Some(&text[third_idx..]);
+    }
+    if first.is_ascii_punctuation()
+        && (second.is_ascii_punctuation() || second.is_ascii_whitespace() || second.is_ascii_digit())
+    {
+        return Some(&text[third_idx..]);
+    }
+    if matches!(first, 'Q' | 'q' | 'Y' | 'y' | 'N' | 'n')
+        && (second.is_ascii_punctuation() || second.is_ascii_whitespace())
+    {
+        return Some(&text[third_idx..]);
+    }
+    None
+}
+
+fn skyper_charset_to_unicode(text: &str) -> String {
+    text.chars()
+        .map(|c| match c {
+            '[' => 'Ä',
+            '\\' => 'Ö',
+            ']' => 'Ü',
+            '{' => 'ä',
+            '|' => 'ö',
+            '}' => 'ü',
+            '~' => 'ß',
+            _ => c,
+        })
+        .collect()
+}
+
+fn should_decode_rot1(raw: &str, decoded: &str) -> bool {
+    if raw.is_empty() {
+        return false;
+    }
+    let raw_spaces = raw.chars().filter(|&c| c == ' ').count();
+    let encoded_spaces = raw.chars().filter(|&c| c == '!').count();
+    let encoded_punctuation = raw.chars().filter(|&c| matches!(c, ';' | '/' | '{' | '}')).count();
+    let decoded_spaces = decoded.chars().filter(|&c| c == ' ').count();
+
+    // DAPNET/Skyper rubrics are ROT-1 encrypted: spaces appear as '!', ':' as ';',
+    // and '.' as '/'. Plain DAPNET messages from the core already contain normal spaces
+    // and must stay untouched.
+    encoded_spaces >= 2
+        && encoded_spaces > raw_spaces
+        && decoded_spaces >= encoded_spaces
+        && encoded_punctuation > 0
+}
+
+fn extract_callsign(text: &str) -> Option<String> {
+    for token in text.split_whitespace() {
+        let cleaned = token.trim_matches(|c: char| !c.is_ascii_alphanumeric() && c != '-' && c != '/');
+        if cleaned.len() < 3 || cleaned.len() > 12 {
+            continue;
+        }
+        let has_alpha = cleaned.chars().any(|c| c.is_ascii_alphabetic());
+        let has_digit = cleaned.chars().any(|c| c.is_ascii_digit());
+        let valid = cleaned
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '/');
+        if has_alpha && has_digit && valid {
+            return Some(cleaned.to_ascii_uppercase());
+        }
+    }
+    None
+}
+
+fn format_plain_message(callsign: &str, text: &str) -> String {
+    let callsign = callsign.trim();
+    let text = text.trim();
+    if callsign.is_empty() {
+        text.to_string()
+    } else {
+        format!("{callsign} - {text}")
+    }
+}
+
+fn prefixed_text(prefix: &str, text: &str) -> String {
+    let prefix = prefix.trim();
+    let text = text.trim();
+    if prefix.is_empty() {
+        text.to_string()
+    } else if text.is_empty() {
+        prefix.to_string()
+    } else {
+        format!("{prefix} {text}")
+    }
+}
+
+fn truncate_chars(text: &str, max: usize) -> (String, bool) {
+    match text.char_indices().nth(max) {
+        Some((idx, _)) => (text[..idx].to_string(), true),
+        None => (text.to_string(), false),
+    }
+}
+
+fn sanitize_log_line(line: &str) -> String {
+    truncate_chars(line, 160).0
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        dapnet_version, decode_dapnet_text, extract_callsign, format_plain_message,
+        parse_rwth_message, prefixed_text, resolve_sds_destination, ric_allowed, rwth_ack_line,
+        truncate_chars,
+    };
+    use tetra_config::bluestation::CfgDapnet;
+
+    #[test]
+    fn parse_rwth_text_message_normalizes_fields() {
+        let msg = parse_rwth_message("#00 6:1:3EC:3:5357.0 EA5FIV von DL4MFF um 1933z").unwrap();
+        assert_eq!(msg.msg_type, 6);
+        assert_eq!(msg.speed, Some(1));
+        assert_eq!(msg.ric, Some(0x3EC));
+        assert_eq!(msg.function, Some(3));
+        assert_eq!(msg.callsign, "EA5FIV");
+        assert_eq!(msg.recipient, "RIC 0001004 / func 3");
+        assert!(msg.id.starts_with("rwth:00:"));
+    }
+
+    #[test]
+    fn parse_rwth_message_keeps_colons_in_text() {
+        let msg = parse_rwth_message("#01 6:1:3EC:3:Alarm: Pumpe: Test").unwrap();
+        assert_eq!(msg.text, "Alarm: Pumpe: Test");
+    }
+
+    #[test]
+    fn dapnet_text_decodes_skyper_rot1_but_keeps_plain_text() {
+        let darc_70mhz =
+            ";#EBSD;!Cvoeftsbut.Esvdltbdif!efgjojfsu!jo!Gvopuf!Sfdiutsbinfo!g~s!81.NI{.Cfusjfc";
+        let nordsee =
+            "\\&Opsetff;!33/17/37!27;41!Ifmhpmboe!Cjoofoibgfo!679/1dn!NOX;vocflboou";
+
+        assert_eq!(
+            decode_dapnet_text("Tfu!pg!JTT!bu!19;67!VUD/"),
+            "Set of ISS at 08:56 UTC."
+        );
+        assert_eq!(
+            decode_dapnet_text("R#Tfu!pg!JTT!bu!19;67!VUD/"),
+            "Set of ISS at 08:56 UTC."
+        );
+        assert_eq!(
+            decode_dapnet_text(";!EBSD;!SUUZ.Uifnfobcfoe"),
+            "DARC: RTTY-Themenabend"
+        );
+        assert_eq!(
+            decode_dapnet_text(darc_70mhz),
+            "DARC: Bundesrats-Drucksache definiert in Funote Rechtsrahmen für 70-MHz-Betrieb"
+        );
+        assert_eq!(
+            decode_dapnet_text(nordsee),
+            "Nordsee: 22.06.26 16:30 Helgoland Binnenhafen 568.0cm MNW:unbekannt"
+        );
+        assert_eq!(
+            decode_dapnet_text("5357.0 EA5FIV von DL4MFF um 1933z"),
+            "5357.0 EA5FIV von DL4MFF um 1933z"
+        );
+        assert_eq!(decode_dapnet_text("XTIME=1702220626"), "XTIME=1702220626");
+    }
+
+    #[test]
+    fn helpers_are_stable() {
+        assert_eq!(dapnet_version("1.0"), "v1.0");
+        assert_eq!(dapnet_version("v2"), "v2");
+        assert_eq!(extract_callsign("foo dl1abc-9 bar"), Some("DL1ABC-9".to_string()));
+        assert_eq!(format_plain_message("DL1ABC", "Hallo"), "DL1ABC - Hallo");
+        assert_eq!(prefixed_text("DAPNET", "Alarm"), "DAPNET Alarm");
+        assert_eq!(truncate_chars("äöü", 2), ("äö".to_string(), true));
+    }
+
+    #[test]
+    fn rwth_ack_line_increments_8bit_counter_and_uses_wire_format() {
+        assert_eq!(rwth_ack_line(0x00, true), "#01 +\r\n");
+        assert_eq!(rwth_ack_line(0x09, true), "#0a +\r\n");
+        assert_eq!(rwth_ack_line(0xff, true), "#00 +\r\n");
+        assert_eq!(rwth_ack_line(0x09, false), "#0a -\r\n");
+    }
+
+    #[test]
+    fn sds_destination_prefers_ric_route_over_static_destination() {
+        let msg = parse_rwth_message("#00 6:1:9A709:3:Alarm DJ2TH").unwrap();
+        let mut dapnet = CfgDapnet::default();
+        dapnet.sds_dest_issi = 9999999;
+        dapnet.sds_dest_is_group = true;
+        dapnet.ric_issi_routes.insert(632585, 2632585);
+
+        let (dest, is_group, route) = resolve_sds_destination(&dapnet, &msg).unwrap();
+        assert_eq!(dest, 2632585);
+        assert!(!is_group);
+        assert_eq!(route, "ric:0632585");
+    }
+
+    #[test]
+    fn sds_destination_can_route_dapnet_ric_to_tetra_group() {
+        let msg = parse_rwth_message("#00 6:1:11A8:3:Rubric alarm").unwrap();
+        let mut dapnet = CfgDapnet::default();
+        dapnet.sds_dest_issi = 9999999;
+        dapnet.ric_gssi_routes.insert(4520, 80);
+        dapnet.sds_allowed_rics.insert(4520);
+
+        let (dest, is_group, route) = resolve_sds_destination(&dapnet, &msg).unwrap();
+        assert_eq!(dest, 80);
+        assert!(is_group);
+        assert_eq!(route, "ric-group:0004520");
+        assert!(ric_allowed(&dapnet.sds_allowed_rics, &msg));
+
+        let other = parse_rwth_message("#01 6:1:D0:3:Time sync").unwrap();
+        assert!(!ric_allowed(&dapnet.sds_allowed_rics, &other));
+    }
+}

--- a/crates/tetra-entities/src/net_dashboard/dapnet.rs
+++ b/crates/tetra-entities/src/net_dashboard/dapnet.rs
@@ -1,0 +1,160 @@
+//! Dashboard-side persistence and helpers for DAPNET settings.
+//!
+//! Mirrors the Telegram/WX dashboard helpers: rewrite only the `[dapnet]` section while
+//! preserving the rest of the active config file, and mask secrets before returning them to UI.
+
+use tetra_config::bluestation::DapnetRuntimeOverride;
+
+/// Mask a secret for display. Returns an empty string for an empty value.
+pub fn mask_secret(secret: &str) -> String {
+    let secret = secret.trim();
+    if secret.is_empty() {
+        return String::new();
+    }
+    let chars: Vec<char> = secret.chars().collect();
+    if chars.len() <= 10 {
+        return "•".repeat(chars.len());
+    }
+    let head: String = chars[..4].iter().collect();
+    let tail: String = chars[chars.len() - 4..].iter().collect();
+    format!("{head}…{tail}")
+}
+
+fn toml_escape(s: &str) -> String {
+    s.replace('\\', "\\\\").replace('"', "\\\"")
+}
+
+fn ric_set_toml(rics: &std::collections::BTreeSet<u32>) -> String {
+    rics.iter()
+        .map(|ric| format!("\"{}\"", tetra_config::bluestation::format_ric_route_key(*ric)))
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+fn ric_routes_toml(routes: &std::collections::BTreeMap<u32, u32>) -> String {
+    routes
+        .iter()
+        .map(|(ric, ssi)| {
+            format!(
+                "\"{}\" = {}",
+                tetra_config::bluestation::format_ric_route_key(*ric),
+                ssi
+            )
+        })
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+/// Rewrite (or insert) the `[dapnet]` section in the TOML file. A `.dapnet.bak` backup is made.
+pub fn write_dapnet_to_toml(
+    config_path: &str,
+    ov: &DapnetRuntimeOverride,
+) -> std::io::Result<()> {
+    let original = std::fs::read_to_string(config_path)?;
+    let ric_issi_routes = ric_routes_toml(&ov.ric_issi_routes);
+    let ric_gssi_routes = ric_routes_toml(&ov.ric_gssi_routes);
+    let sds_allowed_rics = ric_set_toml(&ov.sds_allowed_rics);
+    let callout_allowed_rics = ric_set_toml(&ov.callout_allowed_rics);
+    let telegram_allowed_rics = ric_set_toml(&ov.telegram_allowed_rics);
+    let section = format!(
+        "[dapnet]\n\
+         enabled = {}\n\
+         api_url = \"{}\"\n\
+         username = \"{}\"\n\
+         password = \"{}\"\n\
+         poll_interval_secs = {}\n\n\
+         forward_sds = {}\n\
+         forward_callout = {}\n\
+         forward_telegram = {}\n\n\
+         sds_source_issi = {}\n\
+         sds_dest_issi = {}\n\
+         sds_dest_is_group = {}\n\
+         ric_issi_routes = {{{}}}\n\
+         ric_gssi_routes = {{{}}}\n\
+         sds_allowed_rics = [{}]\n\
+         callout_allowed_rics = [{}]\n\
+         telegram_allowed_rics = [{}]\n\n\
+         callout_source_issi = {}\n\
+         callout_dest_issi = {}\n\
+         callout_incident_base = {}\n\
+         callout_text_prefix = \"{}\"\n\n\
+         telegram_prefix = \"{}\"\n\n\
+         rwth_core_enabled = {}\n\
+         rwth_core_host = \"{}\"\n\
+         rwth_core_port = {}\n\
+         rwth_core_device = \"{}\"\n\
+         rwth_core_version = \"{}\"\n\
+         rwth_core_callsign = \"{}\"\n\
+         rwth_core_authkey = \"{}\"\n\
+         rwth_messages_limit = {}",
+        ov.enabled,
+        toml_escape(&ov.api_url),
+        toml_escape(&ov.username),
+        toml_escape(&ov.password),
+        ov.poll_interval_secs.max(1),
+        ov.forward_sds,
+        ov.forward_callout,
+        ov.forward_telegram,
+        ov.sds_source_issi,
+        ov.sds_dest_issi,
+        ov.sds_dest_is_group,
+        ric_issi_routes,
+        ric_gssi_routes,
+        sds_allowed_rics,
+        callout_allowed_rics,
+        telegram_allowed_rics,
+        ov.callout_source_issi,
+        ov.callout_dest_issi,
+        ov.callout_incident_base.clamp(1, 256),
+        toml_escape(&ov.callout_text_prefix),
+        toml_escape(&ov.telegram_prefix),
+        ov.rwth_core_enabled,
+        toml_escape(&ov.rwth_core_host),
+        ov.rwth_core_port,
+        toml_escape(&ov.rwth_core_device),
+        toml_escape(&ov.rwth_core_version),
+        toml_escape(&ov.rwth_core_callsign),
+        toml_escape(&ov.rwth_core_authkey),
+        ov.rwth_messages_limit.max(1),
+    );
+
+    let lines: Vec<&str> = original.lines().collect();
+    let mut out: Vec<String> = Vec::with_capacity(lines.len() + 32);
+    let mut i = 0;
+    let mut replaced = false;
+
+    while i < lines.len() {
+        let trimmed = lines[i].trim_start();
+        if trimmed.starts_with("[dapnet]") {
+            out.push(section.clone());
+            replaced = true;
+            i += 1;
+            while i < lines.len() {
+                let t = lines[i].trim_start();
+                if t.starts_with('[') && t.contains(']') {
+                    break;
+                }
+                i += 1;
+            }
+            continue;
+        }
+        out.push(lines[i].to_string());
+        i += 1;
+    }
+
+    if !replaced {
+        if !out.is_empty() && !out.last().map(|l| l.is_empty()).unwrap_or(true) {
+            out.push(String::new());
+        }
+        out.push(section);
+    }
+
+    let mut new_content = out.join("\n");
+    if original.ends_with('\n') {
+        new_content.push('\n');
+    }
+
+    let backup = format!("{config_path}.dapnet.bak");
+    let _ = std::fs::copy(config_path, &backup);
+    std::fs::write(config_path, new_content)
+}

--- a/crates/tetra-entities/src/net_dashboard/geoalarm.rs
+++ b/crates/tetra-entities/src/net_dashboard/geoalarm.rs
@@ -1,0 +1,124 @@
+//! Dashboard-side persistence helpers for GeoAlarm settings.
+
+use tetra_config::bluestation::GeoalarmRuntimeOverride;
+
+fn toml_escape(s: &str) -> String {
+    s.replace('\\', "\\\\").replace('"', "\\\"")
+}
+
+fn u32_set_toml(values: &std::collections::BTreeSet<u32>) -> String {
+    values
+        .iter()
+        .map(|v| v.to_string())
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+fn string_set_toml(values: &std::collections::BTreeSet<String>) -> String {
+    values
+        .iter()
+        .map(|v| format!("\"{}\"", toml_escape(v)))
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+/// Rewrite (or insert) the `[geoalarm]` section in the TOML file. A `.geoalarm.bak` backup is made.
+pub fn write_geoalarm_to_toml(
+    config_path: &str,
+    ov: &GeoalarmRuntimeOverride,
+) -> std::io::Result<()> {
+    let original = std::fs::read_to_string(config_path)?;
+    let section = format!(
+        "[geoalarm]\n\
+         enabled = {}\n\
+         flowstation_lat = {:.8}\n\
+         flowstation_lon = {:.8}\n\
+         radius_m = {:.1}\n\
+         cooldown_secs = {}\n\n\
+         trigger_tetra = {}\n\
+         trigger_meshcom = {}\n\n\
+         forward_tpg2200 = {}\n\
+         forward_sds = {}\n\
+         forward_sip = {}\n\
+         forward_telegram = {}\n\n\
+         tetra_issi_whitelist = [{}]\n\
+         tetra_issi_blacklist = [{}]\n\
+         meshcom_source_whitelist = [{}]\n\
+         meshcom_source_blacklist = [{}]\n\n\
+         sds_source_issi = {}\n\
+         sds_dest_issi = {}\n\
+         sds_dest_is_group = {}\n\n\
+         tpg2200_source_issi = {}\n\
+         tpg2200_dest_issi = {}\n\
+         tpg2200_incident_base = {}\n\
+         tpg2200_text_prefix = \"{}\"\n\
+         tpg2200_max_text_chars = {}\n\n\
+         sip_title_prefix = \"{}\"\n\
+         telegram_prefix = \"{}\"",
+        ov.enabled,
+        ov.flowstation_lat,
+        ov.flowstation_lon,
+        ov.radius_m.max(1.0),
+        ov.cooldown_secs.clamp(1, 86_400),
+        ov.trigger_tetra,
+        ov.trigger_meshcom,
+        ov.forward_tpg2200,
+        ov.forward_sds,
+        ov.forward_sip,
+        ov.forward_telegram,
+        u32_set_toml(&ov.tetra_issi_whitelist),
+        u32_set_toml(&ov.tetra_issi_blacklist),
+        string_set_toml(&ov.meshcom_source_whitelist),
+        string_set_toml(&ov.meshcom_source_blacklist),
+        ov.sds_source_issi.max(1),
+        ov.sds_dest_issi,
+        ov.sds_dest_is_group,
+        ov.tpg2200_source_issi.max(1),
+        ov.tpg2200_dest_issi,
+        ov.tpg2200_incident_base.clamp(1, 256),
+        toml_escape(&ov.tpg2200_text_prefix),
+        ov.tpg2200_max_text_chars.clamp(8, 160),
+        toml_escape(&ov.sip_title_prefix),
+        toml_escape(&ov.telegram_prefix),
+    );
+
+    let lines: Vec<&str> = original.lines().collect();
+    let mut out: Vec<String> = Vec::with_capacity(lines.len() + 32);
+    let mut i = 0;
+    let mut replaced = false;
+
+    while i < lines.len() {
+        let trimmed = lines[i].trim_start();
+        if trimmed.starts_with("[geoalarm]") {
+            out.push(section.clone());
+            replaced = true;
+            i += 1;
+            while i < lines.len() {
+                let t = lines[i].trim_start();
+                if t.starts_with('[') && t.contains(']') {
+                    break;
+                }
+                i += 1;
+            }
+            continue;
+        }
+        out.push(lines[i].to_string());
+        i += 1;
+    }
+
+    if !replaced {
+        if !out.is_empty() && !out.last().map(|l| l.is_empty()).unwrap_or(true) {
+            out.push(String::new());
+        }
+        out.push(section);
+    }
+
+    let mut new_content = out.join("\n");
+    if original.ends_with('\n') {
+        new_content.push('\n');
+    }
+
+    let backup = format!("{config_path}.geoalarm.bak");
+    let _ = std::fs::copy(config_path, &backup);
+    std::fs::write(config_path, new_content)
+}

--- a/crates/tetra-entities/src/net_dashboard/html.rs
+++ b/crates/tetra-entities/src/net_dashboard/html.rs
@@ -695,6 +695,7 @@ input[type="radio"]{accent-color:var(--accent);}
    except the full-bleed code editor, which stays edge-to-edge. */
 #page-telegram .card-body,
 #page-config .card-body,
+#page-dapnet .card-body,
 #page-wifi .card-body{padding:16px 18px;}
 #page-config .card-body:has(#config-editor){padding:0;}
 
@@ -1544,6 +1545,8 @@ tbody tr:hover td{background:color-mix(in srgb,var(--bg3) 70%, transparent);}
 #page-sdslog .sds-time{ white-space:nowrap; color:var(--text2); font-variant-numeric:tabular-nums; }
 #page-sdslog .sds-msg{ word-break:break-word; max-width:560px; }
 .sds-empty{ color:var(--text3); font-style:italic; }
+.sds-map-link{ color:var(--accent2); font-weight:700; text-decoration:none; }
+.sds-map-link:hover{ text-decoration:underline; }
 /* Signal cell: centre the bar+value as a unit, and keep the dBFS reading on one line
    (it was wrapping to two, which read as "toy-like"). */
 #page-stations .rssi-bar{ justify-content:center; }
@@ -1782,6 +1785,18 @@ tbody tr:hover td{background:color-mix(in srgb,var(--bg3) 70%, transparent);}
     </div>
 
     <div class="nav-section-label" data-i18n-section="manage">MANAGE</div>
+    <div class="nav-item" onclick="showPage('asterisk',this)" id="nav-asterisk">
+      <span class="nav-icon">☎</span>
+      <span class="nav-label" data-i18n="asterisk">Asterisk SIP</span>
+    </div>
+    <div class="nav-item" onclick="showPage('dapnet',this)" id="nav-dapnet">
+      <span class="nav-icon">📟</span>
+      <span class="nav-label" data-i18n="dapnet">DAPNET</span>
+    </div>
+    <div class="nav-item" onclick="showPage('geoalarm',this)" id="nav-geoalarm">
+      <span class="nav-icon">◎</span>
+      <span class="nav-label" data-i18n="geoalarm">GeoAlarm</span>
+    </div>
     <div class="nav-item" onclick="showPage('config',this)" id="nav-config">
       <span class="nav-icon">⚙</span>
       <span class="nav-label" data-i18n="config">CONFIG</span>
@@ -2207,6 +2222,8 @@ tbody tr:hover td{background:color-mix(in srgb,var(--bg3) 70%, transparent);}
           <div class="card-title" data-i18n="sdslog">SDS Log</div>
           <div class="card-actions">
             <button class="btn btn-sm" onclick="loadSdsLog()" data-i18n="sds_refresh">⟳ Refresh</button>
+            <button class="btn btn-sm" onclick="exportSdsLog()" data-i18n="export">⤓ Export</button>
+            <button class="btn btn-sm btn-danger" onclick="clearSdsLog()" data-i18n="clear">Clear</button>
           </div>
         </div>
         <div class="card-body">
@@ -2221,6 +2238,11 @@ tbody tr:hover td{background:color-mix(in srgb,var(--bg3) 70%, transparent);}
               </tr></thead>
               <tbody id="sdslog-tbody"></tbody>
             </table>
+          </div>
+          <div class="log-controls">
+            <button class="btn btn-sm" onclick="sdsLogPrevPage()">‹ Prev</button>
+            <span class="sds-empty" id="sdslog-page">Page 1 / 1</span>
+            <button class="btn btn-sm" onclick="sdsLogNextPage()">Next ›</button>
           </div>
         </div>
       </div>
@@ -2336,6 +2358,422 @@ tbody tr:hover td{background:color-mix(in srgb,var(--bg3) 70%, transparent);}
         </div>
       </div>
 
+    </div>
+
+    <!-- ── ASTERISK SIP ── -->
+    <div class="page" id="page-asterisk">
+      <div class="card">
+        <div class="card-head">
+          <div class="card-title" data-i18n="asterisk_title">Asterisk SIP</div>
+          <div class="card-actions">
+            <button class="btn btn-sm" onclick="loadAsteriskStatus()" data-i18n="refresh">⟳ Refresh</button>
+          </div>
+        </div>
+        <div class="card-body">
+          <div class="stat-grid" style="margin-bottom:14px">
+            <div class="stat-card">
+              <div class="stat-label" data-i18n="ast_configured">Configured</div>
+              <div class="stat-value" id="ast-configured">—</div>
+              <div class="stat-sub" id="ast-enabled">—</div>
+            </div>
+            <div class="stat-card blue">
+              <div class="stat-label" data-i18n="ast_register">REGISTER</div>
+              <div class="stat-value blue" id="ast-register">—</div>
+              <div class="stat-sub" id="ast-dialogs">—</div>
+            </div>
+          </div>
+          <div class="info-grid">
+            <div class="info-row"><div class="info-key" data-i18n="ast_sip_listen">SIP listen</div><div class="info-val" id="ast-sip-listen">—</div></div>
+            <div class="info-row"><div class="info-key" data-i18n="ast_remote">Remote Asterisk</div><div class="info-val" id="ast-remote">—</div></div>
+            <div class="info-row"><div class="info-key" data-i18n="ast_rtp">RTP ports</div><div class="info-val" id="ast-rtp">—</div></div>
+            <div class="info-row"><div class="info-key" data-i18n="ast_codec">Codec</div><div class="info-val" id="ast-codec">—</div></div>
+            <div class="info-row"><div class="info-key" data-i18n="ast_last_rx">Last RX</div><div class="info-val" id="ast-last-rx">—</div></div>
+            <div class="info-row"><div class="info-key" data-i18n="ast_last_tx">Last TX</div><div class="info-val" id="ast-last-tx">—</div></div>
+            <div class="info-row"><div class="info-key" data-i18n="ast_last_error">Last error</div><div class="info-val" id="ast-last-error">—</div></div>
+          </div>
+        </div>
+      </div>
+
+      <div class="card">
+        <div class="card-head">
+          <div class="card-title">Snom SIP NOTIFY</div>
+          <div class="card-actions">
+            <button class="btn btn-sm" onclick="loadSnomNotify()" data-i18n="refresh">⟳ Refresh</button>
+            <button class="btn btn-primary" onclick="saveSnomNotify()" data-i18n="save">Save</button>
+          </div>
+        </div>
+        <div class="card-body">
+          <label class="sw-row">
+            <span class="sw-text">Enable SnomIPPhoneText notifications</span>
+            <span class="sw"><input type="checkbox" id="snom-enabled"><i></i></span>
+          </label>
+
+          <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(220px,1fr));gap:10px;align-items:center;margin-top:14px">
+            <label style="color:var(--muted);font-size:13px">AMI host</label>
+            <input type="text" id="snom-ami-host" class="form-input" placeholder="127.0.0.1">
+            <label style="color:var(--muted);font-size:13px">AMI port</label>
+            <input type="number" id="snom-ami-port" class="form-input" min="1" max="65535" placeholder="5038">
+            <label style="color:var(--muted);font-size:13px">AMI user</label>
+            <input type="text" id="snom-ami-user" class="form-input" autocomplete="off" spellcheck="false" placeholder="flowstation">
+            <label style="color:var(--muted);font-size:13px">AMI password</label>
+            <input type="password" id="snom-ami-password" class="form-input" autocomplete="new-password" spellcheck="false" oninput="snomPasswordDirty=true">
+            <label style="color:var(--muted);font-size:13px;align-self:flex-start;padding-top:8px">PJSIP endpoints</label>
+            <textarea id="snom-endpoints" class="form-input" rows="3" placeholder="385&#10;386"></textarea>
+          </div>
+
+          <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(260px,1fr));gap:14px;margin-top:16px">
+            <div>
+              <label class="sw-row"><span class="sw-text">Notify TETRA SDS</span><span class="sw"><input type="checkbox" id="snom-notify-sds"><i></i></span></label>
+              <div style="display:flex;gap:14px;flex-wrap:wrap;margin:8px 0 10px;color:var(--muted);font-size:13px">
+                <label><input type="checkbox" id="snom-dir-rx"> RX</label>
+                <label><input type="checkbox" id="snom-dir-net"> NET</label>
+                <label><input type="checkbox" id="snom-dir-tx"> TX</label>
+              </div>
+              <label style="color:var(--muted);font-size:13px">SDS ISSI whitelist</label>
+              <textarea id="snom-sds-issis" class="form-input" rows="4" placeholder="2632585&#10;9999"></textarea>
+              <div class="help-text">Empty = every SDS. A match on source or destination ISSI is enough.</div>
+            </div>
+            <div>
+              <label class="sw-row"><span class="sw-text">Notify DAPNET</span><span class="sw"><input type="checkbox" id="snom-notify-dapnet"><i></i></span></label>
+              <label style="color:var(--muted);font-size:13px">DAPNET RIC whitelist</label>
+              <textarea id="snom-dapnet-rics" class="form-input" rows="4" placeholder="0632585&#10;0000200"></textarea>
+              <div class="help-text">Empty = every DAPNET message. Leading zeros are preserved in config.</div>
+            </div>
+            <div>
+              <label class="sw-row"><span class="sw-text">Notify Telegram</span><span class="sw"><input type="checkbox" id="snom-notify-telegram"><i></i></span></label>
+              <div style="display:grid;grid-template-columns:130px 1fr;gap:10px;align-items:center;margin-top:10px">
+                <label style="color:var(--muted);font-size:13px">Title prefix</label>
+                <input type="text" id="snom-title-prefix" class="form-input" placeholder="FlowStation">
+                <label style="color:var(--muted);font-size:13px">Max text chars</label>
+                <input type="number" id="snom-max-text" class="form-input" min="40" max="2000" placeholder="240">
+                <label style="color:var(--muted);font-size:13px">Timeout (s)</label>
+                <input type="number" id="snom-timeout" class="form-input" min="1" max="30" placeholder="3">
+              </div>
+            </div>
+          </div>
+          <div class="config-msg" id="snom-msg"></div>
+        </div>
+      </div>
+    </div>
+
+    <!-- ── DAPNET ── -->
+    <div class="page" id="page-dapnet">
+      <div class="card">
+        <div class="card-head">
+          <div class="card-title" data-i18n="dapnet_log">DAPNET Log</div>
+          <div class="card-actions">
+            <button class="btn btn-sm" onclick="loadDapnetLog()" data-i18n="refresh">⟳ Refresh</button>
+            <button class="btn btn-sm" onclick="exportDapnetLog()" data-i18n="export">⤓ Export</button>
+            <button class="btn btn-sm btn-danger" onclick="clearDapnetLog()" data-i18n="clear">Clear</button>
+          </div>
+        </div>
+        <div class="card-body">
+          <div class="table-wrap">
+            <table>
+              <thead><tr>
+                <th data-i18n="th_time">Time</th>
+                <th data-i18n="th_dir">Dir</th>
+                <th>Callsign</th>
+                <th>Recipient</th>
+                <th>Paths</th>
+                <th data-i18n="th_message">Message</th>
+              </tr></thead>
+              <tbody id="dapnetlog-tbody"></tbody>
+            </table>
+          </div>
+          <div class="log-controls">
+            <button class="btn btn-sm" onclick="dapnetLogPrevPage()">‹ Prev</button>
+            <span class="sds-empty" id="dapnetlog-page">Page 1 / 1</span>
+            <button class="btn btn-sm" onclick="dapnetLogNextPage()">Next ›</button>
+          </div>
+        </div>
+      </div>
+
+      <div class="card">
+        <div class="card-head">
+          <div class="card-title" data-i18n="dapnet_title">DAPNET</div>
+          <div class="card-actions">
+            <button class="btn btn-primary" onclick="saveDapnet()" data-i18n="save">Save</button>
+          </div>
+        </div>
+        <div class="card-body">
+          <label class="sw-row">
+            <span class="sw-text">Enable DAPNET integration</span>
+            <span class="sw"><input type="checkbox" id="dap-enabled"><i></i></span>
+          </label>
+          <label class="sw-row">
+            <span class="sw-text">Enable RWTH core receive feed</span>
+            <span class="sw"><input type="checkbox" id="dap-rwth-enabled"><i></i></span>
+          </label>
+
+          <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(190px,1fr));gap:10px;align-items:center;margin-top:14px">
+            <label style="color:var(--muted);font-size:13px">Poll interval (s)</label>
+            <input type="number" id="dap-poll" class="form-input" min="1" placeholder="30">
+            <label style="color:var(--muted);font-size:13px">Messages limit</label>
+            <input type="number" id="dap-limit" class="form-input" min="1" placeholder="100">
+
+            <label style="color:var(--muted);font-size:13px">Hampager API URL</label>
+            <input type="text" id="dap-api-url" class="form-input" placeholder="https://hampager.de/api/calls" style="grid-column:1 / -1;min-width:0">
+
+            <label style="color:var(--muted);font-size:13px">API username</label>
+            <input type="text" id="dap-username" class="form-input" autocomplete="off" spellcheck="false">
+            <label style="color:var(--muted);font-size:13px">API password</label>
+            <input type="password" id="dap-password" class="form-input" autocomplete="new-password" spellcheck="false" oninput="dapPasswordDirty=true">
+
+            <label style="color:var(--muted);font-size:13px">RWTH host</label>
+            <input type="text" id="dap-rwth-host" class="form-input" placeholder="dapnet.afu.rwth-aachen.de">
+            <label style="color:var(--muted);font-size:13px">RWTH port</label>
+            <input type="number" id="dap-rwth-port" class="form-input" min="1" max="65535" placeholder="43434">
+
+            <label style="color:var(--muted);font-size:13px">Device</label>
+            <input type="text" id="dap-rwth-device" class="form-input" placeholder="FlowStation">
+            <label style="color:var(--muted);font-size:13px">Version</label>
+            <input type="text" id="dap-rwth-version" class="form-input" placeholder="1.0">
+
+            <label style="color:var(--muted);font-size:13px">RWTH callsign</label>
+            <input type="text" id="dap-rwth-callsign" class="form-input" autocomplete="off" spellcheck="false" style="text-transform:uppercase">
+            <label style="color:var(--muted);font-size:13px">RWTH authkey</label>
+            <input type="password" id="dap-rwth-authkey" class="form-input" autocomplete="new-password" spellcheck="false" oninput="dapAuthDirty=true">
+          </div>
+          <div class="config-msg" id="dap-msg"></div>
+        </div>
+      </div>
+
+      <div class="card">
+        <div class="card-head">
+          <div class="card-title" data-i18n="dapnet_routing">Routing</div>
+          <div class="card-actions">
+            <button class="btn btn-primary" onclick="saveDapnet()" data-i18n="save">Save</button>
+          </div>
+        </div>
+        <div class="card-body">
+          <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(260px,1fr));gap:14px">
+            <div>
+              <label class="sw-row"><span class="sw-text">Forward to SDS</span><span class="sw"><input type="checkbox" id="dap-forward-sds"><i></i></span></label>
+              <div style="display:grid;grid-template-columns:130px 1fr;gap:10px;align-items:center;margin-top:10px">
+                <label style="color:var(--muted);font-size:13px">Source ISSI</label>
+                <input type="number" id="dap-sds-source" class="form-input" min="1" max="16777215" placeholder="9999">
+                <label style="color:var(--muted);font-size:13px">Destination</label>
+                <input type="number" id="dap-sds-dest" class="form-input" min="0" max="16777215" placeholder="ISSI or GSSI">
+                <label style="color:var(--muted);font-size:13px">Destination is group</label>
+                <label style="display:flex;align-items:center;gap:10px"><span class="sw"><input type="checkbox" id="dap-sds-group"><i></i></span><span style="color:var(--muted);font-size:12px">GSSI</span></label>
+                <label style="color:var(--muted);font-size:13px;align-self:flex-start;padding-top:8px">RIC → ISSI</label>
+                <textarea id="dap-ric-routes" class="form-input" rows="3" placeholder="0632585=2632585"></textarea>
+                <label style="color:var(--muted);font-size:13px;align-self:flex-start;padding-top:8px">RIC → GSSI</label>
+                <textarea id="dap-ric-group-routes" class="form-input" rows="3" placeholder="0004520=80"></textarea>
+                <label style="color:var(--muted);font-size:13px;align-self:flex-start;padding-top:8px">SDS RIC filter</label>
+                <textarea id="dap-sds-rics" class="form-input" rows="3" placeholder="0004520&#10;0000200"></textarea>
+              </div>
+            </div>
+
+            <div>
+              <label class="sw-row"><span class="sw-text">Forward to TPG2200 Call-Out</span><span class="sw"><input type="checkbox" id="dap-forward-callout"><i></i></span></label>
+              <div style="display:grid;grid-template-columns:130px 1fr;gap:10px;align-items:center;margin-top:10px">
+                <label style="color:var(--muted);font-size:13px">Source ISSI</label>
+                <input type="number" id="dap-callout-source" class="form-input" min="1" max="16777215" placeholder="9999">
+                <label style="color:var(--muted);font-size:13px">Destination</label>
+                <input type="number" id="dap-callout-dest" class="form-input" min="0" max="16777215" placeholder="TPG2200 ISSI">
+                <label style="color:var(--muted);font-size:13px">Incident base</label>
+                <input type="number" id="dap-callout-incident" class="form-input" min="1" max="256" placeholder="2">
+                <label style="color:var(--muted);font-size:13px">Text prefix</label>
+                <input type="text" id="dap-callout-prefix" class="form-input" placeholder="DAPNET">
+                <label style="color:var(--muted);font-size:13px;align-self:flex-start;padding-top:8px">Call-Out RIC filter</label>
+                <textarea id="dap-callout-rics" class="form-input" rows="3" placeholder="0004520"></textarea>
+              </div>
+            </div>
+
+            <div>
+              <label class="sw-row"><span class="sw-text">Forward to Telegram</span><span class="sw"><input type="checkbox" id="dap-forward-telegram"><i></i></span></label>
+              <div style="display:grid;grid-template-columns:130px 1fr;gap:10px;align-items:center;margin-top:10px">
+                <label style="color:var(--muted);font-size:13px">Telegram prefix</label>
+                <input type="text" id="dap-telegram-prefix" class="form-input" placeholder="DAPNET">
+                <label style="color:var(--muted);font-size:13px;align-self:flex-start;padding-top:8px">Telegram RIC filter</label>
+                <textarea id="dap-telegram-rics" class="form-input" rows="3" placeholder="0004520"></textarea>
+              </div>
+              <div class="help-text" style="margin-top:10px">Uses the existing Telegram alert configuration and recipients.</div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div class="card">
+        <div class="card-head">
+          <div class="card-title" data-i18n="dapnet_send">Send DAPNET Message</div>
+          <div class="card-actions">
+            <button class="btn btn-primary" onclick="sendDapnetMessage()">Send</button>
+          </div>
+        </div>
+        <div class="card-body">
+          <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(190px,1fr));gap:10px;align-items:center">
+            <label style="color:var(--muted);font-size:13px">Callsign recipients</label>
+            <input type="text" id="dap-out-callsigns" class="form-input" placeholder="DJ2TH, DB0ABC">
+            <label style="color:var(--muted);font-size:13px">Transmitter groups</label>
+            <input type="text" id="dap-out-groups" class="form-input" placeholder="dl-all, regional">
+            <label style="color:var(--muted);font-size:13px">Emergency</label>
+            <label style="display:flex;align-items:center;gap:10px"><span class="sw"><input type="checkbox" id="dap-out-emergency"><i></i></span><span style="color:var(--muted);font-size:12px">Set emergency flag</span></label>
+            <label style="color:var(--muted);font-size:13px;align-self:flex-start;padding-top:8px">Message</label>
+            <textarea id="dap-out-text" class="form-input" rows="3" maxlength="80" placeholder="Message text"></textarea>
+          </div>
+          <div class="config-msg" id="dap-send-msg"></div>
+        </div>
+      </div>
+    </div>
+
+    <!-- ── GEOALARM ── -->
+    <div class="page" id="page-geoalarm">
+      <div class="card">
+        <div class="card-head">
+          <div class="card-title" data-i18n="geoalarm_title">GeoAlarm</div>
+          <div class="card-actions">
+            <button class="btn btn-sm" onclick="loadGeoalarm()" data-i18n="refresh">⟳ Refresh</button>
+            <button class="btn btn-primary" onclick="saveGeoalarm()" data-i18n="save">Save</button>
+          </div>
+        </div>
+        <div class="card-body">
+          <div class="stat-grid" style="margin-bottom:14px">
+            <div class="stat-card">
+              <div class="stat-label">Positions</div>
+              <div class="stat-value" id="geo-seen">0</div>
+              <div class="stat-sub" id="geo-center">—</div>
+            </div>
+            <div class="stat-card blue">
+              <div class="stat-label">Alarms</div>
+              <div class="stat-value blue" id="geo-alarms">0</div>
+              <div class="stat-sub" id="geo-radius">—</div>
+            </div>
+          </div>
+          <div class="info-grid" style="margin-bottom:14px">
+            <div class="info-row"><div class="info-key">Last position</div><div class="info-val" id="geo-last-position">—</div></div>
+            <div class="info-row"><div class="info-key">Last alarm</div><div class="info-val" id="geo-last-alarm">—</div></div>
+            <div class="info-row"><div class="info-key">Last error</div><div class="info-val" id="geo-last-error">—</div></div>
+          </div>
+
+          <label class="sw-row">
+            <span class="sw-text">Enable GeoAlarm</span>
+            <span class="sw"><input type="checkbox" id="geo-enabled"><i></i></span>
+          </label>
+          <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(190px,1fr));gap:10px;align-items:center;margin-top:14px">
+            <label style="color:var(--muted);font-size:13px">FlowStation latitude</label>
+            <input type="number" id="geo-lat" class="form-input" step="0.000001" min="-90" max="90" placeholder="50.775346">
+            <label style="color:var(--muted);font-size:13px">FlowStation longitude</label>
+            <input type="number" id="geo-lon" class="form-input" step="0.000001" min="-180" max="180" placeholder="6.083887">
+            <label style="color:var(--muted);font-size:13px">Radius / cooldown</label>
+            <div style="display:grid;grid-template-columns:1fr 1fr;gap:8px">
+              <input type="number" id="geo-radius-m" class="form-input" min="1" step="1" placeholder="500">
+              <input type="number" id="geo-cooldown" class="form-input" min="1" max="86400" placeholder="300">
+            </div>
+            <label style="color:var(--muted);font-size:13px">Input sources</label>
+            <div style="display:flex;gap:14px;flex-wrap:wrap">
+              <label style="display:flex;align-items:center;gap:8px"><span class="sw"><input type="checkbox" id="geo-trigger-tetra"><i></i></span><span style="color:var(--muted);font-size:12px">TETRA LIP</span></label>
+              <label style="display:flex;align-items:center;gap:8px"><span class="sw"><input type="checkbox" id="geo-trigger-meshcom"><i></i></span><span style="color:var(--muted);font-size:12px">MeshCom</span></label>
+            </div>
+          </div>
+          <div class="help-text" style="margin-top:10px">GeoAlarm fires when an allowed device enters the radius, then suppresses repeated alarms for the cooldown time.</div>
+          <div class="config-msg" id="geo-msg"></div>
+        </div>
+      </div>
+
+      <div class="card">
+        <div class="card-head">
+          <div class="card-title">GeoAlarm Routing</div>
+        </div>
+        <div class="card-body">
+          <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(280px,1fr));gap:14px">
+            <div>
+              <label class="sw-row">
+                <span class="sw-text">Alarm → TPG2200</span>
+                <span class="sw"><input type="checkbox" id="geo-forward-tpg"><i></i></span>
+              </label>
+              <div style="display:grid;grid-template-columns:1fr 1fr;gap:8px;margin-top:10px">
+                <input type="number" id="geo-tpg-source" class="form-input" min="1" max="16777215" placeholder="Source ISSI">
+                <input type="number" id="geo-tpg-dest" class="form-input" min="0" max="16777215" placeholder="TPG ISSI">
+              </div>
+              <div style="display:grid;grid-template-columns:1fr 1fr;gap:8px;margin-top:10px">
+                <input type="number" id="geo-tpg-incident" class="form-input" min="1" max="256" placeholder="Incident base">
+                <input type="number" id="geo-tpg-max" class="form-input" min="8" max="160" placeholder="Max chars">
+              </div>
+              <input type="text" id="geo-tpg-prefix" class="form-input" placeholder="TPG text prefix" style="margin-top:10px">
+            </div>
+            <div>
+              <label class="sw-row">
+                <span class="sw-text">Alarm → SDS</span>
+                <span class="sw"><input type="checkbox" id="geo-forward-sds"><i></i></span>
+              </label>
+              <div style="display:grid;grid-template-columns:1fr 1fr;gap:8px;margin-top:10px">
+                <input type="number" id="geo-sds-source" class="form-input" min="1" max="16777215" placeholder="Source ISSI">
+                <input type="number" id="geo-sds-dest" class="form-input" min="0" max="16777215" placeholder="Destination ISSI/GSSI">
+              </div>
+              <label style="display:flex;align-items:center;gap:10px;margin-top:10px"><span class="sw"><input type="checkbox" id="geo-sds-group"><i></i></span><span style="color:var(--muted);font-size:12px">Destination is group/GSSI</span></label>
+            </div>
+            <div>
+              <label class="sw-row">
+                <span class="sw-text">Alarm → SIP/Snom</span>
+                <span class="sw"><input type="checkbox" id="geo-forward-sip"><i></i></span>
+              </label>
+              <input type="text" id="geo-sip-prefix" class="form-input" placeholder="Snom title prefix" style="margin-top:10px">
+              <label class="sw-row" style="margin-top:14px">
+                <span class="sw-text">Alarm → Telegram</span>
+                <span class="sw"><input type="checkbox" id="geo-forward-telegram"><i></i></span>
+              </label>
+              <input type="text" id="geo-telegram-prefix" class="form-input" placeholder="Telegram prefix" style="margin-top:10px">
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div class="card">
+        <div class="card-head">
+          <div class="card-title">GeoAlarm Filters</div>
+        </div>
+        <div class="card-body">
+          <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(260px,1fr));gap:14px">
+            <div>
+              <label style="color:var(--muted);font-size:13px">TETRA ISSI whitelist</label>
+              <textarea id="geo-tetra-white" class="form-input" rows="4" placeholder="empty = all TETRA ISSIs"></textarea>
+            </div>
+            <div>
+              <label style="color:var(--muted);font-size:13px">TETRA ISSI blacklist</label>
+              <textarea id="geo-tetra-black" class="form-input" rows="4" placeholder="blocked ISSIs"></textarea>
+            </div>
+            <div>
+              <label style="color:var(--muted);font-size:13px">MeshCom source whitelist</label>
+              <textarea id="geo-mesh-white" class="form-input" rows="4" placeholder="empty = all MeshCom sources"></textarea>
+            </div>
+            <div>
+              <label style="color:var(--muted);font-size:13px">MeshCom source blacklist</label>
+              <textarea id="geo-mesh-black" class="form-input" rows="4" placeholder="blocked MeshCom sources"></textarea>
+            </div>
+          </div>
+          <div class="help-text" style="margin-top:10px">Whitelist empty means allow all. Blacklists always win. MeshCom source matching is case-insensitive.</div>
+        </div>
+      </div>
+
+      <div class="card">
+        <div class="card-head">
+          <div class="card-title">GeoAlarm Events</div>
+        </div>
+        <div class="card-body">
+          <div class="table-wrap">
+            <table>
+              <thead><tr>
+                <th data-i18n="th_time">Time</th>
+                <th>Source</th>
+                <th>Device</th>
+                <th>Distance</th>
+                <th>Position</th>
+                <th>Status</th>
+                <th>Paths</th>
+              </tr></thead>
+              <tbody id="geo-events-tbody"></tbody>
+            </table>
+          </div>
+          <div class="log-controls">
+            <button class="btn btn-sm" onclick="geoPrevPage()">‹ Prev</button>
+            <span class="sds-empty" id="geo-events-page">Page 1 / 1</span>
+            <button class="btn btn-sm" onclick="geoNextPage()">Next ›</button>
+          </div>
+        </div>
+      </div>
     </div>
 
     <!-- ── CONFIG ── -->
@@ -2636,6 +3074,10 @@ tbody tr:hover td{background:color-mix(in srgb,var(--bg3) 70%, transparent);}
           </div>
         </div>
         <div id="health-grid" style="display:grid;grid-template-columns:repeat(auto-fill,minmax(330px,1fr));gap:14px"></div>
+        <div style="margin-top:18px;font-size:13px;font-weight:700;color:var(--text);letter-spacing:.04em;text-transform:uppercase">Integrations</div>
+        <div id="health-integrations-grid" style="display:grid;grid-template-columns:repeat(auto-fill,minmax(330px,1fr));gap:14px;margin-top:10px">
+          <div class="sds-empty" style="padding:12px 0">Loading integration health…</div>
+        </div>
         <div style="margin-top:16px;font-size:12px;color:var(--text2,#9aa4b2);line-height:1.6">
           Auto-refreshes every few seconds. Levels:
           <b style="color:#3fb950">OK</b> · <b style="color:var(--warn)">DEGRADED</b> · <b style="color:var(--danger)">CRITICAL</b>.
@@ -2824,6 +3266,33 @@ tbody tr:hover td{background:color-mix(in srgb,var(--bg3) 70%, transparent);}
       <label class="form-label" data-i18n="sds_msg_label">Message</label>
       <input type="text" id="sds-msg" class="form-input" placeholder="..." maxlength="160">
     </div>
+    <div class="form-row">
+      <label class="form-label" style="display:flex;align-items:center;gap:8px">
+        <input type="checkbox" id="sds-callout" onchange="toggleSdsCallout()">
+        <span data-i18n="sds_callout_enable">TPG2200 Call-Out / Alarm senden</span>
+      </label>
+    </div>
+    <div id="sds-callout-fields" style="display:none">
+      <div class="form-row">
+        <label class="form-label" data-i18n="sds_callout_source">Source ISSI</label>
+        <input type="number" id="sds-callout-source" class="form-input" value="9999" min="1">
+      </div>
+      <div class="form-row">
+        <label class="form-label" data-i18n="sds_callout_incident">Vorfallnummer</label>
+        <input type="number" id="sds-callout-incident" class="form-input" value="1" min="1" max="256">
+      </div>
+      <div class="form-row">
+        <label class="form-label" data-i18n="sds_callout_text">Alarmtext</label>
+        <input type="text" id="sds-callout-text" class="form-input" value="ALARM" maxlength="120">
+      </div>
+      <div class="form-row">
+        <label class="form-label" data-i18n="sds_callout_raw">Raw Hex Payload optional</label>
+        <input type="text" id="sds-callout-raw" class="form-input" placeholder="C3 00 09 0D 10 11 27 0F 02 30 8D 41 4C 41 52 4D">
+      </div>
+      <div class="form-row" style="font-size:12px;color:var(--muted);line-height:1.45" data-i18n="sds_callout_help">
+        Vorfall 1-15 use the confirmed byte formula (N &lt;&lt; 4) | 0x01: 1=11, 2=21, 3=31, 4=41. Vorfall 16-256 use the extended one-byte selector. Raw Hex overrides automatic payload generation.
+      </div>
+    </div>
     <div class="modal-actions">
       <button class="btn" onclick="closeSdsModal()" data-i18n="cancel">Cancel</button>
       <button class="btn btn-primary" onclick="sendSds()" data-i18n="send">Send</button>
@@ -2873,7 +3342,7 @@ const LANGS={
   en:{
     bts_ip:'BTS IP',offline:'OFFLINE',online:'ONLINE',
     brew_online:'ONLINE',brew_offline:'OFFLINE',
-    stations:'Radios',calls:'Calls',lastheard:'Last Heard',log:'Log',rf:'RF',config:'Config',
+    stations:'Radios',calls:'Calls',lastheard:'Last Heard',log:'Log',rf:'RF',health:'Health',asterisk:'Asterisk SIP',dapnet:'DAPNET',echolink:'EchoLink',echolink_title:'EchoLink',meshcom:'MeshCom',meshcom_title:'MeshCom',geoalarm:'GeoAlarm',geoalarm_title:'GeoAlarm',config:'Config',
     sdslog:'SDS Log',th_dir:'Dir',th_from:'From',th_to:'To',th_message:'Message',no_sds:'No SDS messages yet',sds_refresh:'⟳ Refresh',
     rf_freq:'Center freq',rf_rate:'Sample rate',rf_rms:'RMS',rf_peak:'Peak',rf_age:'Snapshot',
     rf_waiting:'waiting…',rf_live:'live',rf_stale:'stale',
@@ -2888,6 +3357,10 @@ const LANGS={
     rf_temp_cold:'cold',rf_temp_nominal:'nominal',rf_temp_warm:'warm',rf_temp_hot:'hot',rf_temp_na:'no sensor',
     rf_no_gains:'unavailable',rf_just_now:'just now',
 
+    asterisk_title:'Asterisk SIP',ast_configured:'Configured',ast_register:'REGISTER',ast_sip_listen:'SIP listen',
+    ast_remote:'Remote Asterisk',ast_rtp:'RTP ports',ast_codec:'Codec',ast_last_rx:'Last RX',
+    ast_last_tx:'Last TX',ast_last_error:'Last error',
+    dapnet_title:'DAPNET',dapnet_log:'DAPNET Log',dapnet_routing:'Routing',dapnet_send:'Send DAPNET Message',dapnet_saved:'✓ Saved',
     terminals:'Radios',registered:'registered',
     active_calls:'Active Calls',circuits:'circuits in use',
     registered_terminals:'Registered Radios',
@@ -2906,6 +3379,12 @@ const LANGS={
     wx_periodic_icao:'Station ICAO',wx_periodic_dest:'Destination',wx_periodic_isgroup:'Destination is group',wx_periodic_isgroup_hint:'(GSSI instead of individual ISSI)',
     wx_periodic_interval:'Interval (seconds)',wx_interval_hint:'Minimum 300 s (5 min) to avoid hammering the weather API.',wx_periodic_incomplete:'Set both station ICAO and destination for periodic mode.',
     sds_title:'⬡ Send SDS Message',sds_dest:'Destination ISSI',
+    sds_callout_enable:'TPG2200 Call-Out / Send alarm',
+    sds_callout_source:'Source ISSI',
+    sds_callout_incident:'Incident number',
+    sds_callout_text:'Alarm text',
+    sds_callout_raw:'Raw Hex Payload optional',
+    sds_callout_help:'Incidents 1-15 use the confirmed byte formula (N << 4) | 0x01: 1=11, 2=21, 3=31, 4=41. Incidents 16-256 use the extended one-byte selector. Raw Hex overrides automatic payload generation.',
     live_sds_desc:'Broadcast a text message to all radios on the cell, repeating at the Home Mode Display interval. Repeats until deleted or the repeat count is reached.',
     live_sds_text:'Message text (max 251 chars)',live_sds_repeat:'Repeat (0=∞)',live_sds_send:'📢 Broadcast',
     live_sds_clear_all:'Clear All',live_sds_empty:'No active broadcasts.',
@@ -2973,7 +3452,7 @@ const LANGS={
   ro:{
     bts_ip:'IP BTS',offline:'DECONECTAT',online:'CONECTAT',
     brew_online:'ONLINE',brew_offline:'OFFLINE',
-    stations:'Radiouri',calls:'Apeluri',lastheard:'Ultima Activitate',log:'Log',rf:'RF',config:'Config',
+    stations:'Radiouri',calls:'Apeluri',lastheard:'Ultima Activitate',log:'Log',rf:'RF',health:'Health',echolink:'EchoLink',echolink_title:'EchoLink',config:'Config',
     sdslog:'Jurnal SDS',th_dir:'Dir',th_from:'De la',th_to:'Către',th_message:'Mesaj',no_sds:'Niciun mesaj SDS încă',sds_refresh:'⟳ Reîmprospătează',
     rf_freq:'Frecvență centru',rf_rate:'Rată eșantion',rf_rms:'RMS',rf_peak:'Vârf',rf_age:'Captură',
     rf_waiting:'în așteptare…',rf_live:'live',rf_stale:'expirat',
@@ -3072,7 +3551,7 @@ const LANGS={
   de:{
     bts_ip:'BTS-IP',offline:'OFFLINE',online:'ONLINE',
     brew_online:'ONLINE',brew_offline:'OFFLINE',
-    stations:'Radios',calls:'Anrufe',lastheard:'Zuletzt Gehört',log:'Log',rf:'RF',config:'Config',
+    stations:'Radios',calls:'Anrufe',lastheard:'Zuletzt Gehört',log:'Log',rf:'RF',health:'Health',asterisk:'Asterisk SIP',dapnet:'DAPNET',echolink:'EchoLink',echolink_title:'EchoLink',meshcom:'MeshCom',meshcom_title:'MeshCom',geoalarm:'GeoAlarm',geoalarm_title:'GeoAlarm',config:'Config',
     sdslog:'SDS-Log',th_dir:'Ri.',th_from:'Von',th_to:'An',th_message:'Nachricht',no_sds:'Noch keine SDS-Nachrichten',sds_refresh:'⟳ Aktualisieren',
     rf_freq:'Mittenfrequenz',rf_rate:'Abtastrate',rf_rms:'RMS',rf_peak:'Spitze',rf_age:'Aufnahme',
     rf_waiting:'wartet…',rf_live:'live',rf_stale:'veraltet',
@@ -3087,6 +3566,10 @@ const LANGS={
     rf_temp_cold:'kalt',rf_temp_nominal:'nominal',rf_temp_warm:'warm',rf_temp_hot:'heiß',rf_temp_na:'kein Sensor',
     rf_no_gains:'nicht verfügbar',rf_just_now:'gerade eben',
 
+    asterisk_title:'Asterisk SIP',ast_configured:'Konfiguriert',ast_register:'REGISTER',ast_sip_listen:'SIP hört auf',
+    ast_remote:'Remote Asterisk',ast_rtp:'RTP-Ports',ast_codec:'Codec',ast_last_rx:'Letztes RX',
+    ast_last_tx:'Letztes TX',ast_last_error:'Letzter Fehler',
+    dapnet_title:'DAPNET',dapnet_log:'DAPNET-Log',dapnet_routing:'Routing',dapnet_send:'DAPNET-Nachricht senden',dapnet_saved:'✓ Gespeichert',
     terminals:'Radios',registered:'registriert',
     active_calls:'Aktive Anrufe',circuits:'Schaltkreise aktiv',
     registered_terminals:'Registrierte Radios',
@@ -3106,6 +3589,12 @@ const LANGS={
     live_sds_sent:'gesendet',live_sds_times:'×',live_sds_forever:'∞',live_sds_delete:'✕',
     fallback_title:'⚠ FALLBACK-KONFIGURATION AKTIV — Primäre Konfiguration konnte nicht geladen werden',
     sds_title:'⬡ SDS-Nachricht senden',sds_dest:'Ziel-ISSI',
+    sds_callout_enable:'TPG2200 Call-Out / Alarm senden',
+    sds_callout_source:'Source ISSI',
+    sds_callout_incident:'Vorfallnummer',
+    sds_callout_text:'Alarmtext',
+    sds_callout_raw:'Raw Hex Payload optional',
+    sds_callout_help:'Vorfall 1-15 nutzen die bestätigte Byte-Formel (N << 4) | 0x01: 1=11, 2=21, 3=31, 4=41. Vorfall 16-256 nutzen den erweiterten Ein-Byte-Selector. Raw Hex überschreibt die automatische Payload.',
     sds_msg_label:'Nachricht',cancel:'Abbrechen',send:'Senden',
     th_issi:'ISSI',th_groups:'Gruppen',th_ee:'Energiesparen',th_signal:'Signal',
     th_status:'Status',th_last_seen:'Zuletzt',th_actions:'Aktionen',
@@ -3143,7 +3632,7 @@ const LANGS={
   es:{
     bts_ip:'IP BTS',offline:'SIN CONEXIÓN',online:'EN LÍNEA',
     brew_online:'EN LÍNEA',brew_offline:'SIN CONEXIÓN',
-    stations:'Radios',calls:'Llamadas',lastheard:'Última Actividad',log:'Log',rf:'RF',config:'Config',
+    stations:'Radios',calls:'Llamadas',lastheard:'Última Actividad',log:'Log',rf:'RF',health:'Health',echolink:'EchoLink',echolink_title:'EchoLink',config:'Config',
     sdslog:'Registro SDS',th_dir:'Dir',th_from:'De',th_to:'Para',th_message:'Mensaje',no_sds:'Aún no hay mensajes SDS',sds_refresh:'⟳ Actualizar',
     rf_freq:'Frecuencia central',rf_rate:'Tasa de muestreo',rf_rms:'RMS',rf_peak:'Pico',rf_age:'Captura',
     rf_waiting:'esperando…',rf_live:'en vivo',rf_stale:'obsoleto',
@@ -3214,7 +3703,7 @@ const LANGS={
   hu:{
     bts_ip:'BTS IP',offline:'OFFLINE',online:'ONLINE',
     brew_online:'ONLINE',brew_offline:'OFFLINE',
-    stations:'Rádiók',calls:'Hívások',lastheard:'Utoljára Hallott',log:'Napló',rf:'RF',config:'Konfig',
+    stations:'Rádiók',calls:'Hívások',lastheard:'Utoljára Hallott',log:'Napló',rf:'RF',health:'Health',echolink:'EchoLink',echolink_title:'EchoLink',config:'Konfig',
     sdslog:'SDS Napló',th_dir:'Irány',th_from:'Feladó',th_to:'Címzett',th_message:'Üzenet',no_sds:'Még nincs SDS üzenet',sds_refresh:'⟳ Frissítés',
     rf_freq:'Központi frekvencia',rf_rate:'Mintavételezési ráta',rf_rms:'RMS',rf_peak:'Csúcs',rf_age:'Pillanatkép',
     rf_waiting:'várakozás…',rf_live:'élő',rf_stale:'elavult',
@@ -3277,7 +3766,7 @@ const LANGS={
   zh:{
     bts_ip:'BTS IP',offline:'离线',online:'在线',
     brew_online:'在线',brew_offline:'离线',
-    stations:'终端',calls:'通话',lastheard:'最近通话',log:'日志',rf:'RF',config:'配置',
+    stations:'终端',calls:'通话',lastheard:'最近通话',log:'日志',rf:'RF',health:'Health',echolink:'EchoLink',echolink_title:'EchoLink',config:'配置',
     sdslog:'SDS日志',th_dir:'方向',th_from:'发件',th_to:'收件',th_message:'消息',no_sds:'暂无SDS消息',sds_refresh:'⟳ 刷新',
     rf_freq:'中心频率',rf_rate:'采样率',rf_rms:'RMS',rf_peak:'峰值',rf_age:'快照',
     rf_waiting:'等待中…',rf_live:'实时',rf_stale:'已过期',
@@ -3442,7 +3931,7 @@ function closeMobileSidebar(){
 }
 
 // ── Page navigation ───────────────────────────────────────────────────────
-const PAGE_TITLES={stations:'stations',calls:'calls',lastheard:'lastheard',log:'log',sdslog:'sdslog',rf:'rf',config:'config',system:'system'};
+const PAGE_TITLES={stations:'stations',calls:'calls',lastheard:'lastheard',log:'log',sdslog:'sdslog',rf:'rf',health:'health',asterisk:'asterisk',dapnet:'dapnet',echolink:'echolink',meshcom:'meshcom',geoalarm:'geoalarm',config:'config',system:'system'};
 function showPage(name,el){
   document.querySelectorAll('.page').forEach(p=>p.classList.remove('active'));
   document.querySelectorAll('.nav-item').forEach(n=>n.classList.remove('active'));
@@ -3452,6 +3941,10 @@ function showPage(name,el){
   document.getElementById('topbar-title').textContent=t(name)||name;
   if(name==='stations'){loadBtsInfo();}
   if(name==='sdslog'){loadSdsLog();}
+  if(name==='health'){loadHealthIntegrations();}
+  if(name==='asterisk'){loadAsteriskStatus();loadSnomNotify();}
+  if(name==='dapnet'){loadDapnet();loadDapnetLog();}
+  if(name==='geoalarm'){loadGeoalarm();}
   if(name==='config'){loadConfig();loadWhitelist();loadWx();}
   if(name==='telegram'){loadTelegram();}
   if(name==='system'){loadSystemInfo();loadConfigProfiles();loadLiveSds();loadBrightness();}
@@ -3772,7 +4265,7 @@ async function wifiCall(url, body){
 function escAttr(s){ return String(s).replace(/&/g,'&amp;').replace(/'/g,"&#39;").replace(/"/g,'&quot;'); }
 
 // ── State + WS ────────────────────────────────────────────────────────────
-let ws=null,state={ms:{},calls:{},emergencies:{},lastHeard:[],sdsLog:[],brewOnline:false,brewVer:0},sdsDest=0;
+let ws=null,state={ms:{},calls:{},emergencies:{},lastHeard:[],sdsLog:[],dapnetLog:[],geoalarmEvents:[],brewOnline:false,brewVer:0},sdsDest=0;
 
 // ── RadioID callsigns (indicativ) ──────────────────────────────────────────────
 // issi -> {cs:"CALLSIGN", fl:"🇷🇴"} (found; fl is the country flag emoji from the prefix, or "")
@@ -3977,6 +4470,11 @@ function handleMsg(msg){
       state.sdsLog.unshift({ts:nowStamp(),direction:msg.direction,source_issi:msg.source_issi,dest_issi:msg.dest_issi,is_group:msg.is_group,protocol_id:msg.protocol_id,text:msg.text});
       if(state.sdsLog.length>500)state.sdsLog.pop();
       renderSdsLog();refreshCallsigns();break;
+    case 'dapnet_log':
+      if(!state.dapnetLog)state.dapnetLog=[];
+      state.dapnetLog.unshift({ts:nowStamp(),direction:msg.direction,id:msg.id,callsign:msg.callsign,recipient:msg.recipient,text:msg.text,priority:msg.priority,paths:msg.paths||[]});
+      if(state.dapnetLog.length>500)state.dapnetLog.pop();
+      renderDapnetLog();break;
     case 'tx_visual':handleTxVisual(msg);break;
     case 'tx_quality':handleTxQuality(msg);break;
     case 'sdr_health':handleSdrHealth(msg);break;
@@ -4259,25 +4757,457 @@ function _p2(n){return String(n).padStart(2,'0');}
 // Local "YYYY-MM-DD HH:MM:SS" stamp matching the server's persisted format. Used only for
 // live rows arriving over the WS; rows fetched from /api/sds-log already carry a server stamp.
 function nowStamp(){const d=new Date();return `${d.getFullYear()}-${_p2(d.getMonth()+1)}-${_p2(d.getDate())} ${_p2(d.getHours())}:${_p2(d.getMinutes())}:${_p2(d.getSeconds())}`;}
+const LOG_PAGE_SIZE=50;
+let sdsLogPageIndex=0,dapnetLogPageIndex=0,geoalarmPageIndex=0;
+function setLogPager(id,page,total){
+  const el=document.getElementById(id);if(!el)return;
+  if(!total){el.textContent='Page 0 / 0 · 0';return;}
+  const pages=Math.max(1,Math.ceil(total/LOG_PAGE_SIZE));
+  el.textContent=`Page ${page+1} / ${pages} · ${total}`;
+}
+function clampLogPage(page,total){
+  const pages=Math.max(1,Math.ceil(total/LOG_PAGE_SIZE));
+  return Math.max(0,Math.min(page,pages-1));
+}
+function logExportStamp(){
+  const d=new Date();
+  return `${d.getFullYear()}${_p2(d.getMonth()+1)}${_p2(d.getDate())}-${_p2(d.getHours())}${_p2(d.getMinutes())}${_p2(d.getSeconds())}`;
+}
+function logExportCell(v){
+  return String(v??'').replace(/\r?\n/g,' ').replace(/\t/g,' ').trim();
+}
+function downloadTextFile(filename,text){
+  const blob=new Blob([text],{type:'text/plain;charset=utf-8'});
+  const a=document.createElement('a');
+  a.href=URL.createObjectURL(blob);
+  a.download=filename;
+  document.body.appendChild(a);a.click();
+  setTimeout(()=>{URL.revokeObjectURL(a.href);a.remove();},0);
+}
 // Human label for known SDS protocol-identifier bytes so binary payloads (no decoded text)
 // still read meaningfully. 0x02/0x09/0x82/0x89 = text; 0x0A = LIP position; 0xDC = Home Mode Display.
 function pidLabel(pid){const m={2:'text',9:'text',10:'LIP position',12:'concat',128:'text',130:'text',137:'text',218:'status',220:'home-display'};return m[pid]||('PID '+pid);}
 const SDS_DIR={rx:['badge-green','RX'],net:['badge-blue','NET'],tx:['badge-yellow','TX']};
 function dirBadge(dir){const x=SDS_DIR[dir]||['badge-dim',(dir||'?').toUpperCase()];return `<span class="badge ${x[0]}">${x[1]}</span>`;}
+function lipPositionFromText(text){
+  const m=String(text||'').match(/^LIP position:\s*(-?\d+(?:\.\d+)?),\s*(-?\d+(?:\.\d+)?)/);
+  if(!m)return null;
+  const lat=Number(m[1]),lon=Number(m[2]);
+  if(!Number.isFinite(lat)||!Number.isFinite(lon)||lat<-90||lat>90||lon<-180||lon>180)return null;
+  return {lat,lon};
+}
+function sdsMessageBody(e){
+  if(e.text&&e.text.length){
+    const lip=lipPositionFromText(e.text);
+    if(lip){
+      const label=`LIP position: ${lip.lat.toFixed(6)}, ${lip.lon.toFixed(6)}`;
+      const url=`https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(`${lip.lat.toFixed(6)},${lip.lon.toFixed(6)}`)}`;
+      return `<a class="sds-map-link" href="${url}" target="_blank" rel="noopener noreferrer">${escHtml(label)}</a>`;
+    }
+    return escHtml(e.text);
+  }
+  return `<span class="sds-empty">[${escHtml(pidLabel(e.protocol_id))}]</span>`;
+}
 function sdsRow(e){
   const to=e.is_group?`<code>${e.dest_issi}</code> <span class="sds-empty">grp</span>`:idCell(e.dest_issi);
-  const body=(e.text&&e.text.length)?escHtml(e.text):`<span class="sds-empty">[${escHtml(pidLabel(e.protocol_id))}]</span>`;
+  const body=sdsMessageBody(e);
   return `<tr><td class="sds-time">${escHtml(e.ts||'')}</td><td>${dirBadge(e.direction)}</td><td>${idCell(e.source_issi)}</td><td>${to}</td><td class="sds-msg">${body}</td></tr>`;
 }
 function renderSdsLog(){
   const tb=document.getElementById('sdslog-tbody');if(!tb)return;
   const rows=state.sdsLog||[];
+  sdsLogPageIndex=clampLogPage(sdsLogPageIndex,rows.length);
+  setLogPager('sdslog-page',sdsLogPageIndex,rows.length);
   if(!rows.length){tb.innerHTML=`<tr><td colspan="5" class="sds-empty" style="text-align:center;padding:24px">${t('no_sds')}</td></tr>`;return;}
-  tb.innerHTML=rows.map(sdsRow).join('');
+  const start=sdsLogPageIndex*LOG_PAGE_SIZE;
+  tb.innerHTML=rows.slice(start,start+LOG_PAGE_SIZE).map(sdsRow).join('');
 }
 async function loadSdsLog(){
-  try{const r=await fetch('/api/sds-log');if(!r.ok)return;state.sdsLog=await r.json();renderSdsLog();refreshCallsigns();}catch{}
+  try{const r=await fetch('/api/sds-log');if(!r.ok)return;state.sdsLog=await r.json();sdsLogPageIndex=0;renderSdsLog();refreshCallsigns();}catch{}
 }
+function sdsLogPrevPage(){sdsLogPageIndex--;renderSdsLog();}
+function sdsLogNextPage(){sdsLogPageIndex++;renderSdsLog();}
+async function clearSdsLog(){
+  if(!confirm('Clear SDS Log?'))return;
+  try{const r=await fetch('/api/sds-log',{method:'DELETE'});if(!r.ok)return;state.sdsLog=[];sdsLogPageIndex=0;renderSdsLog();}catch{}
+}
+function exportSdsLog(){
+  const rows=state.sdsLog||[];
+  if(!rows.length)return;
+  const lines=['TIME\tDIR\tFROM\tTO\tGROUP\tPID\tMESSAGE'];
+  for(const e of rows){
+    lines.push([
+      e.ts||'',
+      (e.direction||'').toUpperCase(),
+      e.source_issi||'',
+      e.dest_issi||'',
+      e.is_group?'yes':'no',
+      e.protocol_id??'',
+      logExportCell(e.text||pidLabel(e.protocol_id))
+    ].map(logExportCell).join('\t'));
+  }
+  downloadTextFile(`flowstation-sds-log-${logExportStamp()}.txt`,lines.join('\n')+'\n');
+}
+
+// ── DAPNET ────────────────────────────────────────────────────────────────
+let dapPasswordDirty=false,dapAuthDirty=false;
+function dapSet(id,v){
+  const el=document.getElementById(id);if(!el)return;
+  const value=(v===null||v===undefined)?'':v;
+  if('value' in el)el.value=value;
+  else el.textContent=value;
+}
+function dapCheck(id,v){const el=document.getElementById(id);if(el)el.checked=!!v;}
+function dapVal(id){const el=document.getElementById(id);return el?(el.value||'').trim():'';}
+function dapNum(id,def,min,max){
+  const n=parseInt(dapVal(id),10);
+  if(!Number.isFinite(n))return def;
+  return Math.max(min,Math.min(max,n));
+}
+function dapList(id){return dapVal(id).split(/[\s,]+/).map(s=>s.trim()).filter(Boolean);}
+function dapRicRoutesText(routes){
+  return Object.keys(routes||{}).sort().map(k=>`${k}=${routes[k]}`).join('\n');
+}
+function dapRicRoutesBody(id,label){
+  const raw=dapVal(id);
+  const out={};
+  if(!raw)return out;
+  for(const lineRaw of raw.split(/\n+/)){
+    const line=lineRaw.trim();
+    if(!line||line.startsWith('#'))continue;
+    const m=line.match(/^([0-9A-Fa-fxX]+)\s*=\s*([0-9]+)$/);
+    if(!m){setDapMsg(`Invalid ${label} route: ${line}`,false);return null;}
+    const issi=parseInt(m[2],10);
+    if(!Number.isFinite(issi)||issi<1||issi>16777215){setDapMsg(`Invalid SSI in ${label} route: ${line}`,false);return null;}
+    out[m[1]]=issi;
+  }
+  return out;
+}
+function dapRicListText(rics){
+  if(!rics)return '';
+  if(Array.isArray(rics))return rics.join('\n');
+  return Object.keys(rics).sort().join('\n');
+}
+function dapRicListBody(id,label){
+  const raw=dapVal(id);
+  const out=[];
+  if(!raw)return out;
+  const seen=new Set();
+  for(const lineRaw of raw.split(/\n+/)){
+    const line=lineRaw.split('#')[0].trim();
+    if(!line)continue;
+    for(const partRaw of line.split(/[\s,]+/)){
+      const part=partRaw.trim();
+      if(!part)continue;
+      if(!/^(?:0x[0-9a-f]+|[0-9]+)$/i.test(part)){setDapMsg(`Invalid ${label} RIC: ${part}`,false);return null;}
+      if(!seen.has(part)){seen.add(part);out.push(part);}
+    }
+  }
+  return out;
+}
+function dapPaths(paths){
+  const p=paths||[];
+  if(!p.length)return '<span class="sds-empty">—</span>';
+  return p.map(x=>`<span class="badge badge-blue" style="font-size:10px">${escHtml(x)}</span>`).join(' ');
+}
+function dapnetRow(e){
+  return `<tr><td class="sds-time">${escHtml(e.ts||'')}</td><td>${dirBadge(e.direction)}</td><td>${escHtml(e.callsign||'')}</td><td>${escHtml(e.recipient||'')}</td><td>${dapPaths(e.paths)}</td><td class="sds-msg">${escHtml(e.text||'')}</td></tr>`;
+}
+function renderDapnetLog(){
+  const tb=document.getElementById('dapnetlog-tbody');if(!tb)return;
+  const rows=state.dapnetLog||[];
+  dapnetLogPageIndex=clampLogPage(dapnetLogPageIndex,rows.length);
+  setLogPager('dapnetlog-page',dapnetLogPageIndex,rows.length);
+  if(!rows.length){tb.innerHTML=`<tr><td colspan="6" class="sds-empty" style="text-align:center;padding:24px">No DAPNET messages yet</td></tr>`;return;}
+  const start=dapnetLogPageIndex*LOG_PAGE_SIZE;
+  tb.innerHTML=rows.slice(start,start+LOG_PAGE_SIZE).map(dapnetRow).join('');
+}
+async function loadDapnetLog(){
+  try{const r=await fetch('/api/dapnet-log');if(!r.ok)return;state.dapnetLog=await r.json();dapnetLogPageIndex=0;renderDapnetLog();}catch{}
+}
+function dapnetLogPrevPage(){dapnetLogPageIndex--;renderDapnetLog();}
+function dapnetLogNextPage(){dapnetLogPageIndex++;renderDapnetLog();}
+async function clearDapnetLog(){
+  if(!confirm('Clear DAPNET Log?'))return;
+  try{const r=await fetch('/api/dapnet-log',{method:'DELETE'});if(!r.ok)return;state.dapnetLog=[];dapnetLogPageIndex=0;renderDapnetLog();}catch{}
+}
+function exportDapnetLog(){
+  const rows=state.dapnetLog||[];
+  if(!rows.length)return;
+  const lines=['TIME\tDIR\tCALLSIGN\tRECIPIENT\tPATHS\tMESSAGE'];
+  for(const e of rows){
+    lines.push([
+      e.ts||'',
+      (e.direction||'').toUpperCase(),
+      e.callsign||'',
+      e.recipient||'',
+      (e.paths||[]).join(','),
+      e.text||''
+    ].map(logExportCell).join('\t'));
+  }
+  downloadTextFile(`flowstation-dapnet-log-${logExportStamp()}.txt`,lines.join('\n')+'\n');
+}
+async function loadDapnet(){
+  try{
+    const r=await fetch('/api/dapnet');
+    if(!r.ok){setDapMsg(t('conn_error'),false);return;}
+    const d=await r.json();
+    dapCheck('dap-enabled',d.enabled);
+    dapCheck('dap-rwth-enabled',d.rwth_core_enabled);
+    dapSet('dap-poll',d.poll_interval_secs||30);
+    dapSet('dap-limit',d.rwth_messages_limit||100);
+    dapSet('dap-api-url',d.api_url||'');
+    dapSet('dap-username',d.username||'');
+    dapSet('dap-password',d.password_set?(d.password_masked||''):'');
+    dapPasswordDirty=false;
+    dapSet('dap-rwth-host',d.rwth_core_host||'');
+    dapSet('dap-rwth-port',d.rwth_core_port||43434);
+    dapSet('dap-rwth-device',d.rwth_core_device||'FlowStation');
+    dapSet('dap-rwth-version',d.rwth_core_version||'1.0');
+    dapSet('dap-rwth-callsign',d.rwth_core_callsign||'');
+    dapSet('dap-rwth-authkey',d.rwth_core_authkey_set?(d.rwth_core_authkey_masked||''):'');
+    dapAuthDirty=false;
+    dapCheck('dap-forward-sds',d.forward_sds);
+    dapCheck('dap-forward-callout',d.forward_callout);
+    dapCheck('dap-forward-telegram',d.forward_telegram);
+    dapSet('dap-sds-source',d.sds_source_issi||9999);
+    dapSet('dap-sds-dest',d.sds_dest_issi||0);
+    dapCheck('dap-sds-group',d.sds_dest_is_group);
+    dapSet('dap-ric-routes',dapRicRoutesText(d.ric_issi_routes));
+    dapSet('dap-ric-group-routes',dapRicRoutesText(d.ric_gssi_routes));
+    dapSet('dap-sds-rics',dapRicListText(d.sds_allowed_rics));
+    dapSet('dap-callout-source',d.callout_source_issi||9999);
+    dapSet('dap-callout-dest',d.callout_dest_issi||0);
+    dapSet('dap-callout-incident',d.callout_incident_base||2);
+    dapSet('dap-callout-prefix',d.callout_text_prefix||'DAPNET');
+    dapSet('dap-callout-rics',dapRicListText(d.callout_allowed_rics));
+    dapSet('dap-telegram-prefix',d.telegram_prefix||'DAPNET');
+    dapSet('dap-telegram-rics',dapRicListText(d.telegram_allowed_rics));
+    setDapMsg('',true);
+  }catch{setDapMsg(t('conn_error'),false);}
+}
+async function saveDapnet(){
+  const ricRoutes=dapRicRoutesBody('dap-ric-routes','RIC to ISSI');
+  if(ricRoutes===null)return;
+  const ricGroupRoutes=dapRicRoutesBody('dap-ric-group-routes','RIC to GSSI');
+  if(ricGroupRoutes===null)return;
+  const sdsRics=dapRicListBody('dap-sds-rics','SDS');
+  if(sdsRics===null)return;
+  const calloutRics=dapRicListBody('dap-callout-rics','Call-Out');
+  if(calloutRics===null)return;
+  const telegramRics=dapRicListBody('dap-telegram-rics','Telegram');
+  if(telegramRics===null)return;
+  const body={
+    enabled:document.getElementById('dap-enabled').checked,
+    rwth_core_enabled:document.getElementById('dap-rwth-enabled').checked,
+    poll_interval_secs:dapNum('dap-poll',30,1,86400),
+    rwth_messages_limit:dapNum('dap-limit',100,1,10000),
+    api_url:dapVal('dap-api-url'),
+    username:dapVal('dap-username'),
+    rwth_core_host:dapVal('dap-rwth-host'),
+    rwth_core_port:dapNum('dap-rwth-port',43434,1,65535),
+    rwth_core_device:dapVal('dap-rwth-device')||'FlowStation',
+    rwth_core_version:dapVal('dap-rwth-version')||'1.0',
+    rwth_core_callsign:dapVal('dap-rwth-callsign').toUpperCase(),
+    forward_sds:document.getElementById('dap-forward-sds').checked,
+    forward_callout:document.getElementById('dap-forward-callout').checked,
+    forward_telegram:document.getElementById('dap-forward-telegram').checked,
+    sds_source_issi:dapNum('dap-sds-source',9999,1,16777215),
+    sds_dest_issi:dapNum('dap-sds-dest',0,0,16777215),
+    sds_dest_is_group:document.getElementById('dap-sds-group').checked,
+    ric_issi_routes:ricRoutes,
+    ric_gssi_routes:ricGroupRoutes,
+    sds_allowed_rics:sdsRics,
+    callout_source_issi:dapNum('dap-callout-source',9999,1,16777215),
+    callout_dest_issi:dapNum('dap-callout-dest',0,0,16777215),
+    callout_incident_base:dapNum('dap-callout-incident',2,1,256),
+    callout_text_prefix:dapVal('dap-callout-prefix')||'DAPNET',
+    callout_allowed_rics:calloutRics,
+    telegram_prefix:dapVal('dap-telegram-prefix')||'DAPNET',
+    telegram_allowed_rics:telegramRics
+  };
+  if(dapPasswordDirty)body.password=dapVal('dap-password');
+  if(dapAuthDirty)body.rwth_core_authkey=dapVal('dap-rwth-authkey');
+  try{
+    const r=await fetch('/api/dapnet',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify(body)});
+    if(r.ok){setDapMsg(t('dapnet_saved'),true);loadDapnet();}
+    else setDapMsg(t('save_fail')+': '+await r.text(),false);
+  }catch{setDapMsg(t('conn_error'),false);}
+}
+async function sendDapnetMessage(){
+  const body={
+    callSignNames:dapList('dap-out-callsigns'),
+    transmitterGroupNames:dapList('dap-out-groups'),
+    emergency:document.getElementById('dap-out-emergency').checked,
+    text:document.getElementById('dap-out-text').value.trim()
+  };
+  if(!body.text){setDapSendMsg('Message text is empty',false);return;}
+  if(!body.callSignNames.length&&!body.transmitterGroupNames.length){setDapSendMsg('Set callsign or transmitter group',false);return;}
+  setDapSendMsg('Sending…',true);
+  try{
+    const r=await fetch('/api/dapnet/send',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify(body)});
+    const d=await r.json();
+    if(d.ok){setDapSendMsg('✓ Sent',true);document.getElementById('dap-out-text').value='';loadDapnetLog();}
+    else setDapSendMsg('✗ '+(d.error||'Send failed'),false);
+  }catch{setDapSendMsg(t('conn_error'),false);}
+}
+
+// ── Shared map-link + paths helpers (also used by GeoAlarm) ────────────────
+function meshMapLink(lat,lon,label){
+  if(lat===null||lat===undefined||lon===null||lon===undefined)return '—';
+  const la=Number(lat),lo=Number(lon);
+  if(!Number.isFinite(la)||!Number.isFinite(lo))return '—';
+  const url=`https://maps.google.com/?q=${encodeURIComponent(la+','+lo)}`;
+  return `<a class="sds-map-link" href="${url}" target="_blank" rel="noopener noreferrer">${escHtml(label||`${la.toFixed(5)}, ${lo.toFixed(5)}`)}</a>`;
+}
+function meshRfText(row){
+  const parts=[];
+  if(row.rssi!==null&&row.rssi!==undefined)parts.push(`RSSI ${row.rssi}`);
+  if(row.snr!==null&&row.snr!==undefined)parts.push(`SNR ${row.snr}`);
+  return parts.join(' · ')||'—';
+}
+function meshSourceListText(values){
+  return Array.isArray(values)?values.join('\n'):'';
+}
+function meshSourceListBody(id){
+  const raw=dapVal(id);
+  if(!raw)return [];
+  return raw.split(/[\s,]+/).map(v=>v.trim()).filter(Boolean);
+}
+function meshPaths(paths){
+  if(!Array.isArray(paths)||!paths.length)return '<span class="sds-empty">—</span>';
+  return paths.map(p=>`<span class="badge badge-blue" style="font-size:10px">${escHtml(p)}</span>`).join(' ');
+}
+
+// ── GeoAlarm ──────────────────────────────────────────────────────────────
+function geoFloat(id,def,min,max){
+  const n=parseFloat(dapVal(id));
+  if(!Number.isFinite(n))return def;
+  return Math.max(min,Math.min(max,n));
+}
+function geoIssiListText(values){
+  return Array.isArray(values)?values.join('\n'):'';
+}
+function geoIssiListBody(id,label){
+  const raw=dapVal(id);
+  if(!raw)return [];
+  const out=[],seen=new Set();
+  for(const part of raw.split(/[\s,]+/).map(v=>v.trim()).filter(Boolean)){
+    const n=Number(part);
+    if(!Number.isInteger(n)||n<0||n>16777215){setGeoMsg(`Invalid ${label} ISSI: ${part}`,false);return null;}
+    if(!seen.has(n)){seen.add(n);out.push(n);}
+  }
+  return out;
+}
+function geoEventRow(e){
+  const status=e.alarmed
+    ? '<span class="badge badge-green" style="font-size:10px">ALARM</span>'
+    : (e.inside_radius?'<span class="badge badge-blue" style="font-size:10px">inside</span>':'<span class="badge" style="font-size:10px">outside</span>');
+  return `<tr>
+    <td class="sds-time">${escHtml(e.ts||'')}</td>
+    <td>${escHtml(e.source||'—')}</td>
+    <td>${escHtml(e.device||'—')}</td>
+    <td class="sds-time">${Number(e.distance_m||0).toFixed(0)} m</td>
+    <td>${meshMapLink(e.lat,e.lon,'map')}</td>
+    <td>${status}</td>
+    <td>${meshPaths(e.paths)}</td>
+  </tr>`;
+}
+function renderGeoalarmEvents(){
+  const tb=document.getElementById('geo-events-tbody');if(!tb)return;
+  const rows=state.geoalarmEvents||[];
+  geoalarmPageIndex=clampLogPage(geoalarmPageIndex,rows.length);
+  setLogPager('geo-events-page',geoalarmPageIndex,rows.length);
+  if(!rows.length){tb.innerHTML=`<tr><td colspan="7" class="sds-empty" style="text-align:center;padding:24px">No GeoAlarm events yet</td></tr>`;return;}
+  const start=geoalarmPageIndex*LOG_PAGE_SIZE;
+  tb.innerHTML=rows.slice(start,start+LOG_PAGE_SIZE).map(geoEventRow).join('');
+}
+function geoPrevPage(){geoalarmPageIndex--;renderGeoalarmEvents();}
+function geoNextPage(){geoalarmPageIndex++;renderGeoalarmEvents();}
+async function loadGeoalarm(){
+  try{
+    const r=await fetch('/api/geoalarm');
+    if(!r.ok){setGeoMsg(t('conn_error'),false);return;}
+    const d=await r.json(),rt=d.runtime||{};
+    dapCheck('geo-enabled',d.enabled);
+    dapSet('geo-lat',d.flowstation_lat??0);
+    dapSet('geo-lon',d.flowstation_lon??0);
+    dapSet('geo-radius-m',d.radius_m||500);
+    dapSet('geo-cooldown',d.cooldown_secs||300);
+    dapCheck('geo-trigger-tetra',d.trigger_tetra);
+    dapCheck('geo-trigger-meshcom',d.trigger_meshcom);
+    dapCheck('geo-forward-tpg',d.forward_tpg2200);
+    dapCheck('geo-forward-sds',d.forward_sds);
+    dapCheck('geo-forward-sip',d.forward_sip);
+    dapCheck('geo-forward-telegram',d.forward_telegram);
+    dapSet('geo-tetra-white',geoIssiListText(d.tetra_issi_whitelist));
+    dapSet('geo-tetra-black',geoIssiListText(d.tetra_issi_blacklist));
+    dapSet('geo-mesh-white',meshSourceListText(d.meshcom_source_whitelist));
+    dapSet('geo-mesh-black',meshSourceListText(d.meshcom_source_blacklist));
+    dapSet('geo-sds-source',d.sds_source_issi||9999);
+    dapSet('geo-sds-dest',d.sds_dest_issi||0);
+    dapCheck('geo-sds-group',d.sds_dest_is_group);
+    dapSet('geo-tpg-source',d.tpg2200_source_issi||9999);
+    dapSet('geo-tpg-dest',d.tpg2200_dest_issi||0);
+    dapSet('geo-tpg-incident',d.tpg2200_incident_base||1);
+    dapSet('geo-tpg-prefix',d.tpg2200_text_prefix||'GeoAlarm');
+    dapSet('geo-tpg-max',d.tpg2200_max_text_chars||80);
+    dapSet('geo-sip-prefix',d.sip_title_prefix||'GeoAlarm');
+    dapSet('geo-telegram-prefix',d.telegram_prefix||'GeoAlarm');
+    dapSet('geo-seen',rt.seen_positions??0);
+    dapSet('geo-alarms',rt.alarm_count??0);
+    dapSet('geo-center',rt.center||`${d.flowstation_lat??0},${d.flowstation_lon??0}`);
+    dapSet('geo-radius',`${Number(rt.radius_m||d.radius_m||0).toFixed(0)} m`);
+    dapSet('geo-last-position',rt.last_position||'—');
+    dapSet('geo-last-alarm',rt.last_alarm||'—');
+    dapSet('geo-last-error',rt.last_error||'—');
+    state.geoalarmEvents=d.events||[];
+    geoalarmPageIndex=0;
+    renderGeoalarmEvents();
+    setGeoMsg('',true);
+  }catch{setGeoMsg(t('conn_error'),false);}
+}
+async function saveGeoalarm(){
+  const tetraWhite=geoIssiListBody('geo-tetra-white','whitelist');
+  if(tetraWhite===null)return;
+  const tetraBlack=geoIssiListBody('geo-tetra-black','blacklist');
+  if(tetraBlack===null)return;
+  const body={
+    enabled:document.getElementById('geo-enabled').checked,
+    flowstation_lat:geoFloat('geo-lat',0,-90,90),
+    flowstation_lon:geoFloat('geo-lon',0,-180,180),
+    radius_m:dapNum('geo-radius-m',500,1,1000000),
+    cooldown_secs:dapNum('geo-cooldown',300,1,86400),
+    trigger_tetra:document.getElementById('geo-trigger-tetra').checked,
+    trigger_meshcom:document.getElementById('geo-trigger-meshcom').checked,
+    forward_tpg2200:document.getElementById('geo-forward-tpg').checked,
+    forward_sds:document.getElementById('geo-forward-sds').checked,
+    forward_sip:document.getElementById('geo-forward-sip').checked,
+    forward_telegram:document.getElementById('geo-forward-telegram').checked,
+    tetra_issi_whitelist:tetraWhite,
+    tetra_issi_blacklist:tetraBlack,
+    meshcom_source_whitelist:meshSourceListBody('geo-mesh-white'),
+    meshcom_source_blacklist:meshSourceListBody('geo-mesh-black'),
+    sds_source_issi:dapNum('geo-sds-source',9999,1,16777215),
+    sds_dest_issi:dapNum('geo-sds-dest',0,0,16777215),
+    sds_dest_is_group:document.getElementById('geo-sds-group').checked,
+    tpg2200_source_issi:dapNum('geo-tpg-source',9999,1,16777215),
+    tpg2200_dest_issi:dapNum('geo-tpg-dest',0,0,16777215),
+    tpg2200_incident_base:dapNum('geo-tpg-incident',1,1,256),
+    tpg2200_text_prefix:dapVal('geo-tpg-prefix')||'GeoAlarm',
+    tpg2200_max_text_chars:dapNum('geo-tpg-max',80,8,160),
+    sip_title_prefix:dapVal('geo-sip-prefix')||'GeoAlarm',
+    telegram_prefix:dapVal('geo-telegram-prefix')||'GeoAlarm'
+  };
+  try{
+    const r=await fetch('/api/geoalarm',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify(body)});
+    if(r.ok){setGeoMsg('✓ Saved',true);setTimeout(loadGeoalarm,500);}
+    else setGeoMsg(t('save_fail')+': '+await r.text(),false);
+  }catch{setGeoMsg(t('conn_error'),false);}
+}
+function setGeoMsg(txt,ok){const el=document.getElementById('geo-msg');if(!el)return;el.textContent=txt;el.style.color=ok?'var(--accent)':'var(--danger)';if(txt)setTimeout(()=>{if(el.textContent===txt)el.textContent='';},5000);}
+function setDapMsg(txt,ok){const el=document.getElementById('dap-msg');if(!el)return;el.textContent=txt;el.style.color=ok?'var(--accent)':'var(--danger)';if(txt)setTimeout(()=>{if(el.textContent===txt)el.textContent='';},5000);}
+function setDapSendMsg(txt,ok){const el=document.getElementById('dap-send-msg');if(!el)return;el.textContent=txt;el.style.color=ok?'var(--accent)':'var(--danger)';if(txt)setTimeout(()=>{if(el.textContent===txt)el.textContent='';},5000);}
 
 function appendLog(msg){
   const f=logFilter(),lv={'':0,DEBUG:0,INFO:1,WARN:2,ERROR:3};
@@ -4311,6 +5241,134 @@ function exportLog(){
   a.download=`flowstation-log-${stamp}.log`;
   document.body.appendChild(a);a.click();
   setTimeout(()=>{URL.revokeObjectURL(a.href);a.remove();},0);
+}
+
+// ── Asterisk SIP ───────────────────────────────────────────────────────────
+async function loadAsteriskStatus(){
+  const set=(id,v)=>{const el=document.getElementById(id);if(el)el.textContent=(v===null||v===undefined||v==='')?'—':v;};
+  try{
+    const r=await fetch('/api/asterisk/status');
+    if(!r.ok)throw new Error('http '+r.status);
+    const d=await r.json();
+    const c=d.config||{}, rt=d.runtime||{};
+    set('ast-configured', (c.configured||rt.configured)?'YES':'NO');
+    set('ast-enabled', (c.enabled||rt.enabled)?'enabled':'disabled');
+    set('ast-register', rt.register_status||'—');
+    set('ast-dialogs', (rt.active_dialogs??0)+' active dialogs');
+    set('ast-sip-listen', rt.sip_listen||c.sip_listen);
+    set('ast-remote', rt.remote||c.remote);
+    set('ast-rtp', rt.rtp_port_range||c.rtp_port_range);
+    set('ast-codec', rt.codec||c.codec);
+    set('ast-last-rx', rt.last_rx);
+    set('ast-last-tx', rt.last_tx);
+    set('ast-last-error', rt.last_error);
+  }catch(e){
+    set('ast-configured','—');set('ast-enabled','status unavailable');set('ast-register','—');
+    set('ast-last-error',t('conn_error'));
+  }
+}
+
+let snomPasswordDirty=false;
+function setSnomMsg(txt,ok){
+  const el=document.getElementById('snom-msg');
+  if(!el)return;
+  el.textContent=txt||'';
+  el.style.color=ok?'var(--accent)':'var(--danger)';
+}
+function snomListText(values){return (values||[]).join('\n');}
+function snomListBody(id){
+  return (document.getElementById(id)?.value||'')
+    .split(/[\s,]+/)
+    .map(v=>v.trim())
+    .filter(Boolean);
+}
+function snomRicListBody(id,label){
+  const out=[],seen=new Set();
+  for(const rawLine of (document.getElementById(id)?.value||'').split(/\r?\n/)){
+    const line=rawLine.split('#')[0].trim();
+    if(!line)continue;
+    for(const raw of line.split(/[\s,]+/)){
+      const part=raw.trim();
+      if(!part)continue;
+      if(!/^(?:0x[0-9a-f]+|[0-9]+)$/i.test(part)){setSnomMsg(`Invalid ${label} RIC: ${part}`,false);return null;}
+      if(!seen.has(part)){seen.add(part);out.push(part);}
+    }
+  }
+  return out;
+}
+function snomIssiListBody(id,label){
+  const out=[],seen=new Set();
+  for(const raw of snomListBody(id)){
+    const n=Number(raw);
+    if(!Number.isInteger(n)||n<0||n>16777215){setSnomMsg(`Invalid ${label} ISSI: ${raw}`,false);return null;}
+    if(!seen.has(n)){seen.add(n);out.push(n);}
+  }
+  return out;
+}
+function snomSetDirections(values){
+  const dirs=new Set((values&&values.length?values:['rx','net','tx']).map(v=>String(v).toLowerCase()));
+  dapCheck('snom-dir-rx',dirs.has('rx'));
+  dapCheck('snom-dir-net',dirs.has('net'));
+  dapCheck('snom-dir-tx',dirs.has('tx'));
+}
+function snomDirectionsBody(){
+  const dirs=[];
+  if(document.getElementById('snom-dir-rx')?.checked)dirs.push('rx');
+  if(document.getElementById('snom-dir-net')?.checked)dirs.push('net');
+  if(document.getElementById('snom-dir-tx')?.checked)dirs.push('tx');
+  return dirs;
+}
+async function loadSnomNotify(){
+  try{
+    const r=await fetch('/api/snom-notify');
+    if(!r.ok){setSnomMsg(t('conn_error'),false);return;}
+    const d=await r.json();
+    dapCheck('snom-enabled',d.enabled);
+    dapSet('snom-ami-host',d.ami_host||'127.0.0.1');
+    dapSet('snom-ami-port',d.ami_port||5038);
+    dapSet('snom-ami-user',d.ami_username||'');
+    dapSet('snom-ami-password',d.ami_password_set?(d.ami_password_masked||''):'');
+    snomPasswordDirty=false;
+    dapSet('snom-endpoints',snomListText(d.endpoints));
+    dapCheck('snom-notify-sds',d.notify_sds);
+    dapCheck('snom-notify-dapnet',d.notify_dapnet);
+    dapCheck('snom-notify-telegram',d.notify_telegram);
+    snomSetDirections(d.sds_directions);
+    dapSet('snom-dapnet-rics',dapRicListText(d.dapnet_allowed_rics));
+    dapSet('snom-sds-issis',snomListText(d.sds_allowed_issis));
+    dapSet('snom-title-prefix',d.title_prefix||'FlowStation');
+    dapSet('snom-max-text',d.max_text_chars||240);
+    dapSet('snom-timeout',d.connect_timeout_secs||3);
+    setSnomMsg('',true);
+  }catch{setSnomMsg(t('conn_error'),false);}
+}
+async function saveSnomNotify(){
+  const dapnetRics=snomRicListBody('snom-dapnet-rics','DAPNET');
+  if(dapnetRics===null)return;
+  const sdsIssis=snomIssiListBody('snom-sds-issis','SDS');
+  if(sdsIssis===null)return;
+  const body={
+    enabled:document.getElementById('snom-enabled').checked,
+    ami_host:dapVal('snom-ami-host')||'127.0.0.1',
+    ami_port:dapNum('snom-ami-port',5038,1,65535),
+    ami_username:dapVal('snom-ami-user'),
+    endpoints:snomListBody('snom-endpoints'),
+    notify_sds:document.getElementById('snom-notify-sds').checked,
+    notify_dapnet:document.getElementById('snom-notify-dapnet').checked,
+    notify_telegram:document.getElementById('snom-notify-telegram').checked,
+    sds_directions:snomDirectionsBody(),
+    dapnet_allowed_rics:dapnetRics,
+    sds_allowed_issis:sdsIssis,
+    title_prefix:dapVal('snom-title-prefix')||'FlowStation',
+    max_text_chars:dapNum('snom-max-text',240,40,2000),
+    connect_timeout_secs:dapNum('snom-timeout',3,1,30)
+  };
+  if(snomPasswordDirty)body.ami_password=dapVal('snom-ami-password');
+  try{
+    const r=await fetch('/api/snom-notify',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify(body)});
+    if(r.ok){setSnomMsg('✓ Saved',true);loadSnomNotify();}
+    else setSnomMsg(t('save_fail')+': '+await r.text(),false);
+  }catch{setSnomMsg(t('conn_error'),false);}
 }
 
 // ── Config ────────────────────────────────────────────────────────────────
@@ -4518,9 +5576,11 @@ function wsSend(msg){if(ws&&ws.readyState===WebSocket.OPEN){ws.send(JSON.stringi
 async function restartService(){if(!confirm(t('confirm_restart')))return;wsSend({type:'restart'});}
 async function shutdownService(){if(!confirm(t('confirm_shutdown')))return;wsSend({type:'shutdown'});}
 function kickMs(issi){if(!confirm(t('confirm_kick',{issi})))return;wsSend({type:'kick',issi});}
-function openSds(issi){sdsDest=issi;document.getElementById('sds-dest').value=issi;document.getElementById('sds-msg').value='';document.getElementById('sds-modal').classList.add('open');}
+function toggleSdsCallout(){const on=document.getElementById('sds-callout').checked;document.getElementById('sds-callout-fields').style.display=on?'block':'none';}
+function resetSdsCallout(){document.getElementById('sds-callout').checked=false;document.getElementById('sds-callout-source').value='9999';document.getElementById('sds-callout-incident').value='1';document.getElementById('sds-callout-text').value='ALARM';document.getElementById('sds-callout-raw').value='';toggleSdsCallout();}
+function openSds(issi){sdsDest=issi;document.getElementById('sds-dest').value=issi;document.getElementById('sds-msg').value='';resetSdsCallout();document.getElementById('sds-modal').classList.add('open');}
 function closeSdsModal(){document.getElementById('sds-modal').classList.remove('open');}
-function sendSds(){const dest=parseInt(document.getElementById('sds-dest').value),msg=document.getElementById('sds-msg').value.trim();if(!dest||!msg)return;wsSend({type:'sds',dest_issi:dest,message:msg});closeSdsModal();}
+function sendSds(){const dest=parseInt(document.getElementById('sds-dest').value);if(!dest)return;if(document.getElementById('sds-callout').checked){const source=parseInt(document.getElementById('sds-callout-source').value)||9999;const incident=Math.max(1,Math.min(256,parseInt(document.getElementById('sds-callout-incident').value)||1));const alarmText=document.getElementById('sds-callout-text').value.trim()||'ALARM';const rawhex=document.getElementById('sds-callout-raw').value.trim();wsSend({type:'sds_callout',dest_issi:dest,source_issi:source,incident,message:alarmText,raw_hex:rawhex});closeSdsModal();return;}const msg=document.getElementById('sds-msg').value.trim();if(!msg)return;wsSend({type:'sds',dest_issi:dest,message:msg});closeSdsModal();}
 function openDgna(issi){document.getElementById('dgna-issi').value=issi;document.getElementById('dgna-gssi').value='';const cur=document.getElementById('dgna-current');const gl=(state.ms[issi]&&state.ms[issi].groups)||[];cur.innerHTML=gl.length?gl.slice().sort((a,b)=>a-b).map(g=>`<span class="badge badge-blue" style="font-size:10px">${g}</span>`).join(''):'<span class="badge badge-dim">—</span>';document.getElementById('dgna-modal').classList.add('open');}
 function closeDgnaModal(){document.getElementById('dgna-modal').classList.remove('open');}
 function sendDgna(attach){const issi=parseInt(document.getElementById('dgna-issi').value),gssi=parseInt(document.getElementById('dgna-gssi').value);if(!issi||!gssi)return;wsSend({type:'dgna',issi,gssi,attach});closeDgnaModal();}
@@ -5174,6 +6234,117 @@ function renderHealthTab(h){
   });
 }
 
+let healthIntegrationState={asterisk:null,dapnet:null,geoalarm:null,lastLoad:0};
+function integrationHealthCard(title,icon,level,detail,extra){
+  const col=healthColor(level);
+  const card=document.createElement('div');
+  card.style.cssText='border:1px solid var(--border,#2a2f3a);border-left:4px solid '+col+';border-radius:12px;padding:14px 16px;background:var(--bg2,#161a22)';
+  card.innerHTML=
+    '<div style="display:flex;align-items:center;gap:8px">'
+      + '<span style="font-size:18px">'+icon+'</span>'
+      + '<span style="font-weight:700;color:var(--text);flex:1">'+escHtml(title)+'</span>'
+      + '<span style="font-size:11px;font-weight:700;letter-spacing:.5px;color:'+col+';border:1px solid '+col+';border-radius:6px;padding:2px 8px">'+level.toUpperCase()+'</span>'
+    + '</div>'
+    + '<div style="margin-top:8px;font-size:13px;color:var(--text2,#9aa4b2)"><span style="opacity:.6">Status:</span> '+escHtml(detail||'')+'</div>'
+    + (extra?'<div style="margin-top:6px;font-size:13px;color:var(--text2,#9aa4b2);line-height:1.5">'+escHtml(extra)+'</div>':'');
+  return card;
+}
+function classifyAsteriskHealth(data){
+  const c=(data&&data.config)||{},rt=(data&&data.runtime)||{};
+  const enabled=!!(c.enabled||rt.enabled);
+  if(!enabled)return {level:'ok',detail:'disabled',extra:'SIP bridge is configured but not active.'};
+  const reg=String(rt.register_status||'').toLowerCase();
+  const dialogs=rt.active_dialogs??0;
+  const err=rt.last_error||'';
+  let level='ok';
+  if(err)level='degraded';
+  if(c.register && reg && !/(registered|reachable|ok|disabled)/.test(reg))level='degraded';
+  const detail=(rt.register_status||'enabled')+' · '+dialogs+' active dialog(s)';
+  const extra=err?('Last error: '+err):('Remote '+(rt.remote||c.remote||'—')+' · codec '+(rt.codec||c.codec||'—'));
+  return {level,detail,extra};
+}
+function classifyDapnetHealth(data){
+  if(!data||!data.enabled)return {level:'ok',detail:'disabled',extra:'DAPNET worker is not active.'};
+  const rt=data.runtime||{};
+  const paths=[];
+  if(data.forward_sds||rt.forward_sds)paths.push('SDS');
+  if(data.forward_callout||rt.forward_callout)paths.push('TPG2200');
+  if(data.forward_telegram||rt.forward_telegram)paths.push('Telegram');
+  let level='ok';
+  const notes=[];
+  const rwthStatus=String(rt.rwth_core_status||'').toLowerCase();
+  const lastError=rt.last_error||'';
+  if(data.rwth_core_enabled){
+    if(!data.rwth_core_callsign)notes.push('RWTH callsign missing');
+    if(!data.rwth_core_authkey_set)notes.push('RWTH authkey missing');
+    if(lastError)notes.push('Last error: '+lastError);
+    if(rwthStatus && !/(logged in|connected)/.test(rwthStatus))notes.push('RWTH status '+rt.rwth_core_status);
+  } else {
+    notes.push('RWTH receive feed disabled');
+  }
+  if(!paths.length)notes.push('no forwarding path enabled');
+  if(notes.length)level='degraded';
+  const status=rt.rwth_core_status||(data.rwth_core_enabled?'enabled':'disabled');
+  const detail='RWTH '+status+' · '+(paths.length?paths.join(', '):'no forwarding');
+  const extra=notes.length?notes.join(' · '):('Host '+(rt.endpoint||((data.rwth_core_host||'—')+':'+(data.rwth_core_port||'—')))+' · seen '+(rt.seen_messages??0)+(rt.last_rx?' · last RX '+rt.last_rx:''));
+  return {level,detail,extra};
+}
+function classifyGeoalarmHealth(data){
+  if(!data||!data.enabled)return {level:'ok',detail:'disabled',extra:'GeoAlarm is not active.'};
+  const rt=data.runtime||{};
+  const err=rt.last_error||'';
+  const paths=[];
+  if(data.forward_tpg2200||rt.forward_tpg2200)paths.push('TPG2200');
+  if(data.forward_sds||rt.forward_sds)paths.push('SDS');
+  if(data.forward_sip||rt.forward_sip)paths.push('SIP');
+  if(data.forward_telegram||rt.forward_telegram)paths.push('Telegram');
+  const notes=[];
+  if(!paths.length)notes.push('no forwarding path enabled');
+  if(!data.trigger_tetra&&!data.trigger_meshcom)notes.push('no input source enabled');
+  if(err)notes.push('Last error: '+err);
+  const level=notes.length?'degraded':'ok';
+  const detail=(rt.seen_positions??0)+' position(s) · '+(rt.alarm_count??0)+' alarm(s)';
+  const extra=notes.length?notes.join(' · '):('Center '+(rt.center||'—')+' · radius '+Number(rt.radius_m||data.radius_m||0).toFixed(0)+' m · routes '+paths.join(', '));
+  return {level,detail,extra};
+}
+function renderHealthIntegrations(){
+  const grid=document.getElementById('health-integrations-grid');
+  if(!grid)return;
+  grid.innerHTML='';
+  if(healthIntegrationState.asterisk){
+    const a=classifyAsteriskHealth(healthIntegrationState.asterisk);
+    grid.appendChild(integrationHealthCard('Asterisk SIP','☎',a.level,a.detail,a.extra));
+  } else {
+    grid.appendChild(integrationHealthCard('Asterisk SIP','☎','degraded','status unavailable','Open the Asterisk SIP page or wait for the next refresh.'));
+  }
+  if(healthIntegrationState.dapnet){
+    const d=classifyDapnetHealth(healthIntegrationState.dapnet);
+    grid.appendChild(integrationHealthCard('DAPNET','📟',d.level,d.detail,d.extra));
+  } else {
+    grid.appendChild(integrationHealthCard('DAPNET','📟','degraded','status unavailable','Open the DAPNET page or wait for the next refresh.'));
+  }
+  if(healthIntegrationState.geoalarm){
+    const g=classifyGeoalarmHealth(healthIntegrationState.geoalarm);
+    grid.appendChild(integrationHealthCard('GeoAlarm','◎',g.level,g.detail,g.extra));
+  } else {
+    grid.appendChild(integrationHealthCard('GeoAlarm','◎','degraded','status unavailable','Open the GeoAlarm page or wait for the next refresh.'));
+  }
+}
+async function loadHealthIntegrations(){
+  healthIntegrationState.lastLoad=Date.now();
+  try{
+    const [ast,dap,geo]=await Promise.all([
+      fetch('/api/asterisk/status').then(r=>r.ok?r.json():null).catch(()=>null),
+      fetch('/api/dapnet').then(r=>r.ok?r.json():null).catch(()=>null),
+      fetch('/api/geoalarm').then(r=>r.ok?r.json():null).catch(()=>null)
+    ]);
+    healthIntegrationState.asterisk=ast;
+    healthIntegrationState.dapnet=dap;
+    healthIntegrationState.geoalarm=geo;
+  }catch{}
+  renderHealthIntegrations();
+}
+
 function handleHealth(h){
   // Topbar station-health badge: colour + label by overall level, details in the tooltip.
   const badge = document.getElementById('health-badge');
@@ -5194,6 +6365,9 @@ function handleHealth(h){
   badge.title = tip;
   // Also refresh the full Health "Looking Glass" tab.
   renderHealthTab(h);
+  if(document.getElementById('page-health')?.classList.contains('active') && Date.now()-healthIntegrationState.lastLoad>10000){
+    loadHealthIntegrations();
+  }
 }
 
 function handleSysHealth(msg){

--- a/crates/tetra-entities/src/net_dashboard/mod.rs
+++ b/crates/tetra-entities/src/net_dashboard/mod.rs
@@ -1,7 +1,10 @@
 pub mod callsign;
+pub mod dapnet;
+pub mod geoalarm;
 pub mod html;
 pub mod radioid;
 pub mod server;
+pub mod snom_notify;
 pub mod state;
 pub mod telegram;
 pub mod update_check;

--- a/crates/tetra-entities/src/net_dashboard/server.rs
+++ b/crates/tetra-entities/src/net_dashboard/server.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::io::{BufRead, BufReader, Read, Write};
 use std::net::{TcpListener, TcpStream};
 use std::sync::{Arc, Mutex, RwLock};
@@ -10,6 +10,7 @@ use crate::net_dashboard::html::DASHBOARD_HTML;
 use crate::net_dashboard::state::{DashboardState, DashboardStateInner, MsEntry, CallEntry};
 use crate::net_telemetry::TelemetryEvent;
 use crate::net_control::commands::ControlCommand;
+use crate::tpg2200::build_tpg2200_callout_payload;
 
 type CmdSender = crossbeam_channel::Sender<ControlCommand>;
 
@@ -878,6 +879,17 @@ impl DashboardServer {
                         }
                     }
                 }
+                TelemetryEvent::DapnetLog { direction, id, callsign, recipient, text, priority, paths } => {
+                    s.push_dapnet_log(
+                        direction,
+                        id.clone(),
+                        callsign.clone(),
+                        recipient.clone(),
+                        text.clone(),
+                        *priority,
+                        paths.clone(),
+                    );
+                }
             }
         }
         if let Some(json) = msg {
@@ -1007,6 +1019,8 @@ fn event_to_ws_msg(event: &TelemetryEvent) -> Option<String> {
         // Emergency add/remove are broadcast explicitly (transition-gated) from handle_telemetry,
         // so the generic path stays silent — otherwise every periodic re-send would re-broadcast.
         TelemetryEvent::EmergencyAlarm { .. } | TelemetryEvent::EmergencyCancel { .. } => return None,
+        TelemetryEvent::DapnetLog { direction, id, callsign, recipient, text, priority, paths } =>
+            serde_json::json!({"type":"dapnet_log","direction":direction,"id":id,"callsign":callsign,"recipient":recipient,"text":text,"priority":priority,"paths":paths}),
     };
     serde_json::to_string(&v).ok()
 }
@@ -1140,6 +1154,14 @@ fn handle_connection(
     }
     let header_str = String::from_utf8_lossy(&header_buf);
     let req_line = header_str.lines().next().unwrap_or("").to_string();
+
+    // Snom/desk-phone ActionURL endpoint. It has its own token and must work without the
+    // dashboard cookie session, so handle it before the normal dashboard auth gate.
+    if is_tpg2200_action_request(&req_line) {
+        drain_http_headers(&mut stream);
+        serve_tpg2200_action_url(stream, &req_line, &shared_config, &cmd_tx, &state);
+        return;
+    }
 
     // ── Cookie-session auth ──────────────────────────────────────────────────
     // We replaced the browser-native Basic Auth dialog with a form-based login at
@@ -1486,6 +1508,17 @@ fn handle_connection(
             if line == "\r\n" || line.is_empty() || line == "\n" { break; }
         }
         serve_bts_info(buf.into_inner(), &shared_config);
+    } else if req_line.contains("GET /api/asterisk/status") {
+        let mut s = stream;
+        drain_http_headers(&mut s);
+        serve_asterisk_status(s, &shared_config);
+    } else if req_line.contains("GET /api/snom-notify") {
+        let mut s = stream;
+        drain_http_headers(&mut s);
+        serve_snom_notify_get(s, &shared_config);
+    } else if req_line.contains("POST /api/snom-notify") {
+        let (inner, body_str) = read_post_body(stream);
+        serve_snom_notify_post(inner, &shared_config, &config_path, &body_str);
     } else if req_line.contains("GET /api/whitelist") {
         let mut buf = BufReader::new(stream);
         loop {
@@ -1554,6 +1587,31 @@ fn handle_connection(
     } else if req_line.contains("POST /api/telegram") {
         let (inner, body_str) = read_post_body(stream);
         serve_telegram_post(inner, &shared_config, &config_path, &body_str);
+    } else if req_line.contains("DELETE /api/dapnet-log") {
+        let mut s = stream;
+        drain_http_headers(&mut s);
+        serve_dapnet_log_clear(s, &state);
+    } else if req_line.contains("GET /api/dapnet-log") {
+        let mut s = stream;
+        drain_http_headers(&mut s);
+        serve_dapnet_log(s, &state);
+    } else if req_line.contains("POST /api/dapnet/send") {
+        let (inner, body_str) = read_post_body(stream);
+        serve_dapnet_send(inner, &shared_config, &state, &clients, &body_str);
+    } else if req_line.contains("GET /api/dapnet") {
+        let mut s = stream;
+        drain_http_headers(&mut s);
+        serve_dapnet_get(s, &shared_config);
+    } else if req_line.contains("POST /api/dapnet") {
+        let (inner, body_str) = read_post_body(stream);
+        serve_dapnet_post(inner, &shared_config, &config_path, &body_str);
+    } else if req_line.contains("GET /api/geoalarm") {
+        let mut s = stream;
+        drain_http_headers(&mut s);
+        serve_geoalarm_get(s, &shared_config);
+    } else if req_line.contains("POST /api/geoalarm") {
+        let (inner, body_str) = read_post_body(stream);
+        serve_geoalarm_post(inner, &shared_config, &config_path, &body_str);
     } else if req_line.contains("GET /api/config") {
         let mut buf = BufReader::new(stream);
         loop {
@@ -1562,6 +1620,14 @@ fn handle_connection(
             if line == "\r\n" || line.is_empty() || line == "\n" { break; }
         }
         serve_config_get(buf.into_inner(), &config_path);
+    } else if req_line.contains("DELETE /api/sds-log") {
+        let mut buf = BufReader::new(stream);
+        loop {
+            let mut line = String::new();
+            let _ = buf.read_line(&mut line);
+            if line == "\r\n" || line.is_empty() || line == "\n" { break; }
+        }
+        serve_sds_log_clear(buf.into_inner(), &state);
     } else if req_line.contains("GET /api/sds-log") {
         // Return the persisted SDS Log (newest first) as JSON.
         let mut buf = BufReader::new(stream);
@@ -3057,6 +3123,1416 @@ fn serve_login_page(mut stream: TcpStream) {
     );
     let _ = stream.write_all(header.as_bytes());
     let _ = stream.write_all(body.as_bytes());
+}
+
+// ===========================================================================
+// Integration dashboard endpoints — DAPNET / GeoAlarm / Snom NOTIFY / Asterisk
+// plus the TPG2200 ActionURL and DAPNET/SDS log helpers. Ported from the dj2th
+// fork (echolink/meshcom routes intentionally excluded).
+// ===========================================================================
+
+/// DELETE /api/sds-log — clear the persisted SDS Log.
+fn serve_sds_log_clear(stream: TcpStream, state: &DashboardState) {
+    if let Ok(mut s) = state.write() {
+        s.clear_sds_log();
+    }
+    http_json_response(stream, 200, "{\"ok\":true}");
+}
+
+/// GET /api/dapnet-log — the persisted DAPNET Log as a JSON array, newest entry first.
+fn serve_dapnet_log(stream: TcpStream, state: &DashboardState) {
+    let body = {
+        match state.read() {
+            Ok(s) => {
+                let list: Vec<_> = s.dapnet_log.iter().rev().cloned().collect();
+                serde_json::to_string(&list).unwrap_or_else(|_| "[]".to_string())
+            }
+            Err(_) => "[]".to_string(),
+        }
+    };
+    http_json_response(stream, 200, &body);
+}
+
+/// DELETE /api/dapnet-log — clear the persisted DAPNET Log.
+fn serve_dapnet_log_clear(stream: TcpStream, state: &DashboardState) {
+    if let Ok(mut s) = state.write() {
+        s.clear_dapnet_log();
+    }
+    http_json_response(stream, 200, "{\"ok\":true}");
+}
+
+fn request_path(req_line: &str) -> Option<&str> {
+    req_line.split_whitespace().nth(1)
+}
+
+fn is_tpg2200_action_request(req_line: &str) -> bool {
+    let mut parts = req_line.split_whitespace();
+    let method = parts.next().unwrap_or("");
+    let path = parts.next().unwrap_or("");
+    let route = path.split_once('?').map(|(route, _)| route).unwrap_or(path);
+    matches!(method, "GET" | "POST") && route == "/api/action/tpg2200"
+}
+
+fn query_params(path: &str) -> HashMap<String, String> {
+    let Some((_, query)) = path.split_once('?') else {
+        return HashMap::new();
+    };
+    query
+        .split('&')
+        .filter_map(|part| {
+            if part.is_empty() {
+                return None;
+            }
+            let (key, value) = part.split_once('=').unwrap_or((part, ""));
+            Some((url_decode(key), url_decode(value)))
+        })
+        .collect()
+}
+
+fn truncate_action_text(text: &str, max: usize) -> (String, bool) {
+    match text.char_indices().nth(max) {
+        Some((idx, _)) => (text[..idx].to_string(), true),
+        None => (text.to_string(), false),
+    }
+}
+
+fn next_tpg2200_action_incident(
+    cfg: &tetra_config::bluestation::SharedConfig,
+    base: u16,
+) -> u16 {
+    let base = base.clamp(1, 256);
+    let mut state = cfg.state_write();
+    let incident = state.tpg2200_action_next_incident.unwrap_or(base).clamp(1, 256);
+    state.tpg2200_action_next_incident = Some(if incident >= 256 { 1 } else { incident + 1 });
+    incident
+}
+
+/// GET /api/action/tpg2200?token=...&text=...
+///
+/// Public-by-design ActionURL endpoint for phones that cannot hold the dashboard session cookie.
+/// The dedicated token is mandatory and configured in `[tpg2200_action]`.
+fn serve_tpg2200_action_url(
+    stream: TcpStream,
+    req_line: &str,
+    shared_config: &Option<tetra_config::bluestation::SharedConfig>,
+    cmd_tx: &Arc<Mutex<Option<CmdSender>>>,
+    state: &DashboardState,
+) {
+    let Some(cfg) = shared_config else {
+        http_response(stream, 503, "Config not available");
+        return;
+    };
+    let action = cfg.config().tpg2200_action.clone();
+    if !action.enabled {
+        http_response(stream, 404, "TPG2200 ActionURL disabled");
+        return;
+    }
+    let Some(path) = request_path(req_line) else {
+        http_response(stream, 400, "Invalid request");
+        return;
+    };
+    let params = query_params(path);
+    let supplied_token = params.get("token").map(|s| s.as_str()).unwrap_or("");
+    let expected_token = action.token.as_ref();
+    if expected_token.trim().is_empty()
+        || !timing_safe_eq(supplied_token.as_bytes(), expected_token.as_bytes())
+    {
+        tracing::warn!("TPG2200 ActionURL rejected: invalid token");
+        http_response(stream, 403, "Forbidden");
+        return;
+    }
+    if action.dest_issi == 0 || action.source_issi == 0 {
+        http_response(stream, 500, "TPG2200 ActionURL not fully configured");
+        return;
+    }
+
+    let requested_text = params
+        .get("text")
+        .or_else(|| params.get("message"))
+        .or_else(|| params.get("msg"))
+        .map(|s| s.trim())
+        .filter(|s| !s.is_empty())
+        .unwrap_or(action.default_text.trim());
+    let message = if requested_text.is_empty() { "ALARM" } else { requested_text };
+    let (message, truncated) = truncate_action_text(message, action.max_text_chars.max(1));
+    if truncated {
+        tracing::warn!(
+            "TPG2200 ActionURL text truncated to {} chars",
+            action.max_text_chars
+        );
+    }
+
+    let tx = match cmd_tx.lock() {
+        Ok(guard) => guard.clone(),
+        Err(_) => None,
+    };
+    let Some(tx) = tx else {
+        http_response(stream, 503, "CMCE control channel unavailable");
+        return;
+    };
+
+    let incident = next_tpg2200_action_incident(cfg, action.incident_base);
+    let payload = build_tpg2200_callout_payload(incident, &message);
+    if payload.len() > (u16::MAX as usize / 8) {
+        http_response(stream, 500, "TPG2200 payload too large");
+        return;
+    }
+    let len_bits = (payload.len() * 8) as u16;
+    let cmd = ControlCommand::SendRawSdsType4 {
+        handle: 0,
+        source_ssi: action.source_issi,
+        dest_ssi: action.dest_issi,
+        dest_is_group: false,
+        len_bits,
+        payload,
+    };
+    if tx.send(cmd).is_err() {
+        http_response(stream, 503, "CMCE control channel unavailable");
+        return;
+    }
+
+    tracing::info!(
+        "TPG2200 ActionURL sent: dest={} source={} incident={} text={:?}",
+        action.dest_issi,
+        action.source_issi,
+        incident,
+        message
+    );
+    if let Ok(mut s) = state.write() {
+        s.push_log(
+            "INFO",
+            format!(
+                "TPG2200 ActionURL sent to {}: incident {} text {}",
+                action.dest_issi, incident, message
+            ),
+        );
+    }
+    http_response(stream, 200, &format!("OK incident={incident}"));
+}
+
+/// GET /api/asterisk/status — return Asterisk SIP/RTP config + runtime status.
+fn serve_asterisk_status(
+    stream: TcpStream,
+    shared_config: &Option<tetra_config::bluestation::SharedConfig>,
+) {
+    let body = match shared_config {
+        Some(cfg) => {
+            let c = cfg.config();
+            let runtime = cfg.state_read().asterisk_status.clone();
+            serde_json::json!({
+                "config": {
+                    "configured": true,
+                    "enabled": c.asterisk.enabled,
+                    "register": c.asterisk.register,
+                    "sip_listen": format!("{}:{}", c.asterisk.bind_addr, c.asterisk.bind_port),
+                    "remote": format!("{}:{}", c.asterisk.remote_host, c.asterisk.remote_port),
+                    "rtp_port_range": format!("{}-{}", c.asterisk.rtp_port_min, c.asterisk.rtp_port_max),
+                    "codec": c.asterisk.codec.clone(),
+                    "outbound_prefix": c.asterisk.outbound_prefix.clone(),
+                    "strip_outbound_prefix": c.asterisk.strip_outbound_prefix,
+                    "service_numbers": c.asterisk.service_numbers.clone(),
+                    "local_user": c.asterisk.local_user.clone(),
+                    "auth_user": c.asterisk.auth_user.clone(),
+                    "realm": c.asterisk.realm.clone(),
+                },
+                "runtime": {
+                    "configured": runtime.configured,
+                    "enabled": runtime.enabled,
+                    "register_status": runtime.register_status,
+                    "sip_listen": runtime.sip_listen,
+                    "remote": runtime.remote,
+                    "rtp_port_range": runtime.rtp_port_range,
+                    "codec": runtime.codec,
+                    "active_dialogs": runtime.active_dialogs,
+                    "last_rx": runtime.last_rx,
+                    "last_tx": runtime.last_tx,
+                    "last_error": runtime.last_error,
+                }
+            })
+        }
+        None => serde_json::json!({
+            "config": { "configured": false, "enabled": false },
+            "runtime": {
+                "configured": false,
+                "enabled": false,
+                "register_status": "disabled",
+                "sip_listen": "",
+                "remote": "",
+                "rtp_port_range": "",
+                "codec": "PCMU",
+                "active_dialogs": 0,
+                "last_rx": null,
+                "last_tx": null,
+                "last_error": null,
+            }
+        }),
+    };
+    http_json_response(stream, 200, &body.to_string());
+}
+
+/// GET /api/snom-notify — return effective Snom XML NOTIFY settings.
+fn serve_snom_notify_get(
+    stream: TcpStream,
+    shared_config: &Option<tetra_config::bluestation::SharedConfig>,
+) {
+    let snom = shared_config
+        .as_ref()
+        .map(|cfg| cfg.effective_snom_notify())
+        .unwrap_or_default();
+    let password = snom.ami_password.as_ref();
+    let body = serde_json::json!({
+        "enabled": snom.enabled,
+        "ami_host": snom.ami_host.clone(),
+        "ami_port": snom.ami_port,
+        "ami_username": snom.ami_username.clone(),
+        "ami_password_masked": crate::net_dashboard::snom_notify::mask_secret(password),
+        "ami_password_set": !password.trim().is_empty(),
+        "endpoints": snom.endpoints.clone(),
+        "notify_sds": snom.notify_sds,
+        "notify_dapnet": snom.notify_dapnet,
+        "notify_telegram": snom.notify_telegram,
+        "sds_directions": snom.sds_directions.clone(),
+        "dapnet_allowed_rics": dapnet_ric_set_as_json(&snom.dapnet_allowed_rics),
+        "sds_allowed_issis": snom.sds_allowed_issis.iter().copied().collect::<Vec<u32>>(),
+        "title_prefix": snom.title_prefix.clone(),
+        "notify_event": snom.notify_event.clone(),
+        "content_type": snom.content_type.clone(),
+        "subscription_state": snom.subscription_state.clone(),
+        "max_text_chars": snom.max_text_chars,
+        "connect_timeout_secs": snom.connect_timeout_secs,
+    });
+    http_json_response(stream, 200, &body.to_string());
+}
+
+/// POST /api/snom-notify — update Snom XML NOTIFY settings live and persist to config.toml.
+fn serve_snom_notify_post(
+    stream: TcpStream,
+    shared_config: &Option<tetra_config::bluestation::SharedConfig>,
+    config_path: &str,
+    body: &str,
+) {
+    use tetra_config::bluestation::SnomNotifyRuntimeOverride;
+
+    let json: serde_json::Value = match serde_json::from_str(body.trim()) {
+        Ok(v) => v,
+        Err(e) => {
+            http_response(stream, 400, &format!("Invalid JSON: {e}"));
+            return;
+        }
+    };
+    let Some(cfg) = shared_config else {
+        http_response(stream, 503, "Config not available");
+        return;
+    };
+
+    let cur = cfg.effective_snom_notify();
+    let dapnet_allowed_rics =
+        match dapnet_ric_set_from_json(&json, "dapnet_allowed_rics", &cur.dapnet_allowed_rics) {
+            Ok(rics) => rics,
+            Err(err) => {
+                http_response(stream, 400, &format!("Invalid Snom DAPNET RIC filter: {err}"));
+                return;
+            }
+        };
+    let sds_allowed_issis =
+        match snom_issi_set_from_json(&json, "sds_allowed_issis", &cur.sds_allowed_issis) {
+            Ok(issis) => issis,
+            Err(err) => {
+                http_response(stream, 400, &format!("Invalid Snom SDS ISSI filter: {err}"));
+                return;
+            }
+        };
+
+    let enabled = dapnet_as_bool(&json, "enabled", cur.enabled);
+    let ami_host = snom_non_empty_or(dapnet_as_string(&json, "ami_host", &cur.ami_host), "127.0.0.1");
+    let ami_port = dapnet_as_u16(&json, "ami_port", cur.ami_port);
+    if ami_port == 0 {
+        http_response(stream, 400, "Invalid Snom NOTIFY setting: AMI port cannot be 0");
+        return;
+    }
+    if enabled && ami_host.trim().is_empty() {
+        http_response(stream, 400, "Invalid Snom NOTIFY setting: AMI host is required when enabled");
+        return;
+    }
+
+    let endpoints = snom_string_list(&json, "endpoints", &cur.endpoints);
+    let sds_directions = snom_string_list(&json, "sds_directions", &cur.sds_directions)
+        .into_iter()
+        .map(|d| d.to_ascii_lowercase())
+        .collect::<Vec<_>>();
+    let ov = SnomNotifyRuntimeOverride {
+        enabled,
+        ami_host,
+        ami_port,
+        ami_username: dapnet_as_string(&json, "ami_username", &cur.ami_username),
+        ami_password: dapnet_resolve_secret(&json, "ami_password", cur.ami_password.as_ref()),
+        endpoints,
+        notify_sds: dapnet_as_bool(&json, "notify_sds", cur.notify_sds),
+        notify_dapnet: dapnet_as_bool(&json, "notify_dapnet", cur.notify_dapnet),
+        notify_telegram: dapnet_as_bool(&json, "notify_telegram", cur.notify_telegram),
+        sds_directions,
+        dapnet_allowed_rics,
+        sds_allowed_issis,
+        title_prefix: snom_non_empty_or(
+            dapnet_as_string(&json, "title_prefix", &cur.title_prefix),
+            "FlowStation",
+        ),
+        notify_event: snom_non_empty_or(dapnet_as_string(&json, "notify_event", &cur.notify_event), "xml"),
+        content_type: snom_non_empty_or(
+            dapnet_as_string(&json, "content_type", &cur.content_type),
+            "application/snomxml",
+        ),
+        subscription_state: snom_non_empty_or(
+            dapnet_as_string(&json, "subscription_state", &cur.subscription_state),
+            "active;expires=30000",
+        ),
+        max_text_chars: dapnet_as_usize(&json, "max_text_chars", cur.max_text_chars).clamp(40, 2000),
+        connect_timeout_secs: dapnet_as_u64(
+            &json,
+            "connect_timeout_secs",
+            cur.connect_timeout_secs,
+        )
+        .clamp(1, 30),
+    };
+
+    let mut text_fields = vec![
+        ov.ami_host.as_str(),
+        ov.ami_username.as_str(),
+        ov.ami_password.as_str(),
+        ov.title_prefix.as_str(),
+        ov.notify_event.as_str(),
+        ov.content_type.as_str(),
+        ov.subscription_state.as_str(),
+    ];
+    text_fields.extend(ov.endpoints.iter().map(String::as_str));
+    text_fields.extend(ov.sds_directions.iter().map(String::as_str));
+    if !text_fields.iter().all(|v| dapnet_text_acceptable(v)) {
+        http_response(stream, 400, "Invalid Snom NOTIFY setting: control characters are not allowed");
+        return;
+    }
+
+    {
+        let mut state = cfg.state_write();
+        state.snom_notify_override = Some(ov.clone());
+    }
+
+    if let Err(e) = crate::net_dashboard::snom_notify::write_snom_notify_to_toml(config_path, &ov) {
+        tracing::warn!("Dashboard: Snom NOTIFY applied at runtime but failed to persist to TOML: {}", e);
+        http_response(stream, 200, "Applied at runtime; failed to write config file (check permissions)");
+        return;
+    }
+
+    tracing::info!(
+        "Dashboard: Snom NOTIFY updated (enabled={} endpoints={} sds={} dapnet={} telegram={})",
+        ov.enabled,
+        ov.endpoints.len(),
+        ov.notify_sds,
+        ov.notify_dapnet,
+        ov.notify_telegram
+    );
+    http_response(stream, 200, "OK");
+}
+
+fn snom_non_empty_or(value: String, fallback: &str) -> String {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        fallback.to_string()
+    } else {
+        trimmed.to_string()
+    }
+}
+
+fn dapnet_resolve_secret(json: &serde_json::Value, key: &str, current: &str) -> String {
+    match json.get(key).and_then(|v| v.as_str()) {
+        Some(v) if !v.contains('…') => v.trim().to_string(),
+        _ => current.to_string(),
+    }
+}
+
+fn dapnet_text_acceptable(s: &str) -> bool {
+    s.chars().all(|c| !c.is_control())
+}
+
+const DAPNET_API_TEXT_MAX_CHARS: usize = 80;
+
+fn dapnet_as_bool(json: &serde_json::Value, key: &str, default: bool) -> bool {
+    json.get(key).and_then(|x| x.as_bool()).unwrap_or(default)
+}
+
+fn dapnet_as_u32(json: &serde_json::Value, key: &str, default: u32) -> u32 {
+    json.get(key)
+        .and_then(|x| x.as_u64())
+        .map(|n| n.min(16_777_215) as u32)
+        .unwrap_or(default)
+}
+
+fn dapnet_as_u64(json: &serde_json::Value, key: &str, default: u64) -> u64 {
+    json.get(key).and_then(|x| x.as_u64()).unwrap_or(default)
+}
+
+fn dapnet_as_u16(json: &serde_json::Value, key: &str, default: u16) -> u16 {
+    json.get(key)
+        .and_then(|x| x.as_u64())
+        .map(|n| n.min(u16::MAX as u64) as u16)
+        .unwrap_or(default)
+}
+
+fn dapnet_as_f64(json: &serde_json::Value, key: &str, default: f64) -> f64 {
+    json.get(key)
+        .and_then(|x| x.as_f64().or_else(|| x.as_str().and_then(|s| s.trim().parse::<f64>().ok())))
+        .filter(|v| v.is_finite())
+        .unwrap_or(default)
+}
+
+fn dapnet_as_usize(json: &serde_json::Value, key: &str, default: usize) -> usize {
+    json.get(key)
+        .and_then(|x| x.as_u64())
+        .map(|n| n.max(1) as usize)
+        .unwrap_or(default)
+}
+
+fn dapnet_as_string(json: &serde_json::Value, key: &str, default: &str) -> String {
+    json.get(key)
+        .and_then(|x| x.as_str())
+        .map(|s| s.trim().to_string())
+        .unwrap_or_else(|| default.to_string())
+}
+
+fn dapnet_ric_routes_as_json(routes: &BTreeMap<u32, u32>) -> serde_json::Value {
+    let mut map = serde_json::Map::new();
+    for (ric, issi) in routes {
+        map.insert(
+            tetra_config::bluestation::format_ric_route_key(*ric),
+            serde_json::json!(issi),
+        );
+    }
+    serde_json::Value::Object(map)
+}
+
+fn dapnet_ric_set_as_json(rics: &BTreeSet<u32>) -> serde_json::Value {
+    serde_json::Value::Array(
+        rics.iter()
+            .map(|ric| {
+                serde_json::Value::String(tetra_config::bluestation::format_ric_route_key(*ric))
+            })
+            .collect(),
+    )
+}
+
+fn dapnet_parse_ric_json_value(value: &serde_json::Value, label: &str) -> Result<u32, String> {
+    if let Some(s) = value.as_str() {
+        return tetra_config::bluestation::parse_ric_route_key(s);
+    }
+    if let Some(n) = value.as_u64() {
+        if n <= u32::MAX as u64 {
+            return Ok(n as u32);
+        }
+    }
+    Err(format!("{label}: RIC must be a string or positive integer"))
+}
+
+fn dapnet_ric_set_from_json(
+    json: &serde_json::Value,
+    key: &str,
+    current: &BTreeSet<u32>,
+) -> Result<BTreeSet<u32>, String> {
+    let Some(value) = json.get(key) else {
+        return Ok(current.clone());
+    };
+    let mut rics = BTreeSet::new();
+    match value {
+        serde_json::Value::Array(items) => {
+            for item in items {
+                rics.insert(dapnet_parse_ric_json_value(item, key)?);
+            }
+        }
+        serde_json::Value::String(text) => {
+            for line_raw in text.lines() {
+                let line = line_raw.split('#').next().unwrap_or("").trim();
+                if line.is_empty() {
+                    continue;
+                }
+                for part in line.split(|c: char| c == ',' || c.is_whitespace()) {
+                    let part = part.trim();
+                    if part.is_empty() {
+                        continue;
+                    }
+                    rics.insert(tetra_config::bluestation::parse_ric_route_key(part)?);
+                }
+            }
+        }
+        _ => return Err(format!("{key} must be an array or text list")),
+    }
+    Ok(rics)
+}
+
+fn dapnet_ric_routes_from_json_key(
+    json: &serde_json::Value,
+    key: &str,
+    current: &BTreeMap<u32, u32>,
+) -> Result<BTreeMap<u32, u32>, String> {
+    let Some(value) = json.get(key) else {
+        return Ok(current.clone());
+    };
+    let mut routes = BTreeMap::new();
+    match value {
+        serde_json::Value::Object(map) => {
+            for (raw_ric, raw_issi) in map {
+                let ric = tetra_config::bluestation::parse_ric_route_key(raw_ric)?;
+                let Some(issi) = raw_issi.as_u64() else {
+                    return Err(format!("RIC route {raw_ric}: ISSI must be a number"));
+                };
+                if issi == 0 || issi > 16_777_215 {
+                    return Err(format!("RIC route {raw_ric}: ISSI out of range"));
+                }
+                routes.insert(ric, issi as u32);
+            }
+        }
+        serde_json::Value::String(text) => {
+            for line in text.lines() {
+                let line = line.trim();
+                if line.is_empty() || line.starts_with('#') {
+                    continue;
+                }
+                let Some((raw_ric, raw_issi)) = line.split_once('=') else {
+                    return Err(format!("RIC route line '{line}' must be RIC=ISSI"));
+                };
+                let ric = tetra_config::bluestation::parse_ric_route_key(raw_ric)?;
+                let issi = raw_issi
+                    .trim()
+                    .parse::<u32>()
+                    .map_err(|_| format!("RIC route line '{line}' has invalid ISSI"))?;
+                if issi == 0 || issi > 16_777_215 {
+                    return Err(format!("RIC route line '{line}' has ISSI out of range"));
+                }
+                routes.insert(ric, issi);
+            }
+        }
+        _ => return Err(format!("{key} must be an object or text lines")),
+    }
+    Ok(routes)
+}
+
+fn dapnet_ric_routes_from_json(
+    json: &serde_json::Value,
+    current: &BTreeMap<u32, u32>,
+) -> Result<BTreeMap<u32, u32>, String> {
+    dapnet_ric_routes_from_json_key(json, "ric_issi_routes", current)
+}
+
+fn dapnet_validate_route_conflicts(
+    issi_routes: &BTreeMap<u32, u32>,
+    gssi_routes: &BTreeMap<u32, u32>,
+) -> Result<(), String> {
+    for ric in issi_routes.keys() {
+        if gssi_routes.contains_key(ric) {
+            return Err(format!(
+                "RIC {} is configured as both ISSI and GSSI route",
+                tetra_config::bluestation::format_ric_route_key(*ric)
+            ));
+        }
+    }
+    Ok(())
+}
+
+/// GET /api/dapnet — return effective DAPNET settings as JSON. Secrets are masked and are never
+/// echoed in the clear.
+fn serve_dapnet_get(
+    stream: TcpStream,
+    shared_config: &Option<tetra_config::bluestation::SharedConfig>,
+) {
+    let (dapnet, runtime) = match shared_config {
+        Some(cfg) => (cfg.effective_dapnet(), cfg.state_read().dapnet_status.clone()),
+        None => (
+            tetra_config::bluestation::CfgDapnet::default(),
+            tetra_config::bluestation::DapnetRuntimeStatus::default(),
+        ),
+    };
+    let password = dapnet.password.as_ref();
+    let authkey = dapnet.rwth_core_authkey.as_ref();
+    let runtime_body = serde_json::json!({
+        "configured": runtime.configured,
+        "enabled": runtime.enabled,
+        "rwth_core_enabled": runtime.rwth_core_enabled,
+        "rwth_core_status": runtime.rwth_core_status,
+        "endpoint": runtime.endpoint,
+        "callsign": runtime.callsign,
+        "forward_sds": runtime.forward_sds,
+        "forward_callout": runtime.forward_callout,
+        "forward_telegram": runtime.forward_telegram,
+        "seen_messages": runtime.seen_messages,
+        "last_rx": runtime.last_rx,
+        "last_error": runtime.last_error,
+    });
+    let mut body = serde_json::json!({
+        "enabled": dapnet.enabled,
+        "api_url": dapnet.api_url.clone(),
+        "username": dapnet.username.clone(),
+        "password_masked": crate::net_dashboard::dapnet::mask_secret(password),
+        "password_set": !password.trim().is_empty(),
+        "poll_interval_secs": dapnet.poll_interval_secs,
+        "forward_sds": dapnet.forward_sds,
+        "forward_callout": dapnet.forward_callout,
+        "forward_telegram": dapnet.forward_telegram,
+        "sds_source_issi": dapnet.sds_source_issi,
+        "sds_dest_issi": dapnet.sds_dest_issi,
+        "sds_dest_is_group": dapnet.sds_dest_is_group,
+        "ric_issi_routes": dapnet_ric_routes_as_json(&dapnet.ric_issi_routes),
+        "ric_gssi_routes": dapnet_ric_routes_as_json(&dapnet.ric_gssi_routes),
+        "sds_allowed_rics": dapnet_ric_set_as_json(&dapnet.sds_allowed_rics),
+        "callout_allowed_rics": dapnet_ric_set_as_json(&dapnet.callout_allowed_rics),
+        "telegram_allowed_rics": dapnet_ric_set_as_json(&dapnet.telegram_allowed_rics),
+        "callout_source_issi": dapnet.callout_source_issi,
+        "callout_dest_issi": dapnet.callout_dest_issi,
+        "callout_incident_base": dapnet.callout_incident_base,
+        "callout_text_prefix": dapnet.callout_text_prefix.clone(),
+        "telegram_prefix": dapnet.telegram_prefix.clone(),
+        "rwth_core_enabled": dapnet.rwth_core_enabled,
+        "rwth_core_host": dapnet.rwth_core_host.clone(),
+        "rwth_core_port": dapnet.rwth_core_port,
+        "rwth_core_device": dapnet.rwth_core_device.clone(),
+        "rwth_core_version": dapnet.rwth_core_version.clone(),
+        "rwth_core_callsign": dapnet.rwth_core_callsign.clone(),
+        "rwth_core_authkey_masked": crate::net_dashboard::dapnet::mask_secret(authkey),
+        "rwth_core_authkey_set": !authkey.trim().is_empty(),
+        "rwth_messages_limit": dapnet.rwth_messages_limit,
+    });
+    if let Some(obj) = body.as_object_mut() {
+        obj.insert("runtime".to_string(), runtime_body);
+    }
+    http_json_response(stream, 200, &body.to_string());
+}
+
+/// POST /api/dapnet — update DAPNET settings. Applies immediately through StackState override
+/// and rewrites `[dapnet]` in config.toml. Secrets are changed only when a fresh, non-masked
+/// value is supplied.
+fn serve_dapnet_post(
+    stream: TcpStream,
+    shared_config: &Option<tetra_config::bluestation::SharedConfig>,
+    config_path: &str,
+    body: &str,
+) {
+    use tetra_config::bluestation::DapnetRuntimeOverride;
+
+    let json: serde_json::Value = match serde_json::from_str(body.trim()) {
+        Ok(v) => v,
+        Err(e) => {
+            http_response(stream, 400, &format!("Invalid JSON: {e}"));
+            return;
+        }
+    };
+    let Some(cfg) = shared_config else {
+        http_response(stream, 503, "Config not available");
+        return;
+    };
+
+    let cur = cfg.effective_dapnet();
+    let password = dapnet_resolve_secret(&json, "password", cur.password.as_ref());
+    let rwth_core_authkey = dapnet_resolve_secret(&json, "rwth_core_authkey", cur.rwth_core_authkey.as_ref());
+    let ric_issi_routes = match dapnet_ric_routes_from_json(&json, &cur.ric_issi_routes) {
+        Ok(routes) => routes,
+        Err(err) => {
+            http_response(stream, 400, &format!("Invalid DAPNET RIC route: {err}"));
+            return;
+        }
+    };
+    let ric_gssi_routes =
+        match dapnet_ric_routes_from_json_key(&json, "ric_gssi_routes", &cur.ric_gssi_routes) {
+            Ok(routes) => routes,
+            Err(err) => {
+                http_response(stream, 400, &format!("Invalid DAPNET group RIC route: {err}"));
+                return;
+            }
+        };
+    if let Err(err) = dapnet_validate_route_conflicts(&ric_issi_routes, &ric_gssi_routes) {
+        http_response(stream, 400, &format!("Invalid DAPNET RIC route: {err}"));
+        return;
+    }
+    let sds_allowed_rics =
+        match dapnet_ric_set_from_json(&json, "sds_allowed_rics", &cur.sds_allowed_rics) {
+            Ok(rics) => rics,
+            Err(err) => {
+                http_response(stream, 400, &format!("Invalid SDS RIC filter: {err}"));
+                return;
+            }
+        };
+    let callout_allowed_rics =
+        match dapnet_ric_set_from_json(&json, "callout_allowed_rics", &cur.callout_allowed_rics) {
+            Ok(rics) => rics,
+            Err(err) => {
+                http_response(stream, 400, &format!("Invalid Call-Out RIC filter: {err}"));
+                return;
+            }
+        };
+    let telegram_allowed_rics =
+        match dapnet_ric_set_from_json(&json, "telegram_allowed_rics", &cur.telegram_allowed_rics) {
+            Ok(rics) => rics,
+            Err(err) => {
+                http_response(stream, 400, &format!("Invalid Telegram RIC filter: {err}"));
+                return;
+            }
+        };
+
+    let ov = DapnetRuntimeOverride {
+        enabled: dapnet_as_bool(&json, "enabled", cur.enabled),
+        api_url: dapnet_as_string(&json, "api_url", &cur.api_url),
+        username: dapnet_as_string(&json, "username", &cur.username),
+        password,
+        poll_interval_secs: dapnet_as_u64(&json, "poll_interval_secs", cur.poll_interval_secs).max(1),
+        forward_sds: dapnet_as_bool(&json, "forward_sds", cur.forward_sds),
+        forward_callout: dapnet_as_bool(&json, "forward_callout", cur.forward_callout),
+        forward_telegram: dapnet_as_bool(&json, "forward_telegram", cur.forward_telegram),
+        sds_source_issi: dapnet_as_u32(&json, "sds_source_issi", cur.sds_source_issi).max(1),
+        sds_dest_issi: dapnet_as_u32(&json, "sds_dest_issi", cur.sds_dest_issi),
+        sds_dest_is_group: dapnet_as_bool(&json, "sds_dest_is_group", cur.sds_dest_is_group),
+        ric_issi_routes,
+        ric_gssi_routes,
+        sds_allowed_rics,
+        callout_allowed_rics,
+        telegram_allowed_rics,
+        callout_source_issi: dapnet_as_u32(
+            &json,
+            "callout_source_issi",
+            cur.callout_source_issi,
+        )
+        .max(1),
+        callout_dest_issi: dapnet_as_u32(&json, "callout_dest_issi", cur.callout_dest_issi),
+        callout_incident_base: dapnet_as_u16(
+            &json,
+            "callout_incident_base",
+            cur.callout_incident_base,
+        )
+        .clamp(1, 256),
+        callout_text_prefix: dapnet_as_string(&json, "callout_text_prefix", &cur.callout_text_prefix),
+        telegram_prefix: dapnet_as_string(&json, "telegram_prefix", &cur.telegram_prefix),
+        rwth_core_enabled: dapnet_as_bool(&json, "rwth_core_enabled", cur.rwth_core_enabled),
+        rwth_core_host: dapnet_as_string(&json, "rwth_core_host", &cur.rwth_core_host),
+        rwth_core_port: dapnet_as_u16(&json, "rwth_core_port", cur.rwth_core_port),
+        rwth_core_device: dapnet_as_string(&json, "rwth_core_device", &cur.rwth_core_device),
+        rwth_core_version: dapnet_as_string(&json, "rwth_core_version", &cur.rwth_core_version),
+        rwth_core_callsign: dapnet_as_string(&json, "rwth_core_callsign", &cur.rwth_core_callsign),
+        rwth_core_authkey,
+        rwth_messages_limit: dapnet_as_usize(&json, "rwth_messages_limit", cur.rwth_messages_limit),
+    };
+
+    let text_fields = [
+        ov.api_url.as_str(),
+        ov.username.as_str(),
+        ov.password.as_str(),
+        ov.callout_text_prefix.as_str(),
+        ov.telegram_prefix.as_str(),
+        ov.rwth_core_host.as_str(),
+        ov.rwth_core_device.as_str(),
+        ov.rwth_core_version.as_str(),
+        ov.rwth_core_callsign.as_str(),
+        ov.rwth_core_authkey.as_str(),
+    ];
+    if !text_fields.iter().all(|v| dapnet_text_acceptable(v)) {
+        http_response(stream, 400, "Invalid DAPNET setting: control characters are not allowed");
+        return;
+    }
+
+    {
+        let mut state = cfg.state_write();
+        state.dapnet_override = Some(ov.clone());
+    }
+
+    if let Err(e) = crate::net_dashboard::dapnet::write_dapnet_to_toml(config_path, &ov) {
+        tracing::warn!("Dashboard: DAPNET applied at runtime but failed to persist to TOML: {}", e);
+        http_response(stream, 200, "Applied at runtime; failed to write config file (check permissions)");
+        return;
+    }
+
+    tracing::info!(
+        "Dashboard: DAPNET updated (enabled={} rwth_core={} routes=sds:{} callout:{} telegram:{})",
+        ov.enabled,
+        ov.rwth_core_enabled,
+        ov.forward_sds,
+        ov.forward_callout,
+        ov.forward_telegram
+    );
+    http_response(stream, 200, "OK");
+}
+
+/// GET /api/geoalarm — return effective GeoAlarm settings and runtime status as JSON.
+fn serve_geoalarm_get(
+    stream: TcpStream,
+    shared_config: &Option<tetra_config::bluestation::SharedConfig>,
+) {
+    let (geoalarm, runtime) = match shared_config {
+        Some(cfg) => (cfg.effective_geoalarm(), cfg.state_read().geoalarm_status.clone()),
+        None => (
+            tetra_config::bluestation::CfgGeoalarm::default(),
+            tetra_config::bluestation::GeoalarmRuntimeStatus::default(),
+        ),
+    };
+    let events = runtime
+        .events
+        .iter()
+        .map(|event| {
+            serde_json::json!({
+                "ts": event.ts.clone(),
+                "source": event.source.clone(),
+                "device": event.device.clone(),
+                "lat": event.lat,
+                "lon": event.lon,
+                "distance_m": event.distance_m,
+                "inside_radius": event.inside_radius,
+                "alarmed": event.alarmed,
+                "paths": event.paths.clone(),
+            })
+        })
+        .collect::<Vec<_>>();
+    let runtime_body = serde_json::json!({
+        "configured": runtime.configured,
+        "enabled": runtime.enabled,
+        "center": runtime.center,
+        "radius_m": runtime.radius_m,
+        "trigger_tetra": runtime.trigger_tetra,
+        "trigger_meshcom": runtime.trigger_meshcom,
+        "forward_tpg2200": runtime.forward_tpg2200,
+        "forward_sds": runtime.forward_sds,
+        "forward_sip": runtime.forward_sip,
+        "forward_telegram": runtime.forward_telegram,
+        "seen_positions": runtime.seen_positions,
+        "alarm_count": runtime.alarm_count,
+        "last_position": runtime.last_position,
+        "last_alarm": runtime.last_alarm,
+        "last_error": runtime.last_error,
+    });
+    let body = serde_json::json!({
+        "enabled": geoalarm.enabled,
+        "flowstation_lat": geoalarm.flowstation_lat,
+        "flowstation_lon": geoalarm.flowstation_lon,
+        "radius_m": geoalarm.radius_m,
+        "cooldown_secs": geoalarm.cooldown_secs,
+        "trigger_tetra": geoalarm.trigger_tetra,
+        "trigger_meshcom": geoalarm.trigger_meshcom,
+        "forward_tpg2200": geoalarm.forward_tpg2200,
+        "forward_sds": geoalarm.forward_sds,
+        "forward_sip": geoalarm.forward_sip,
+        "forward_telegram": geoalarm.forward_telegram,
+        "tetra_issi_whitelist": issi_set_as_json(&geoalarm.tetra_issi_whitelist),
+        "tetra_issi_blacklist": issi_set_as_json(&geoalarm.tetra_issi_blacklist),
+        "meshcom_source_whitelist": meshcom_source_list_as_json(&geoalarm.meshcom_source_whitelist),
+        "meshcom_source_blacklist": meshcom_source_list_as_json(&geoalarm.meshcom_source_blacklist),
+        "sds_source_issi": geoalarm.sds_source_issi,
+        "sds_dest_issi": geoalarm.sds_dest_issi,
+        "sds_dest_is_group": geoalarm.sds_dest_is_group,
+        "tpg2200_source_issi": geoalarm.tpg2200_source_issi,
+        "tpg2200_dest_issi": geoalarm.tpg2200_dest_issi,
+        "tpg2200_incident_base": geoalarm.tpg2200_incident_base,
+        "tpg2200_text_prefix": geoalarm.tpg2200_text_prefix.clone(),
+        "tpg2200_max_text_chars": geoalarm.tpg2200_max_text_chars,
+        "sip_title_prefix": geoalarm.sip_title_prefix.clone(),
+        "telegram_prefix": geoalarm.telegram_prefix.clone(),
+        "runtime": runtime_body,
+        "events": events,
+    });
+    http_json_response(stream, 200, &body.to_string());
+}
+
+/// POST /api/geoalarm — update GeoAlarm settings. Applies immediately through StackState
+/// override and rewrites `[geoalarm]` in config.toml.
+fn serve_geoalarm_post(
+    stream: TcpStream,
+    shared_config: &Option<tetra_config::bluestation::SharedConfig>,
+    config_path: &str,
+    body: &str,
+) {
+    use tetra_config::bluestation::{
+        CfgGeoalarmDto, GeoalarmRuntimeOverride, apply_geoalarm_patch,
+    };
+
+    let json: serde_json::Value = match serde_json::from_str(body.trim()) {
+        Ok(v) => v,
+        Err(e) => {
+            http_response(stream, 400, &format!("Invalid JSON: {e}"));
+            return;
+        }
+    };
+    let Some(cfg) = shared_config else {
+        http_response(stream, 503, "Config not available");
+        return;
+    };
+
+    let cur = cfg.effective_geoalarm();
+    let tetra_issi_whitelist = match snom_issi_set_from_json(
+        &json,
+        "tetra_issi_whitelist",
+        &cur.tetra_issi_whitelist,
+    ) {
+        Ok(v) => v,
+        Err(err) => {
+            http_response(stream, 400, &err);
+            return;
+        }
+    };
+    let tetra_issi_blacklist = match snom_issi_set_from_json(
+        &json,
+        "tetra_issi_blacklist",
+        &cur.tetra_issi_blacklist,
+    ) {
+        Ok(v) => v,
+        Err(err) => {
+            http_response(stream, 400, &err);
+            return;
+        }
+    };
+    let meshcom_source_whitelist = match meshcom_source_list_from_json(
+        &json,
+        "meshcom_source_whitelist",
+        &cur.meshcom_source_whitelist,
+    ) {
+        Ok(v) => v,
+        Err(err) => {
+            http_response(stream, 400, &err);
+            return;
+        }
+    };
+    let meshcom_source_blacklist = match meshcom_source_list_from_json(
+        &json,
+        "meshcom_source_blacklist",
+        &cur.meshcom_source_blacklist,
+    ) {
+        Ok(v) => v,
+        Err(err) => {
+            http_response(stream, 400, &err);
+            return;
+        }
+    };
+
+    let dto = CfgGeoalarmDto {
+        enabled: dapnet_as_bool(&json, "enabled", cur.enabled),
+        flowstation_lat: dapnet_as_f64(&json, "flowstation_lat", cur.flowstation_lat),
+        flowstation_lon: dapnet_as_f64(&json, "flowstation_lon", cur.flowstation_lon),
+        radius_m: dapnet_as_f64(&json, "radius_m", cur.radius_m),
+        cooldown_secs: dapnet_as_u64(&json, "cooldown_secs", cur.cooldown_secs),
+        trigger_tetra: dapnet_as_bool(&json, "trigger_tetra", cur.trigger_tetra),
+        trigger_meshcom: dapnet_as_bool(&json, "trigger_meshcom", cur.trigger_meshcom),
+        forward_tpg2200: dapnet_as_bool(&json, "forward_tpg2200", cur.forward_tpg2200),
+        forward_sds: dapnet_as_bool(&json, "forward_sds", cur.forward_sds),
+        forward_sip: dapnet_as_bool(&json, "forward_sip", cur.forward_sip),
+        forward_telegram: dapnet_as_bool(&json, "forward_telegram", cur.forward_telegram),
+        tetra_issi_whitelist: tetra_issi_whitelist.iter().copied().collect(),
+        tetra_issi_blacklist: tetra_issi_blacklist.iter().copied().collect(),
+        meshcom_source_whitelist,
+        meshcom_source_blacklist,
+        sds_source_issi: dapnet_as_u32(&json, "sds_source_issi", cur.sds_source_issi),
+        sds_dest_issi: dapnet_as_u32(&json, "sds_dest_issi", cur.sds_dest_issi),
+        sds_dest_is_group: dapnet_as_bool(&json, "sds_dest_is_group", cur.sds_dest_is_group),
+        tpg2200_source_issi: dapnet_as_u32(&json, "tpg2200_source_issi", cur.tpg2200_source_issi),
+        tpg2200_dest_issi: dapnet_as_u32(&json, "tpg2200_dest_issi", cur.tpg2200_dest_issi),
+        tpg2200_incident_base: dapnet_as_u16(&json, "tpg2200_incident_base", cur.tpg2200_incident_base),
+        tpg2200_text_prefix: dapnet_as_string(&json, "tpg2200_text_prefix", &cur.tpg2200_text_prefix),
+        tpg2200_max_text_chars: dapnet_as_usize(&json, "tpg2200_max_text_chars", cur.tpg2200_max_text_chars),
+        sip_title_prefix: dapnet_as_string(&json, "sip_title_prefix", &cur.sip_title_prefix),
+        telegram_prefix: dapnet_as_string(&json, "telegram_prefix", &cur.telegram_prefix),
+        extra: HashMap::new(),
+    };
+    let normalized = match apply_geoalarm_patch(dto) {
+        Ok(cfg) => cfg,
+        Err(err) => {
+            http_response(stream, 400, &err);
+            return;
+        }
+    };
+    let text_fields = [
+        normalized.tpg2200_text_prefix.as_str(),
+        normalized.sip_title_prefix.as_str(),
+        normalized.telegram_prefix.as_str(),
+    ];
+    if !text_fields.iter().all(|v| dapnet_text_acceptable(v))
+        || !normalized
+            .meshcom_source_whitelist
+            .iter()
+            .chain(normalized.meshcom_source_blacklist.iter())
+            .all(|v| dapnet_text_acceptable(v))
+    {
+        http_response(stream, 400, "Invalid GeoAlarm setting: control characters are not allowed");
+        return;
+    }
+
+    let ov = GeoalarmRuntimeOverride {
+        enabled: normalized.enabled,
+        flowstation_lat: normalized.flowstation_lat,
+        flowstation_lon: normalized.flowstation_lon,
+        radius_m: normalized.radius_m,
+        cooldown_secs: normalized.cooldown_secs,
+        trigger_tetra: normalized.trigger_tetra,
+        trigger_meshcom: normalized.trigger_meshcom,
+        forward_tpg2200: normalized.forward_tpg2200,
+        forward_sds: normalized.forward_sds,
+        forward_sip: normalized.forward_sip,
+        forward_telegram: normalized.forward_telegram,
+        tetra_issi_whitelist: normalized.tetra_issi_whitelist,
+        tetra_issi_blacklist: normalized.tetra_issi_blacklist,
+        meshcom_source_whitelist: normalized.meshcom_source_whitelist,
+        meshcom_source_blacklist: normalized.meshcom_source_blacklist,
+        sds_source_issi: normalized.sds_source_issi,
+        sds_dest_issi: normalized.sds_dest_issi,
+        sds_dest_is_group: normalized.sds_dest_is_group,
+        tpg2200_source_issi: normalized.tpg2200_source_issi,
+        tpg2200_dest_issi: normalized.tpg2200_dest_issi,
+        tpg2200_incident_base: normalized.tpg2200_incident_base,
+        tpg2200_text_prefix: normalized.tpg2200_text_prefix,
+        tpg2200_max_text_chars: normalized.tpg2200_max_text_chars,
+        sip_title_prefix: normalized.sip_title_prefix,
+        telegram_prefix: normalized.telegram_prefix,
+    };
+
+    {
+        let mut state = cfg.state_write();
+        state.geoalarm_override = Some(ov.clone());
+    }
+
+    if let Err(e) = crate::net_dashboard::geoalarm::write_geoalarm_to_toml(config_path, &ov) {
+        tracing::warn!("Dashboard: GeoAlarm applied at runtime but failed to persist to TOML: {}", e);
+        http_response(stream, 200, "Applied at runtime; failed to write config file (check permissions)");
+        return;
+    }
+
+    tracing::info!(
+        "Dashboard: GeoAlarm updated (enabled={} center={:.6},{:.6} radius={:.0}m routes=tpg2200:{} sds:{} sip:{} telegram:{})",
+        ov.enabled,
+        ov.flowstation_lat,
+        ov.flowstation_lon,
+        ov.radius_m,
+        ov.forward_tpg2200,
+        ov.forward_sds,
+        ov.forward_sip,
+        ov.forward_telegram
+    );
+    http_response(stream, 200, "OK");
+}
+
+fn snom_string_list(json: &serde_json::Value, key: &str, default: &[String]) -> Vec<String> {
+    if let Some(arr) = json.get(key).and_then(|v| v.as_array()) {
+        return arr
+            .iter()
+            .filter_map(|v| v.as_str())
+            .map(|s| s.trim().to_string())
+            .filter(|s| !s.is_empty())
+            .collect();
+    }
+    if let Some(s) = json.get(key).and_then(|v| v.as_str()) {
+        return s
+            .split(|c: char| c == ',' || c == '\n' || c == '\r')
+            .map(|p| p.trim().to_string())
+            .filter(|p| !p.is_empty())
+            .collect();
+    }
+    default.to_vec()
+}
+
+fn meshcom_source_list_as_json(values: &BTreeSet<String>) -> serde_json::Value {
+    serde_json::Value::Array(
+        values
+            .iter()
+            .map(|value| serde_json::Value::String(value.clone()))
+            .collect(),
+    )
+}
+
+fn issi_set_as_json(values: &BTreeSet<u32>) -> serde_json::Value {
+    serde_json::Value::Array(
+        values
+            .iter()
+            .map(|value| serde_json::json!(*value))
+            .collect(),
+    )
+}
+
+fn meshcom_source_list_from_json(
+    json: &serde_json::Value,
+    key: &str,
+    current: &BTreeSet<String>,
+) -> Result<Vec<String>, String> {
+    let Some(value) = json.get(key) else {
+        return Ok(current.iter().cloned().collect());
+    };
+    let mut out = Vec::new();
+    match value {
+        serde_json::Value::Array(items) => {
+            for item in items {
+                let Some(text) = item.as_str() else {
+                    return Err(format!("{key}: source entries must be strings"));
+                };
+                push_meshcom_source_parts(key, text, &mut out)?;
+            }
+        }
+        serde_json::Value::String(text) => {
+            push_meshcom_source_parts(key, text, &mut out)?;
+        }
+        _ => return Err(format!("{key} must be an array or text list")),
+    }
+    Ok(out)
+}
+
+fn push_meshcom_source_parts(key: &str, text: &str, out: &mut Vec<String>) -> Result<(), String> {
+    for line_raw in text.lines() {
+        let line = line_raw.split('#').next().unwrap_or("").trim();
+        if line.is_empty() {
+            continue;
+        }
+        for part in line.split(|c: char| c == ',' || c.is_whitespace()) {
+            let part = part.trim();
+            if part.is_empty() {
+                continue;
+            }
+            if !dapnet_text_acceptable(part) {
+                return Err(format!("{key}: source entries may not contain control characters"));
+            }
+            out.push(part.to_string());
+        }
+    }
+    Ok(())
+}
+
+fn snom_issi_set_from_json(
+    json: &serde_json::Value,
+    key: &str,
+    current: &BTreeSet<u32>,
+) -> Result<BTreeSet<u32>, String> {
+    let Some(value) = json.get(key) else {
+        return Ok(current.clone());
+    };
+    let mut out = BTreeSet::new();
+    match value {
+        serde_json::Value::Array(items) => {
+            for item in items {
+                let issi = if let Some(n) = item.as_u64() {
+                    n
+                } else if let Some(s) = item.as_str() {
+                    s.trim()
+                        .parse::<u64>()
+                        .map_err(|_| format!("{key}: ISSI must be numeric"))?
+                } else {
+                    return Err(format!("{key}: ISSI must be a positive integer"));
+                };
+                if issi > 16_777_215 {
+                    return Err(format!("{key}: ISSI {} out of range", issi));
+                }
+                out.insert(issi as u32);
+            }
+        }
+        serde_json::Value::String(text) => {
+            for part in text.split(|c: char| c == ',' || c.is_whitespace()) {
+                let part = part.trim();
+                if part.is_empty() {
+                    continue;
+                }
+                let issi = part
+                    .parse::<u64>()
+                    .map_err(|_| format!("{key}: ISSI must be numeric"))?;
+                if issi > 16_777_215 {
+                    return Err(format!("{key}: ISSI {} out of range", issi));
+                }
+                out.insert(issi as u32);
+            }
+        }
+        _ => return Err(format!("{key} must be an array or text list")),
+    }
+    Ok(out)
+}
+
+fn dapnet_string_list(json: &serde_json::Value, keys: &[&str]) -> Vec<String> {
+    for key in keys {
+        if let Some(arr) = json.get(*key).and_then(|v| v.as_array()) {
+            return arr
+                .iter()
+                .filter_map(|v| v.as_str())
+                .map(|s| s.trim().to_string())
+                .filter(|s| !s.is_empty())
+                .collect();
+        }
+        if let Some(s) = json.get(*key).and_then(|v| v.as_str()) {
+            return s
+                .split(|c: char| c == ',' || c.is_whitespace())
+                .map(|p| p.trim().to_string())
+                .filter(|p| !p.is_empty())
+                .collect();
+        }
+    }
+    Vec::new()
+}
+
+fn normalize_dapnet_api_url(api_url: &str) -> String {
+    let mut url = api_url.trim().trim_end_matches('/').to_string();
+    if let Some(rest) = url.strip_prefix("https://www.hampager.de") {
+        url = format!("https://hampager.de{rest}");
+    } else if let Some(rest) = url.strip_prefix("http://www.hampager.de") {
+        url = format!("http://hampager.de{rest}");
+    }
+    if let Some(base) = url.strip_suffix("/api/messages") {
+        return format!("{base}/api/calls");
+    }
+    if let Some(base) = url.strip_suffix("/messages")
+        && base.ends_with("/api") {
+            return format!("{base}/calls");
+        }
+    url
+}
+
+fn build_dapnet_call_payload(
+    text: &str,
+    callsigns: Vec<String>,
+    groups: Vec<String>,
+    emergency: bool,
+) -> serde_json::Value {
+    serde_json::json!({
+        "text": text,
+        "callSignNames": callsigns,
+        "transmitterGroupNames": groups,
+        "emergency": emergency,
+    })
+}
+
+fn push_dapnet_log_and_broadcast(
+    state: &DashboardState,
+    clients: &WsClients,
+    direction: &str,
+    id: String,
+    callsign: String,
+    recipient: String,
+    text: String,
+    priority: Option<u8>,
+    paths: Vec<String>,
+) {
+    {
+        if let Ok(mut s) = state.write() {
+            s.push_dapnet_log(
+                direction,
+                id.clone(),
+                callsign.clone(),
+                recipient.clone(),
+                text.clone(),
+                priority,
+                paths.clone(),
+            );
+        }
+    }
+    if let Ok(json) = serde_json::to_string(&serde_json::json!({
+        "type": "dapnet_log",
+        "direction": direction,
+        "id": id,
+        "callsign": callsign,
+        "recipient": recipient,
+        "text": text,
+        "priority": priority,
+        "paths": paths,
+    })) {
+        if let Ok(mut clients) = clients.lock() {
+            clients.retain(|tx| tx.send(json.clone()).is_ok());
+        }
+    }
+}
+
+/// POST /api/dapnet/send — send one outbound DAPNET message through the configured Hampager API.
+fn serve_dapnet_send(
+    stream: TcpStream,
+    shared_config: &Option<tetra_config::bluestation::SharedConfig>,
+    state: &DashboardState,
+    clients: &WsClients,
+    body: &str,
+) {
+    let json: serde_json::Value = match serde_json::from_str(body.trim()) {
+        Ok(v) => v,
+        Err(e) => {
+            http_json_response(stream, 400, &serde_json::json!({"ok":false,"error":format!("Invalid JSON: {e}")}).to_string());
+            return;
+        }
+    };
+    let Some(cfg) = shared_config else {
+        http_json_response(stream, 503, "{\"ok\":false,\"error\":\"Config not available\"}");
+        return;
+    };
+    let dapnet = cfg.effective_dapnet();
+    if !dapnet.enabled {
+        http_json_response(stream, 200, "{\"ok\":false,\"error\":\"DAPNET is disabled\"}");
+        return;
+    }
+    let text = json.get("text").and_then(|v| v.as_str()).unwrap_or("").trim().to_string();
+    if text.is_empty() {
+        http_json_response(stream, 200, "{\"ok\":false,\"error\":\"Message text is empty\"}");
+        return;
+    }
+    if !dapnet_text_acceptable(&text) {
+        http_json_response(stream, 200, "{\"ok\":false,\"error\":\"Message contains control characters\"}");
+        return;
+    }
+    if text.chars().count() > DAPNET_API_TEXT_MAX_CHARS {
+        http_json_response(stream, 200, "{\"ok\":false,\"error\":\"DAPNET message text exceeds 80 characters\"}");
+        return;
+    }
+    let api_url = normalize_dapnet_api_url(&dapnet.api_url);
+    if api_url.is_empty() {
+        http_json_response(stream, 200, "{\"ok\":false,\"error\":\"DAPNET api_url is empty\"}");
+        return;
+    }
+    let callsigns = dapnet_string_list(&json, &["callSignNames", "callsigns", "call_signs"]);
+    let groups = dapnet_string_list(&json, &["transmitterGroupNames", "transmitter_groups", "groups"]);
+    if callsigns.is_empty() && groups.is_empty() {
+        http_json_response(stream, 200, "{\"ok\":false,\"error\":\"Set at least one callsign or transmitter group\"}");
+        return;
+    }
+    let emergency = json.get("emergency").and_then(|v| v.as_bool()).unwrap_or(false);
+    let req_body = build_dapnet_call_payload(&text, callsigns, groups, emergency);
+
+    let client = match reqwest::blocking::Client::builder()
+        .timeout(std::time::Duration::from_secs(15))
+        .build()
+    {
+        Ok(client) => client,
+        Err(e) => {
+            http_json_response(stream, 200, &serde_json::json!({"ok":false,"error":format!("HTTP client error: {e}")}).to_string());
+            return;
+        }
+    };
+    let mut request = client.post(&api_url).json(&req_body);
+    if !dapnet.username.trim().is_empty() {
+        request = request.basic_auth(dapnet.username.trim().to_string(), Some(dapnet.password.as_ref().to_string()));
+    }
+    match request.send() {
+        Ok(resp) => {
+            let status = resp.status();
+            if status.is_success() {
+                tracing::info!(
+                    "Dashboard: DAPNET outbound sent via {} (callsigns={} groups={} emergency={})",
+                    api_url,
+                    req_body["callSignNames"].as_array().map(|a| a.len()).unwrap_or(0),
+                    req_body["transmitterGroupNames"].as_array().map(|a| a.len()).unwrap_or(0),
+                    emergency
+                );
+                push_dapnet_log_and_broadcast(
+                    state,
+                    clients,
+                    "tx",
+                    format!("api:{}", chrono::Utc::now().timestamp_millis()),
+                    req_body["callSignNames"].as_array()
+                        .and_then(|a| a.first())
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("")
+                        .to_string(),
+                    req_body["transmitterGroupNames"].as_array()
+                        .map(|a| a.iter().filter_map(|v| v.as_str()).collect::<Vec<_>>().join(","))
+                        .unwrap_or_default(),
+                    text,
+                    if emergency { Some(1) } else { None },
+                    vec!["dapnet-api".to_string()],
+                );
+                http_json_response(stream, 200, "{\"ok\":true}");
+            } else {
+                let err = format!("DAPNET API returned HTTP {}", status.as_u16());
+                tracing::warn!("Dashboard: {}", err);
+                http_json_response(stream, 200, &serde_json::json!({"ok":false,"error":err}).to_string());
+            }
+        }
+        Err(e) => {
+            tracing::warn!("Dashboard: DAPNET outbound send failed: {}", e);
+            http_json_response(stream, 200, &serde_json::json!({"ok":false,"error":format!("Network error: {e}")}).to_string());
+        }
+    }
 }
 
 #[cfg(test)]

--- a/crates/tetra-entities/src/net_dashboard/snom_notify.rs
+++ b/crates/tetra-entities/src/net_dashboard/snom_notify.rs
@@ -1,0 +1,121 @@
+//! Dashboard-side persistence and helpers for Snom XML NOTIFY settings.
+
+use tetra_config::bluestation::SnomNotifyRuntimeOverride;
+
+pub fn mask_secret(secret: &str) -> String {
+    crate::net_dashboard::dapnet::mask_secret(secret)
+}
+
+fn toml_escape(s: &str) -> String {
+    s.replace('\\', "\\\\").replace('"', "\\\"")
+}
+
+fn string_array_toml(values: &[String]) -> String {
+    values
+        .iter()
+        .map(|v| format!("\"{}\"", toml_escape(v)))
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+fn ric_set_toml(rics: &std::collections::BTreeSet<u32>) -> String {
+    rics.iter()
+        .map(|ric| format!("\"{}\"", tetra_config::bluestation::format_ric_route_key(*ric)))
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+fn u32_set_toml(values: &std::collections::BTreeSet<u32>) -> String {
+    values
+        .iter()
+        .map(|v| v.to_string())
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+/// Rewrite (or insert) the `[snom_notify]` section in the TOML file. A `.snom.bak` backup is made.
+pub fn write_snom_notify_to_toml(
+    config_path: &str,
+    ov: &SnomNotifyRuntimeOverride,
+) -> std::io::Result<()> {
+    let original = std::fs::read_to_string(config_path)?;
+    let section = format!(
+        "[snom_notify]\n\
+         enabled = {}\n\
+         ami_host = \"{}\"\n\
+         ami_port = {}\n\
+         ami_username = \"{}\"\n\
+         ami_password = \"{}\"\n\
+         endpoints = [{}]\n\
+         notify_sds = {}\n\
+         notify_dapnet = {}\n\
+         notify_telegram = {}\n\
+         sds_directions = [{}]\n\
+         dapnet_allowed_rics = [{}]\n\
+         sds_allowed_issis = [{}]\n\
+         title_prefix = \"{}\"\n\
+         notify_event = \"{}\"\n\
+         content_type = \"{}\"\n\
+         subscription_state = \"{}\"\n\
+         max_text_chars = {}\n\
+         connect_timeout_secs = {}",
+        ov.enabled,
+        toml_escape(&ov.ami_host),
+        ov.ami_port,
+        toml_escape(&ov.ami_username),
+        toml_escape(&ov.ami_password),
+        string_array_toml(&ov.endpoints),
+        ov.notify_sds,
+        ov.notify_dapnet,
+        ov.notify_telegram,
+        string_array_toml(&ov.sds_directions),
+        ric_set_toml(&ov.dapnet_allowed_rics),
+        u32_set_toml(&ov.sds_allowed_issis),
+        toml_escape(&ov.title_prefix),
+        toml_escape(&ov.notify_event),
+        toml_escape(&ov.content_type),
+        toml_escape(&ov.subscription_state),
+        ov.max_text_chars.clamp(40, 2000),
+        ov.connect_timeout_secs.clamp(1, 30),
+    );
+
+    let lines: Vec<&str> = original.lines().collect();
+    let mut out: Vec<String> = Vec::with_capacity(lines.len() + 24);
+    let mut i = 0;
+    let mut replaced = false;
+
+    while i < lines.len() {
+        let trimmed = lines[i].trim_start();
+        if trimmed.starts_with("[snom_notify]") {
+            out.push(section.clone());
+            replaced = true;
+            i += 1;
+            while i < lines.len() {
+                let t = lines[i].trim_start();
+                if t.starts_with('[') && t.contains(']') {
+                    break;
+                }
+                i += 1;
+            }
+            continue;
+        }
+        out.push(lines[i].to_string());
+        i += 1;
+    }
+
+    if !replaced {
+        if !out.is_empty() && !out.last().map(|l| l.is_empty()).unwrap_or(true) {
+            out.push(String::new());
+        }
+        out.push(section);
+    }
+
+    let mut new_content = out.join("\n");
+    if original.ends_with('\n') {
+        new_content.push('\n');
+    }
+
+    let backup = format!("{config_path}.snom.bak");
+    let _ = std::fs::copy(config_path, &backup);
+    std::fs::write(config_path, new_content)
+}

--- a/crates/tetra-entities/src/net_dashboard/state.rs
+++ b/crates/tetra-entities/src/net_dashboard/state.rs
@@ -72,6 +72,20 @@ pub struct SdsLogEntry {
     pub text: String,
 }
 
+/// DAPNET Log entry — one inbound RWTH-core message or outbound Hampager API send. Persisted to
+/// disk (`dapnet_log.json` next to the active config) so the history survives a restart.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct DapnetLogEntry {
+    pub ts: String,           // "YYYY-MM-DD HH:MM:SS" local time
+    pub direction: String,    // "rx" | "tx"
+    pub id: String,
+    pub callsign: String,
+    pub recipient: String,
+    pub text: String,
+    pub priority: Option<u8>,
+    pub paths: Vec<String>,
+}
+
 /// Shared mutable state for the dashboard, protected by RwLock
 #[derive(Debug, Default)]
 pub struct DashboardStateInner {
@@ -86,6 +100,10 @@ pub struct DashboardStateInner {
     pub sds_log: std::collections::VecDeque<SdsLogEntry>,
     /// Where `sds_log` is persisted. Empty disables persistence (e.g. config without a parent dir).
     sds_log_path: std::path::PathBuf,
+    /// DAPNET Log ring (chronological, oldest at the front). Backed by an on-disk JSON file.
+    pub dapnet_log: std::collections::VecDeque<DapnetLogEntry>,
+    /// Where `dapnet_log` is persisted. Empty disables persistence.
+    dapnet_log_path: std::path::PathBuf,
     pub config_path: String,
     pub brew_online: bool,
     pub brew_version: u8,
@@ -153,6 +171,8 @@ pub const LAST_HEARD_MAX: usize = 50;
 /// Max SDS Log entries kept in memory and on disk. The log is human-messaging volume, so a
 /// few hundred entries cover a long history while keeping the JSON file small.
 pub const SDS_LOG_MAX: usize = 500;
+/// Max DAPNET Log entries kept in memory and on disk.
+pub const DAPNET_LOG_MAX: usize = 500;
 
 #[derive(Debug)]
 pub struct MsEntry {
@@ -204,6 +224,14 @@ impl DashboardStateInner {
         if !sds_log.is_empty() {
             tracing::info!("SDS Log: loaded {} entries from {}", sds_log.len(), sds_log_path.display());
         }
+        let dapnet_log_path = std::path::Path::new(&config_path)
+            .parent()
+            .map(|d| d.join("dapnet_log.json"))
+            .unwrap_or_else(|| std::path::PathBuf::from("dapnet_log.json"));
+        let dapnet_log = load_dapnet_log(&dapnet_log_path);
+        if !dapnet_log.is_empty() {
+            tracing::info!("DAPNET Log: loaded {} entries from {}", dapnet_log.len(), dapnet_log_path.display());
+        }
         Self {
             ms_map: HashMap::new(),
             calls: HashMap::new(),
@@ -212,6 +240,8 @@ impl DashboardStateInner {
             last_heard: std::collections::VecDeque::with_capacity(LAST_HEARD_MAX + 1),
             sds_log,
             sds_log_path,
+            dapnet_log,
+            dapnet_log_path,
             config_path,
             brew_online: false,
             brew_version: 0,
@@ -279,6 +309,54 @@ impl DashboardStateInner {
         }
     }
 
+    pub fn clear_sds_log(&mut self) {
+        self.sds_log.clear();
+        self.persist_sds_log();
+    }
+
+    /// Append one DAPNET event to the log, evicting the oldest past DAPNET_LOG_MAX, then persist
+    /// the ring to disk. Best-effort only: write failures never affect radio operation.
+    pub fn push_dapnet_log(
+        &mut self,
+        direction: &str,
+        id: String,
+        callsign: String,
+        recipient: String,
+        text: String,
+        priority: Option<u8>,
+        paths: Vec<String>,
+    ) {
+        let entry = DapnetLogEntry {
+            ts: chrono::Local::now().format("%Y-%m-%d %H:%M:%S").to_string(),
+            direction: direction.to_string(),
+            id,
+            callsign,
+            recipient,
+            text,
+            priority,
+            paths,
+        };
+        if self.dapnet_log.len() >= DAPNET_LOG_MAX {
+            self.dapnet_log.pop_front();
+        }
+        self.dapnet_log.push_back(entry);
+        self.persist_dapnet_log();
+    }
+
+    fn persist_dapnet_log(&self) {
+        if self.dapnet_log_path.as_os_str().is_empty() {
+            return;
+        }
+        if let Ok(text) = serde_json::to_string(&self.dapnet_log) {
+            let _ = std::fs::write(&self.dapnet_log_path, text);
+        }
+    }
+
+    pub fn clear_dapnet_log(&mut self) {
+        self.dapnet_log.clear();
+        self.persist_dapnet_log();
+    }
+
     pub fn snapshot_ms(&self) -> Vec<MsState> {
         self.ms_map.values().map(|e| MsState {
             issi: e.issi,
@@ -344,6 +422,13 @@ impl DashboardStateInner {
 /// Load the persisted SDS Log from disk. Returns an empty ring when the file is missing or
 /// unparseable (e.g. first run, or a schema change) — the log is best-effort, never fatal.
 fn load_sds_log(path: &std::path::Path) -> std::collections::VecDeque<SdsLogEntry> {
+    let Ok(text) = std::fs::read_to_string(path) else {
+        return std::collections::VecDeque::new();
+    };
+    serde_json::from_str(&text).unwrap_or_default()
+}
+
+fn load_dapnet_log(path: &std::path::Path) -> std::collections::VecDeque<DapnetLogEntry> {
     let Ok(text) = std::fs::read_to_string(path) else {
         return std::collections::VecDeque::new();
     };

--- a/crates/tetra-entities/src/net_geoalarm/mod.rs
+++ b/crates/tetra-entities/src/net_geoalarm/mod.rs
@@ -1,0 +1,570 @@
+//! GeoAlarm geofence worker.
+//!
+//! The worker is intentionally small and off the real-time TETRA path. TETRA LIP and MeshCom
+//! sources feed decoded coordinates into this channel. When a device enters the configured
+//! radius, the worker forwards through the existing SDS, TPG2200, Snom/SIP and Telegram paths.
+
+use std::collections::{HashMap, VecDeque};
+use std::thread;
+use std::time::{Duration, Instant};
+
+use tetra_config::bluestation::{
+    CfgGeoalarm, GeoalarmEventStatus, GeoalarmRuntimeStatus, SharedConfig,
+};
+
+use crate::net_control::commands::ControlCommand;
+use crate::net_snom::SnomNotifySink;
+use crate::net_telegram::TelegramAlertSink;
+use crate::tpg2200::{build_sds_text_payload, build_tpg2200_callout_payload, format_hex_bytes};
+
+type CmdSender = crossbeam_channel::Sender<ControlCommand>;
+
+const STATUS_TICK: Duration = Duration::from_secs(1);
+const MAX_EVENTS: usize = 250;
+
+#[derive(Debug, Clone)]
+enum GeoAlarmSource {
+    Tetra { issi: u32 },
+    Meshcom { src: String },
+}
+
+impl GeoAlarmSource {
+    fn label(&self) -> String {
+        match self {
+            Self::Tetra { issi } => format!("TETRA {issi}"),
+            Self::Meshcom { src } => format!("MeshCom {src}"),
+        }
+    }
+
+    fn key(&self) -> String {
+        match self {
+            Self::Tetra { issi } => format!("tetra:{issi}"),
+            Self::Meshcom { src } => format!("meshcom:{}", src.trim().to_ascii_uppercase()),
+        }
+    }
+
+    fn kind(&self) -> &'static str {
+        match self {
+            Self::Tetra { .. } => "tetra",
+            Self::Meshcom { .. } => "meshcom",
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+struct GeoAlarmUpdate {
+    source: GeoAlarmSource,
+    lat: f64,
+    lon: f64,
+}
+
+#[derive(Clone)]
+pub struct GeoAlarmSink {
+    tx: crossbeam_channel::Sender<GeoAlarmUpdate>,
+}
+
+impl GeoAlarmSink {
+    #[inline]
+    pub fn send_tetra_lip(&self, source_issi: u32, text: &str) {
+        if let Some((lat, lon)) = parse_lip_position_text(text) {
+            self.send_tetra_position(source_issi, lat, lon);
+        }
+    }
+
+    #[inline]
+    pub fn send_tetra_position(&self, source_issi: u32, lat: f64, lon: f64) {
+        let _ = self.tx.send(GeoAlarmUpdate {
+            source: GeoAlarmSource::Tetra { issi: source_issi },
+            lat,
+            lon,
+        });
+    }
+
+    #[inline]
+    pub fn send_meshcom_position(&self, src: String, lat: f64, lon: f64) {
+        let src = src.trim();
+        if src.is_empty() {
+            return;
+        }
+        let _ = self.tx.send(GeoAlarmUpdate {
+            source: GeoAlarmSource::Meshcom {
+                src: src.to_string(),
+            },
+            lat,
+            lon,
+        });
+    }
+}
+
+fn geoalarm_channel() -> (GeoAlarmSink, crossbeam_channel::Receiver<GeoAlarmUpdate>) {
+    let (tx, rx) = crossbeam_channel::unbounded();
+    (GeoAlarmSink { tx }, rx)
+}
+
+pub fn spawn_geoalarm_worker(
+    cfg: SharedConfig,
+    cmce_cmd_tx: Option<CmdSender>,
+    telegram_sink: Option<TelegramAlertSink>,
+    snom_sink: Option<SnomNotifySink>,
+) -> Option<GeoAlarmSink> {
+    let (sink, rx) = geoalarm_channel();
+    match thread::Builder::new()
+        .name("geoalarm-worker".into())
+        .spawn(move || GeoAlarmWorker::new(cfg, cmce_cmd_tx, telegram_sink, snom_sink, rx).run())
+    {
+        Ok(_handle) => Some(sink),
+        Err(err) => {
+            tracing::warn!("GeoAlarm: failed to spawn worker thread: {}", err);
+            None
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+struct DeviceState {
+    inside: bool,
+    last_alarm: Option<Instant>,
+}
+
+struct GeoAlarmWorker {
+    cfg: SharedConfig,
+    cmce_cmd_tx: Option<CmdSender>,
+    telegram_sink: Option<TelegramAlertSink>,
+    snom_sink: Option<SnomNotifySink>,
+    rx: crossbeam_channel::Receiver<GeoAlarmUpdate>,
+    devices: HashMap<String, DeviceState>,
+    events: VecDeque<GeoalarmEventStatus>,
+    seen_positions: u64,
+    alarm_count: u64,
+    last_position: Option<String>,
+    last_alarm: Option<String>,
+    last_error: Option<String>,
+    last_enabled: Option<bool>,
+    next_tpg2200_incident: u16,
+    last_incident_base: Option<u16>,
+}
+
+impl GeoAlarmWorker {
+    fn new(
+        cfg: SharedConfig,
+        cmce_cmd_tx: Option<CmdSender>,
+        telegram_sink: Option<TelegramAlertSink>,
+        snom_sink: Option<SnomNotifySink>,
+        rx: crossbeam_channel::Receiver<GeoAlarmUpdate>,
+    ) -> Self {
+        let next_tpg2200_incident = cfg.effective_geoalarm().tpg2200_incident_base.clamp(1, 256);
+        Self {
+            cfg,
+            cmce_cmd_tx,
+            telegram_sink,
+            snom_sink,
+            rx,
+            devices: HashMap::new(),
+            events: VecDeque::new(),
+            seen_positions: 0,
+            alarm_count: 0,
+            last_position: None,
+            last_alarm: None,
+            last_error: None,
+            last_enabled: None,
+            next_tpg2200_incident,
+            last_incident_base: None,
+        }
+    }
+
+    fn run(&mut self) {
+        loop {
+            let geoalarm = self.cfg.effective_geoalarm();
+            self.note_config_state(&geoalarm);
+            match self.rx.recv_timeout(STATUS_TICK) {
+                Ok(update) => self.handle_update(&geoalarm, update),
+                Err(crossbeam_channel::RecvTimeoutError::Timeout) => {}
+                Err(crossbeam_channel::RecvTimeoutError::Disconnected) => break,
+            }
+            self.publish_status(&geoalarm);
+        }
+        tracing::info!("GeoAlarm worker exiting");
+    }
+
+    fn note_config_state(&mut self, geoalarm: &CfgGeoalarm) {
+        if self.last_enabled == Some(geoalarm.enabled) {
+            return;
+        }
+        if geoalarm.enabled {
+            tracing::info!(
+                "GeoAlarm enabled (center={:.6},{:.6} radius={:.0}m tetra={} meshcom={} tpg2200={} sds={} sip={} telegram={})",
+                geoalarm.flowstation_lat,
+                geoalarm.flowstation_lon,
+                geoalarm.radius_m,
+                geoalarm.trigger_tetra,
+                geoalarm.trigger_meshcom,
+                geoalarm.forward_tpg2200,
+                geoalarm.forward_sds,
+                geoalarm.forward_sip,
+                geoalarm.forward_telegram
+            );
+            if !(geoalarm.forward_tpg2200
+                || geoalarm.forward_sds
+                || geoalarm.forward_sip
+                || geoalarm.forward_telegram)
+            {
+                tracing::warn!("GeoAlarm: enabled but no forwarding target is enabled");
+            }
+        } else {
+            tracing::info!("GeoAlarm disabled");
+        }
+        self.last_enabled = Some(geoalarm.enabled);
+    }
+
+    fn handle_update(&mut self, geoalarm: &CfgGeoalarm, update: GeoAlarmUpdate) {
+        if !geoalarm.enabled {
+            return;
+        }
+        if !coord_valid(update.lat, update.lon) {
+            self.set_error(format!(
+                "invalid coordinates from {}: {},{}",
+                update.source.label(),
+                update.lat,
+                update.lon
+            ));
+            return;
+        }
+        if !source_enabled(geoalarm, &update.source) || !source_allowed(geoalarm, &update.source) {
+            return;
+        }
+
+        self.seen_positions = self.seen_positions.saturating_add(1);
+        let distance = haversine_m(
+            geoalarm.flowstation_lat,
+            geoalarm.flowstation_lon,
+            update.lat,
+            update.lon,
+        );
+        let inside = distance <= geoalarm.radius_m;
+        let label = update.source.label();
+        let stamp = now_stamp();
+        self.last_position = Some(format!(
+            "{} {:.0}m ({:.6},{:.6})",
+            label, distance, update.lat, update.lon
+        ));
+
+        let key = update.source.key();
+        let cooldown = Duration::from_secs(geoalarm.cooldown_secs.max(1));
+        let (was_inside, cooldown_elapsed) = {
+            let state = self.devices.entry(key.clone()).or_insert(DeviceState {
+                inside: false,
+                last_alarm: None,
+            });
+            let cooldown_elapsed = state
+                .last_alarm
+                .map(|last| last.elapsed() >= cooldown)
+                .unwrap_or(true);
+            let was_inside = state.inside;
+            state.inside = inside;
+            (was_inside, cooldown_elapsed)
+        };
+        let should_alarm = inside && (!was_inside || cooldown_elapsed);
+
+        let mut paths = Vec::new();
+        if should_alarm {
+            paths = self.forward_alarm(geoalarm, &update.source, update.lat, update.lon, distance);
+            if !paths.is_empty() {
+                self.alarm_count = self.alarm_count.saturating_add(1);
+                self.last_alarm = Some(format!("{} via {}", self.last_position.clone().unwrap_or_default(), paths.join(",")));
+                if let Some(state) = self.devices.get_mut(&key) {
+                    state.last_alarm = Some(Instant::now());
+                }
+            }
+        }
+
+        self.events.push_front(GeoalarmEventStatus {
+            ts: stamp,
+            source: update.source.kind().to_string(),
+            device: label,
+            lat: update.lat,
+            lon: update.lon,
+            distance_m: distance,
+            inside_radius: inside,
+            alarmed: should_alarm && !paths.is_empty(),
+            paths,
+        });
+        while self.events.len() > MAX_EVENTS {
+            self.events.pop_back();
+        }
+    }
+
+    fn forward_alarm(
+        &mut self,
+        geoalarm: &CfgGeoalarm,
+        source: &GeoAlarmSource,
+        lat: f64,
+        lon: f64,
+        distance_m: f64,
+    ) -> Vec<String> {
+        let mut paths = Vec::new();
+        let label = source.label();
+        let body = format!(
+            "{} {:.0}m ({:.6},{:.6})",
+            label,
+            distance_m.max(0.0),
+            lat,
+            lon
+        );
+
+        if geoalarm.forward_tpg2200 {
+            match self.forward_tpg2200(geoalarm, &body) {
+                Ok(()) => paths.push("tpg2200".to_string()),
+                Err(err) => self.warn_forward("TPG2200", &label, err),
+            }
+        }
+        if geoalarm.forward_sds {
+            match self.forward_sds(geoalarm, &body) {
+                Ok(()) => paths.push("sds".to_string()),
+                Err(err) => self.warn_forward("SDS", &label, err),
+            }
+        }
+        if geoalarm.forward_sip {
+            match self.forward_sip(geoalarm, &label, &body, distance_m, lat, lon) {
+                Ok(()) => paths.push("sip".to_string()),
+                Err(err) => self.warn_forward("SIP", &label, err),
+            }
+        }
+        if geoalarm.forward_telegram {
+            match self.forward_telegram(geoalarm, &label, &body) {
+                Ok(()) => paths.push("telegram".to_string()),
+                Err(err) => self.warn_forward("Telegram", &label, err),
+            }
+        }
+
+        if paths.is_empty() {
+            tracing::info!("GeoAlarm: {} entered radius but no forwarding target succeeded", label);
+        } else {
+            tracing::info!(
+                "GeoAlarm: {} entered radius ({:.0}m <= {:.0}m), paths={}",
+                label,
+                distance_m,
+                geoalarm.radius_m,
+                paths.join(",")
+            );
+            self.last_error = None;
+        }
+        paths
+    }
+
+    fn forward_tpg2200(&mut self, geoalarm: &CfgGeoalarm, body: &str) -> Result<(), String> {
+        if geoalarm.tpg2200_dest_issi == 0 {
+            return Err("tpg2200_dest_issi is 0".to_string());
+        }
+        let Some(tx) = self.cmce_cmd_tx.clone() else {
+            return Err("CMCE control sender unavailable".to_string());
+        };
+        let incident_base = geoalarm.tpg2200_incident_base.clamp(1, 256);
+        if self.last_incident_base != Some(incident_base) {
+            self.next_tpg2200_incident = incident_base;
+            self.last_incident_base = Some(incident_base);
+        }
+        let incident = self.next_incident();
+        let text = prefixed_text(&geoalarm.tpg2200_text_prefix, body);
+        let (text, truncated) = truncate_chars(&text, geoalarm.tpg2200_max_text_chars);
+        if truncated {
+            tracing::warn!(
+                "GeoAlarm: TPG2200 text truncated to {} chars",
+                geoalarm.tpg2200_max_text_chars
+            );
+        }
+        let payload = build_tpg2200_callout_payload(incident, &text);
+        tracing::debug!(
+            "GeoAlarm: TPG2200 incident={} dest={} payload=[{}]",
+            incident,
+            geoalarm.tpg2200_dest_issi,
+            format_hex_bytes(&payload)
+        );
+        tx.send(ControlCommand::SendRawSdsType4 {
+            handle: 0,
+            source_ssi: geoalarm.tpg2200_source_issi,
+            dest_ssi: geoalarm.tpg2200_dest_issi,
+            dest_is_group: false,
+            len_bits: (payload.len() * 8) as u16,
+            payload,
+        })
+        .map_err(|e| format!("send to CMCE failed: {}", e))
+    }
+
+    fn forward_sds(&self, geoalarm: &CfgGeoalarm, body: &str) -> Result<(), String> {
+        if geoalarm.sds_dest_issi == 0 {
+            return Err("sds_dest_issi is 0".to_string());
+        }
+        let Some(tx) = &self.cmce_cmd_tx else {
+            return Err("CMCE control sender unavailable".to_string());
+        };
+        let text = prefixed_text("GeoAlarm:", body);
+        let (len_bits, payload) = build_sds_text_payload(&text);
+        tx.send(ControlCommand::SendSds {
+            handle: 0,
+            source_ssi: geoalarm.sds_source_issi,
+            dest_ssi: geoalarm.sds_dest_issi,
+            dest_is_group: geoalarm.sds_dest_is_group,
+            len_bits,
+            payload,
+        })
+        .map_err(|e| format!("send to CMCE failed: {}", e))
+    }
+
+    fn forward_sip(
+        &self,
+        geoalarm: &CfgGeoalarm,
+        source: &str,
+        body: &str,
+        distance_m: f64,
+        lat: f64,
+        lon: f64,
+    ) -> Result<(), String> {
+        let Some(sink) = &self.snom_sink else {
+            return Err("Snom notify sink unavailable".to_string());
+        };
+        sink.send_geoalarm(
+            geoalarm.sip_title_prefix.clone(),
+            source.to_string(),
+            body.to_string(),
+            distance_m,
+            lat,
+            lon,
+        );
+        Ok(())
+    }
+
+    fn forward_telegram(
+        &self,
+        geoalarm: &CfgGeoalarm,
+        source: &str,
+        body: &str,
+    ) -> Result<(), String> {
+        let Some(sink) = &self.telegram_sink else {
+            return Err("Telegram alert sink unavailable".to_string());
+        };
+        sink.send_geoalarm(
+            geoalarm.telegram_prefix.clone(),
+            source.to_string(),
+            body.to_string(),
+        );
+        Ok(())
+    }
+
+    fn warn_forward(&mut self, path: &str, source: &str, err: String) {
+        let msg = format!("{path} forwarding failed for {source}: {err}");
+        tracing::warn!("GeoAlarm: {}", msg);
+        self.set_error(msg);
+    }
+
+    fn set_error(&mut self, msg: String) {
+        self.last_error = Some(msg);
+    }
+
+    fn next_incident(&mut self) -> u16 {
+        let incident = self.next_tpg2200_incident.clamp(1, 256);
+        self.next_tpg2200_incident = if incident >= 256 { 1 } else { incident + 1 };
+        incident
+    }
+
+    fn publish_status(&self, geoalarm: &CfgGeoalarm) {
+        let mut state = self.cfg.state_write();
+        state.geoalarm_status = GeoalarmRuntimeStatus {
+            configured: true,
+            enabled: geoalarm.enabled,
+            center: format!("{:.6},{:.6}", geoalarm.flowstation_lat, geoalarm.flowstation_lon),
+            radius_m: geoalarm.radius_m,
+            trigger_tetra: geoalarm.trigger_tetra,
+            trigger_meshcom: geoalarm.trigger_meshcom,
+            forward_tpg2200: geoalarm.forward_tpg2200,
+            forward_sds: geoalarm.forward_sds,
+            forward_sip: geoalarm.forward_sip,
+            forward_telegram: geoalarm.forward_telegram,
+            seen_positions: self.seen_positions,
+            alarm_count: self.alarm_count,
+            last_position: self.last_position.clone(),
+            last_alarm: self.last_alarm.clone(),
+            last_error: self.last_error.clone(),
+            events: self.events.iter().cloned().collect(),
+        };
+    }
+}
+
+fn source_enabled(geoalarm: &CfgGeoalarm, source: &GeoAlarmSource) -> bool {
+    match source {
+        GeoAlarmSource::Tetra { .. } => geoalarm.trigger_tetra,
+        GeoAlarmSource::Meshcom { .. } => geoalarm.trigger_meshcom,
+    }
+}
+
+fn source_allowed(geoalarm: &CfgGeoalarm, source: &GeoAlarmSource) -> bool {
+    match source {
+        GeoAlarmSource::Tetra { issi } => {
+            !geoalarm.tetra_issi_blacklist.contains(issi)
+                && (geoalarm.tetra_issi_whitelist.is_empty()
+                    || geoalarm.tetra_issi_whitelist.contains(issi))
+        }
+        GeoAlarmSource::Meshcom { src } => {
+            let src = src.trim().to_ascii_uppercase();
+            !geoalarm.meshcom_source_blacklist.contains(&src)
+                && (geoalarm.meshcom_source_whitelist.is_empty()
+                    || geoalarm.meshcom_source_whitelist.contains(&src))
+        }
+    }
+}
+
+fn coord_valid(lat: f64, lon: f64) -> bool {
+    lat.is_finite()
+        && lon.is_finite()
+        && (-90.0..=90.0).contains(&lat)
+        && (-180.0..=180.0).contains(&lon)
+}
+
+pub fn parse_lip_position_text(text: &str) -> Option<(f64, f64)> {
+    let rest = text.trim().strip_prefix("LIP position:")?.trim();
+    let (lat, lon) = rest.split_once(',')?;
+    let lat = lat.trim().parse::<f64>().ok()?;
+    let lon = lon.trim().parse::<f64>().ok()?;
+    if coord_valid(lat, lon) {
+        Some((lat, lon))
+    } else {
+        None
+    }
+}
+
+fn haversine_m(lat1: f64, lon1: f64, lat2: f64, lon2: f64) -> f64 {
+    let r = 6_371_000.0_f64;
+    let phi1 = lat1.to_radians();
+    let phi2 = lat2.to_radians();
+    let dphi = (lat2 - lat1).to_radians();
+    let dlambda = (lon2 - lon1).to_radians();
+    let a = (dphi / 2.0).sin().powi(2)
+        + phi1.cos() * phi2.cos() * (dlambda / 2.0).sin().powi(2);
+    let c = 2.0 * a.sqrt().atan2((1.0 - a).sqrt());
+    r * c
+}
+
+fn prefixed_text(prefix: &str, text: &str) -> String {
+    let prefix = prefix.trim();
+    let text = text.trim();
+    if prefix.is_empty() {
+        text.to_string()
+    } else if text.is_empty() {
+        prefix.to_string()
+    } else if prefix.ends_with(':') {
+        format!("{prefix} {text}")
+    } else {
+        format!("{prefix} {text}")
+    }
+}
+
+fn truncate_chars(text: &str, max: usize) -> (String, bool) {
+    if text.chars().count() <= max {
+        (text.to_string(), false)
+    } else {
+        (text.chars().take(max).collect(), true)
+    }
+}
+
+fn now_stamp() -> String {
+    chrono::Local::now().format("%Y-%m-%d %H:%M:%S").to_string()
+}

--- a/crates/tetra-entities/src/net_snom/mod.rs
+++ b/crates/tetra-entities/src/net_snom/mod.rs
@@ -1,0 +1,588 @@
+//! Snom XML minibrowser notifications via Asterisk AMI.
+//!
+//! This worker stays outside the real-time TETRA path. It consumes cloned telemetry / alert
+//! events, builds a one-line `SnomIPPhoneText` XML document, and asks Asterisk AMI to send a
+//! `PJSIPNotify` to configured endpoints.
+
+use std::io::{Read, Write};
+use std::net::{TcpStream, ToSocketAddrs};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::thread;
+use std::time::Duration;
+
+use tetra_config::bluestation::{CfgSnomNotify, SharedConfig, parse_ric_route_key};
+
+use crate::net_telemetry::TelemetryEvent;
+
+const READ_LIMIT: usize = 64 * 1024;
+
+static ACTION_ID: AtomicU64 = AtomicU64::new(1);
+
+#[derive(Debug, Clone)]
+pub enum SnomNotifyMsg {
+    Event(TelemetryEvent),
+    TelegramHtml(String),
+    Meshcom {
+        title: String,
+        src: String,
+        dst: Option<String>,
+        text: String,
+        msg_id: Option<String>,
+    },
+    Geoalarm {
+        title: String,
+        source: String,
+        text: String,
+        distance_m: f64,
+        lat: f64,
+        lon: f64,
+    },
+}
+
+#[derive(Clone)]
+pub struct SnomNotifySink {
+    tx: crossbeam_channel::Sender<SnomNotifyMsg>,
+}
+
+impl SnomNotifySink {
+    #[inline]
+    pub fn send_event(&self, event: TelemetryEvent) {
+        let _ = self.tx.send(SnomNotifyMsg::Event(event));
+    }
+
+    #[inline]
+    pub fn send_telegram_html(&self, html: String) {
+        let _ = self.tx.send(SnomNotifyMsg::TelegramHtml(html));
+    }
+
+    #[inline]
+    pub fn send_meshcom(
+        &self,
+        title: String,
+        src: String,
+        dst: Option<String>,
+        text: String,
+        msg_id: Option<String>,
+    ) {
+        let _ = self.tx.send(SnomNotifyMsg::Meshcom {
+            title,
+            src,
+            dst,
+            text,
+            msg_id,
+        });
+    }
+
+    #[inline]
+    pub fn send_geoalarm(
+        &self,
+        title: String,
+        source: String,
+        text: String,
+        distance_m: f64,
+        lat: f64,
+        lon: f64,
+    ) {
+        let _ = self.tx.send(SnomNotifyMsg::Geoalarm {
+            title,
+            source,
+            text,
+            distance_m,
+            lat,
+            lon,
+        });
+    }
+}
+
+pub struct SnomNotifySource {
+    rx: crossbeam_channel::Receiver<SnomNotifyMsg>,
+}
+
+impl SnomNotifySource {
+    fn recv(&self) -> Result<SnomNotifyMsg, crossbeam_channel::RecvError> {
+        self.rx.recv()
+    }
+}
+
+pub fn snom_notify_channel() -> (SnomNotifySink, SnomNotifySource) {
+    let (tx, rx) = crossbeam_channel::unbounded();
+    (SnomNotifySink { tx }, SnomNotifySource { rx })
+}
+
+pub fn spawn_snom_notify_worker(
+    cfg: SharedConfig,
+    source: SnomNotifySource,
+) -> Option<thread::JoinHandle<()>> {
+    match thread::Builder::new()
+        .name("snom-notify".into())
+        .spawn(move || SnomNotifyWorker::new(cfg, source).run())
+    {
+        Ok(handle) => Some(handle),
+        Err(err) => {
+            tracing::warn!("Snom notify: failed to spawn worker thread: {}", err);
+            None
+        }
+    }
+}
+
+struct SnomNotifyWorker {
+    cfg: SharedConfig,
+    source: SnomNotifySource,
+}
+
+impl SnomNotifyWorker {
+    fn new(cfg: SharedConfig, source: SnomNotifySource) -> Self {
+        Self { cfg, source }
+    }
+
+    fn run(&self) {
+        tracing::info!("Snom notify worker started");
+        while let Ok(msg) = self.source.recv() {
+            let cfg = self.cfg.effective_snom_notify();
+            if !cfg.enabled {
+                continue;
+            }
+            let Some(notification) = self.notification_for_msg(&cfg, msg) else {
+                continue;
+            };
+            if let Err(err) = send_notification(&cfg, &notification.title, &notification.lines) {
+                tracing::warn!("Snom notify: {}", err);
+            }
+        }
+        tracing::info!("Snom notify worker exiting");
+    }
+
+    fn notification_for_msg(
+        &self,
+        cfg: &CfgSnomNotify,
+        msg: SnomNotifyMsg,
+    ) -> Option<SnomNotification> {
+        match msg {
+            SnomNotifyMsg::Event(TelemetryEvent::SdsLog {
+                direction,
+                source_issi,
+                dest_issi,
+                is_group,
+                protocol_id,
+                text,
+            }) => {
+                if !cfg.notify_sds || !direction_allowed(cfg, &direction) {
+                    return None;
+                }
+                if !sds_issi_allowed(cfg, source_issi, dest_issi) {
+                    return None;
+                }
+                let mut lines = vec![
+                    format!("Dir: {}", direction.to_ascii_uppercase()),
+                    format!("From: {source_issi}"),
+                    format!("To: {}{}", if is_group { "GSSI " } else { "" }, dest_issi),
+                ];
+                if protocol_id != 0 {
+                    lines.push(format!("PID: {protocol_id}"));
+                }
+                lines.push(format_message_line("Text", &text, cfg.max_text_chars));
+                Some(SnomNotification {
+                    title: prefixed_title(&cfg.title_prefix, "TETRA SDS"),
+                    lines,
+                })
+            }
+            SnomNotifyMsg::Event(TelemetryEvent::DapnetLog {
+                direction,
+                id: _,
+                callsign,
+                recipient,
+                text,
+                priority,
+                paths,
+            }) => {
+                if !cfg.notify_dapnet {
+                    return None;
+                }
+                if !dapnet_ric_allowed(cfg, &recipient) {
+                    return None;
+                }
+                let mut lines = vec![
+                    format!("Dir: {}", direction.to_ascii_uppercase()),
+                    format!("From: {callsign}"),
+                    format!("To: {recipient}"),
+                ];
+                if let Some(priority) = priority {
+                    lines.push(format!("Priority: {priority}"));
+                }
+                if !paths.is_empty() {
+                    lines.push(format!("Paths: {}", paths.join(",")));
+                }
+                lines.push(format_message_line("Text", &text, cfg.max_text_chars));
+                Some(SnomNotification {
+                    title: prefixed_title(&cfg.title_prefix, "DAPNET"),
+                    lines,
+                })
+            }
+            SnomNotifyMsg::TelegramHtml(html) => {
+                if !cfg.notify_telegram {
+                    return None;
+                }
+                let text = html_to_text(&html);
+                Some(SnomNotification {
+                    title: prefixed_title(&cfg.title_prefix, "Telegram"),
+                    lines: split_for_snom(&text, cfg.max_text_chars),
+                })
+            }
+            SnomNotifyMsg::Meshcom {
+                title,
+                src,
+                dst,
+                text,
+                msg_id,
+            } => {
+                let mut lines = vec![format!("From: {src}")];
+                if let Some(dst) = dst.filter(|v| !v.trim().is_empty()) {
+                    lines.push(format!("To: {dst}"));
+                }
+                if let Some(msg_id) = msg_id.filter(|v| !v.trim().is_empty()) {
+                    lines.push(format!("ID: {msg_id}"));
+                }
+                lines.push(format_message_line("Text", &text, cfg.max_text_chars));
+                Some(SnomNotification {
+                    title: prefixed_title(&cfg.title_prefix, &title),
+                    lines,
+                })
+            }
+            SnomNotifyMsg::Geoalarm {
+                title,
+                source,
+                text,
+                distance_m,
+                lat,
+                lon,
+            } => {
+                let lines = vec![
+                    format!("From: {source}"),
+                    format!("Distance: {:.0} m", distance_m.max(0.0)),
+                    format!("Pos: {:.6}, {:.6}", lat, lon),
+                    format_message_line("Text", &text, cfg.max_text_chars),
+                ];
+                Some(SnomNotification {
+                    title: prefixed_title(&cfg.title_prefix, &title),
+                    lines,
+                })
+            }
+            _ => None,
+        }
+    }
+}
+
+struct SnomNotification {
+    title: String,
+    lines: Vec<String>,
+}
+
+fn direction_allowed(cfg: &CfgSnomNotify, direction: &str) -> bool {
+    cfg.sds_directions.is_empty()
+        || cfg
+            .sds_directions
+            .iter()
+            .any(|d| d.eq_ignore_ascii_case(direction.trim()))
+}
+
+fn sds_issi_allowed(cfg: &CfgSnomNotify, source_issi: u32, dest_issi: u32) -> bool {
+    cfg.sds_allowed_issis.is_empty()
+        || cfg.sds_allowed_issis.contains(&source_issi)
+        || cfg.sds_allowed_issis.contains(&dest_issi)
+}
+
+fn dapnet_ric_allowed(cfg: &CfgSnomNotify, recipient: &str) -> bool {
+    if cfg.dapnet_allowed_rics.is_empty() {
+        return true;
+    }
+    dapnet_recipient_ric(recipient)
+        .map(|ric| cfg.dapnet_allowed_rics.contains(&ric))
+        .unwrap_or(false)
+}
+
+fn dapnet_recipient_ric(recipient: &str) -> Option<u32> {
+    let trimmed = recipient.trim();
+    let rest = trimmed.strip_prefix("RIC ")?;
+    let token = rest.split_whitespace().next()?;
+    parse_ric_route_key(token).ok()
+}
+
+fn prefixed_title(prefix: &str, title: &str) -> String {
+    let prefix = prefix.trim();
+    if prefix.is_empty() {
+        title.to_string()
+    } else {
+        format!("{prefix} {title}")
+    }
+}
+
+fn format_message_line(label: &str, text: &str, max_chars: usize) -> String {
+    let trimmed = text.trim();
+    if trimmed.is_empty() {
+        format!("{label}: -")
+    } else {
+        format!("{label}: {}", truncate_chars(trimmed, max_chars))
+    }
+}
+
+fn split_for_snom(text: &str, max_chars: usize) -> Vec<String> {
+    let mut lines: Vec<String> = text
+        .lines()
+        .map(str::trim)
+        .filter(|l| !l.is_empty())
+        .map(|l| truncate_chars(l, max_chars))
+        .collect();
+    if lines.is_empty() {
+        lines.push("-".to_string());
+    }
+    lines
+}
+
+fn send_notification(cfg: &CfgSnomNotify, title: &str, lines: &[String]) -> Result<(), String> {
+    if cfg.endpoints.is_empty() {
+        return Err("enabled but no endpoints configured".to_string());
+    }
+    if cfg.ami_username.trim().is_empty() || cfg.ami_password.as_ref().trim().is_empty() {
+        return Err("enabled but AMI credentials are incomplete".to_string());
+    }
+
+    let xml = snom_ip_phone_text_xml(title, lines);
+    let timeout = Duration::from_secs(cfg.connect_timeout_secs);
+    let mut stream = connect_ami(&cfg.ami_host, cfg.ami_port, timeout)?;
+    stream
+        .set_read_timeout(Some(timeout))
+        .map_err(|e| format!("AMI set_read_timeout failed: {}", e))?;
+    stream
+        .set_write_timeout(Some(timeout))
+        .map_err(|e| format!("AMI set_write_timeout failed: {}", e))?;
+
+    ami_action(
+        &mut stream,
+        &[
+            ("Action", "Login".to_string()),
+            ("Username", cfg.ami_username.clone()),
+            ("Secret", cfg.ami_password.as_ref().to_string()),
+            ("Events", "off".to_string()),
+            ("ActionID", next_action_id("login")),
+        ],
+    )
+    .map_err(|e| format!("AMI login failed: {}", e))?;
+
+    for endpoint in &cfg.endpoints {
+        let endpoint = endpoint.trim();
+        if endpoint.is_empty() {
+            continue;
+        }
+        let fields = vec![
+            ("Action", "PJSIPNotify".to_string()),
+            ("ActionID", next_action_id("notify")),
+            ("Endpoint", endpoint.to_string()),
+            ("Variable", format!("Event={}", cfg.notify_event)),
+            ("Variable", format!("Content-Type={}", cfg.content_type)),
+            (
+                "Variable",
+                format!("Subscription-State={}", cfg.subscription_state),
+            ),
+            ("Variable", format!("Content={}", sanitize_ami_value(&xml))),
+        ];
+        ami_action(&mut stream, &fields)
+            .map_err(|e| format!("PJSIPNotify endpoint {} failed: {}", endpoint, e))?;
+    }
+
+    let _ = ami_action(
+        &mut stream,
+        &[
+            ("Action", "Logoff".to_string()),
+            ("ActionID", next_action_id("logoff")),
+        ],
+    );
+    Ok(())
+}
+
+fn connect_ami(host: &str, port: u16, timeout: Duration) -> Result<TcpStream, String> {
+    let addr = format!("{host}:{port}");
+    let mut last_err = None;
+    let addrs = addr
+        .to_socket_addrs()
+        .map_err(|e| format!("AMI resolve {} failed: {}", addr, e))?;
+    for socket in addrs {
+        match TcpStream::connect_timeout(&socket, timeout) {
+            Ok(stream) => {
+                let mut stream = stream;
+                // Consume the AMI greeting if it is immediately available; if not, the next
+                // action response read still works because it waits for a complete AMI block.
+                let _ = stream.set_read_timeout(Some(Duration::from_millis(250)));
+                let _ = read_ami_block(&mut stream);
+                let _ = stream.set_read_timeout(Some(timeout));
+                return Ok(stream);
+            }
+            Err(err) => last_err = Some(err),
+        }
+    }
+    Err(format!(
+        "AMI connect {} failed: {}",
+        addr,
+        last_err
+            .map(|e| e.to_string())
+            .unwrap_or_else(|| "no socket addresses".to_string())
+    ))
+}
+
+fn ami_action(stream: &mut TcpStream, fields: &[(&str, String)]) -> Result<String, String> {
+    let mut request = String::new();
+    for (name, value) in fields {
+        request.push_str(name);
+        request.push_str(": ");
+        request.push_str(&sanitize_ami_value(value));
+        request.push_str("\r\n");
+    }
+    request.push_str("\r\n");
+    stream
+        .write_all(request.as_bytes())
+        .and_then(|_| stream.flush())
+        .map_err(|e| format!("write failed: {}", e))?;
+    let block = read_ami_block(stream)?;
+    if block.contains("Response: Error") {
+        Err(sanitize_response(&block))
+    } else {
+        Ok(block)
+    }
+}
+
+fn read_ami_block(stream: &mut TcpStream) -> Result<String, String> {
+    let mut buf = Vec::new();
+    let mut tmp = [0u8; 512];
+    loop {
+        let n = stream.read(&mut tmp).map_err(|e| format!("read failed: {}", e))?;
+        if n == 0 {
+            return Err("connection closed".to_string());
+        }
+        buf.extend_from_slice(&tmp[..n]);
+        if buf.windows(4).any(|w| w == b"\r\n\r\n") {
+            break;
+        }
+        if buf.len() > READ_LIMIT {
+            return Err("response too large".to_string());
+        }
+    }
+    Ok(String::from_utf8_lossy(&buf).to_string())
+}
+
+fn next_action_id(kind: &str) -> String {
+    let id = ACTION_ID.fetch_add(1, Ordering::Relaxed);
+    format!("flowstation-snom-{kind}-{id}")
+}
+
+fn sanitize_ami_value(value: &str) -> String {
+    value.replace(['\r', '\n'], " ")
+}
+
+fn sanitize_response(response: &str) -> String {
+    response
+        .lines()
+        .filter(|line| !line.starts_with("Secret:"))
+        .collect::<Vec<_>>()
+        .join("; ")
+}
+
+fn snom_ip_phone_text_xml(title: &str, lines: &[String]) -> String {
+    let text = lines
+        .iter()
+        .map(|l| xml_escape(l))
+        .collect::<Vec<_>>()
+        .join("<br/>");
+    format!(
+        r#"<?xml version="1.0" encoding="UTF-8"?><SnomIPPhoneText has_scrollbar="yes"><Title>{}</Title><Text>{}</Text></SnomIPPhoneText>"#,
+        xml_escape(title),
+        text
+    )
+}
+
+fn xml_escape(text: &str) -> String {
+    text.replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+        .replace('"', "&quot;")
+        .replace('\'', "&apos;")
+}
+
+fn html_to_text(html: &str) -> String {
+    let mut out = String::new();
+    let mut in_tag = false;
+    let mut tag = String::new();
+    for ch in html.chars() {
+        match ch {
+            '<' => {
+                in_tag = true;
+                tag.clear();
+            }
+            '>' if in_tag => {
+                let normalized = tag
+                    .trim()
+                    .trim_start_matches('/')
+                    .split_whitespace()
+                    .next()
+                    .unwrap_or("")
+                    .to_ascii_lowercase();
+                if normalized == "br" || normalized == "p" || normalized == "div" {
+                    out.push('\n');
+                }
+                in_tag = false;
+            }
+            _ if in_tag => tag.push(ch),
+            _ => out.push(ch),
+        }
+    }
+    decode_basic_html_entities(&out)
+}
+
+fn decode_basic_html_entities(text: &str) -> String {
+    text.replace("&lt;", "<")
+        .replace("&gt;", ">")
+        .replace("&amp;", "&")
+        .replace("&quot;", "\"")
+        .replace("&apos;", "'")
+}
+
+fn truncate_chars(s: &str, max: usize) -> String {
+    match s.char_indices().nth(max) {
+        Some((idx, _)) => format!("{}...", &s[..idx]),
+        None => s.to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn snom_xml_escapes_dynamic_text_and_uses_br() {
+        let xml = snom_ip_phone_text_xml(
+            "Flow <SDS>",
+            &["From: 1".to_string(), "Text: a & b".to_string()],
+        );
+        assert!(xml.contains("<SnomIPPhoneText"));
+        assert!(xml.contains("<Title>Flow &lt;SDS&gt;</Title>"));
+        assert!(xml.contains("From: 1<br/>Text: a &amp; b"));
+        assert!(!xml.contains('\n'));
+    }
+
+    #[test]
+    fn html_to_text_strips_telegram_markup() {
+        let text = html_to_text("X <b>DAPNET</b>\nCall: <code>DJ2TH</code>&amp;test");
+        assert!(text.contains("DAPNET"));
+        assert!(text.contains("DJ2TH&test"));
+        assert!(!text.contains("<b>"));
+    }
+
+    #[test]
+    fn ami_value_is_single_line() {
+        assert_eq!(sanitize_ami_value("a\r\nb"), "a  b");
+    }
+
+    #[test]
+    fn dapnet_ric_filter_extracts_decimal_ric() {
+        assert_eq!(dapnet_recipient_ric("RIC 0632585 / func 3"), Some(632585));
+        assert_eq!(dapnet_recipient_ric("DJ2TH"), None);
+    }
+}

--- a/crates/tetra-entities/src/net_telegram/alerter.rs
+++ b/crates/tetra-entities/src/net_telegram/alerter.rs
@@ -20,6 +20,7 @@ use tetra_config::bluestation::{CfgTelegram, SharedConfig};
 use super::client::TelegramClient;
 use super::format::{self, StationInfo};
 use super::{TelegramAlertMsg, TelegramAlertSource};
+use crate::net_snom::SnomNotifySink;
 use crate::net_telemetry::TelemetryEvent;
 
 /// SDS protocol identifier for the Location Information Protocol (LIP / APRS-style beacons).
@@ -73,6 +74,8 @@ pub struct TelegramAlerter {
     /// ISSIs currently in active emergency — alert only on the idle→emergency transition so the
     /// radio's periodic emergency re-sends don't re-fire the alert.
     emergency_issis: HashSet<u32>,
+    /// Optional Snom display fanout. Receives the same already-formatted alert once per alert.
+    snom_sink: Option<SnomNotifySink>,
 }
 
 impl TelegramAlerter {
@@ -93,7 +96,13 @@ impl TelegramAlerter {
             log_window_start: None,
             last_health: None,
             emergency_issis: HashSet::new(),
+            snom_sink: None,
         }
+    }
+
+    pub fn with_snom_sink(mut self, sink: Option<SnomNotifySink>) -> Self {
+        self.snom_sink = sink;
+        self
     }
 
     pub fn run(&mut self) {
@@ -102,6 +111,9 @@ impl TelegramAlerter {
             match self.source.recv_timeout(POLL) {
                 Ok(TelegramAlertMsg::Event(event)) => self.handle_event(event),
                 Ok(TelegramAlertMsg::CriticalLog { level, message }) => self.handle_log(level, message),
+                Ok(TelegramAlertMsg::Dapnet { prefix, callsign, text }) => self.handle_dapnet(prefix, callsign, text),
+                Ok(TelegramAlertMsg::Meshcom { prefix, src, text }) => self.handle_dapnet(prefix, src, text),
+                Ok(TelegramAlertMsg::Geoalarm { prefix, source, text }) => self.handle_dapnet(prefix, source, text),
                 Err(RecvTimeoutError::Timeout) => {}
                 Err(RecvTimeoutError::Disconnected) => break,
             }
@@ -208,6 +220,14 @@ impl TelegramAlerter {
         }
     }
 
+    fn handle_dapnet(&self, prefix: String, callsign: String, text: String) {
+        let tg = self.cfg.effective_telegram();
+        if tg.is_deliverable() {
+            let html = format::dapnet(&self.station, &prefix, &callsign, &text);
+            self.send_all(&tg, &html);
+        }
+    }
+
     /// Per-tick maintenance: emit deferred disconnects and flush the coalesced log buffer.
     fn maintenance(&mut self) {
         let tg = self.cfg.effective_telegram();
@@ -261,6 +281,9 @@ impl TelegramAlerter {
     /// Deliver one HTML message to every configured chat. Failures are logged at `debug!` (never
     /// WARN/ERROR) so the critical-log catch-all cannot re-feed them as alerts.
     fn send_all(&self, tg: &CfgTelegram, html: &str) {
+        if let Some(sink) = &self.snom_sink {
+            sink.send_telegram_html(html.to_string());
+        }
         let token = tg.bot_token.as_ref();
         for &chat_id in &tg.chat_ids {
             if let Err(e) = self.client.send_message_html(token, chat_id, html) {

--- a/crates/tetra-entities/src/net_telegram/format.rs
+++ b/crates/tetra-entities/src/net_telegram/format.rs
@@ -170,6 +170,22 @@ pub fn test_message(station: &StationInfo) -> String {
     )
 }
 
+/// A DAPNET message forwarded by the DAPNET worker.
+pub fn dapnet(station: &StationInfo, prefix: &str, callsign: &str, text: &str) -> String {
+    let prefix = truncate_chars(prefix.trim(), 32);
+    let callsign = truncate_chars(callsign.trim(), 64);
+    let text = truncate_chars(text.trim(), 900);
+    frame(
+        "📟",
+        if prefix.is_empty() { "DAPNET" } else { &prefix },
+        &[
+            format!("Callsign/recipient: <code>{}</code>", escape_html(&callsign)),
+            format!("Message: {}", escape_html(&text)),
+        ],
+        station,
+    )
+}
+
 /// Station health changed level. Lists the domains that are not Ok, plus the last action taken.
 pub fn health(station: &StationInfo, snap: &crate::health::HealthSnapshot) -> String {
     use crate::health::HealthLevel;
@@ -242,6 +258,14 @@ mod tests {
         assert!(empty.contains("binary"));
         let textual = lip_beacon(&station(), 1, 2, "4426.12N 02606.55E");
         assert!(textual.contains("4426.12N"));
+    }
+
+    #[test]
+    fn dapnet_message_contains_prefix_callsign_and_text() {
+        let m = dapnet(&station(), "DAPNET", "DL1ABC", "Test <msg>");
+        assert!(m.contains("<b>DAPNET</b>"));
+        assert!(m.contains("<code>DL1ABC</code>"));
+        assert!(m.contains("Test &lt;msg&gt;"));
     }
 
     #[test]

--- a/crates/tetra-entities/src/net_telegram/mod.rs
+++ b/crates/tetra-entities/src/net_telegram/mod.rs
@@ -31,6 +31,24 @@ pub enum TelegramAlertMsg {
     Event(TelemetryEvent),
     /// A captured stack log line at WARN or ERROR level (the "critical status" catch-all).
     CriticalLog { level: String, message: String },
+    /// A DAPNET message forwarded through the existing Telegram alert delivery path.
+    Dapnet {
+        prefix: String,
+        callsign: String,
+        text: String,
+    },
+    /// A MeshCom text message forwarded through the existing Telegram alert delivery path.
+    Meshcom {
+        prefix: String,
+        src: String,
+        text: String,
+    },
+    /// A GeoAlarm geofence event forwarded through the existing Telegram alert delivery path.
+    Geoalarm {
+        prefix: String,
+        source: String,
+        text: String,
+    },
 }
 
 /// Cloneable, push-only handle. Cloned into the telemetry-tee and dashboard-log threads.
@@ -51,6 +69,24 @@ impl TelegramAlertSink {
     #[inline]
     pub fn send_log(&self, level: String, message: String) {
         let _ = self.tx.send(TelegramAlertMsg::CriticalLog { level, message });
+    }
+
+    /// Forward a DAPNET message to the alerter for Telegram delivery.
+    #[inline]
+    pub fn send_dapnet(&self, prefix: String, callsign: String, text: String) {
+        let _ = self.tx.send(TelegramAlertMsg::Dapnet { prefix, callsign, text });
+    }
+
+    /// Forward a MeshCom message to the alerter for Telegram delivery.
+    #[inline]
+    pub fn send_meshcom(&self, prefix: String, src: String, text: String) {
+        let _ = self.tx.send(TelegramAlertMsg::Meshcom { prefix, src, text });
+    }
+
+    /// Forward a GeoAlarm event to the alerter for Telegram delivery.
+    #[inline]
+    pub fn send_geoalarm(&self, prefix: String, source: String, text: String) {
+        let _ = self.tx.send(TelegramAlertMsg::Geoalarm { prefix, source, text });
     }
 }
 

--- a/crates/tetra-entities/src/net_telemetry/events.rs
+++ b/crates/tetra-entities/src/net_telemetry/events.rs
@@ -148,8 +148,19 @@ pub enum TelemetryEvent {
     /// Calls table via the call's `priority`, not through this event.)
     EmergencyAlarm { source_issi: u32, dest_ssi: u32 },
     /// A radio's emergency was CLEARED (non-emergency status, clear-timeout, or operator clear).
-    /// Appended last for bitcode wire-stability.
     EmergencyCancel { source_issi: u32 },
+    /// DAPNET message activity for the dashboard DAPNET tab. `direction` is "rx" for messages
+    /// received from the RWTH core feed and "tx" for messages sent through the Hampager API.
+    /// Appended last for bitcode wire-stability.
+    DapnetLog {
+        direction: String,
+        id: String,
+        callsign: String,
+        recipient: String,
+        text: String,
+        priority: Option<u8>,
+        paths: Vec<String>,
+    },
 }
 
 /// A single host-system sensor reading. Kept flat for easy JSON serialisation

--- a/crates/tetra-entities/src/tpg2200.rs
+++ b/crates/tetra-entities/src/tpg2200.rs
@@ -1,0 +1,160 @@
+/// Format a byte slice as uppercase comma-separated hex for diagnostics.
+pub fn format_hex_bytes(bytes: &[u8]) -> String {
+    bytes
+        .iter()
+        .map(|b| format!("{:02X}", b))
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+/// Parse a dashboard/operator-entered hex string. Accepts whitespace and common separators,
+/// with or without `0x` prefixes.
+pub fn parse_hex_payload(raw: &str) -> Result<Vec<u8>, String> {
+    let normalized: String = raw
+        .chars()
+        .map(|c| {
+            if c.is_ascii_whitespace() || matches!(c, ',' | ';' | ':' | '-') {
+                ' '
+            } else {
+                c
+            }
+        })
+        .collect();
+    let mut bytes = Vec::new();
+    for token in normalized.split_whitespace() {
+        let hex = token
+            .strip_prefix("0x")
+            .or_else(|| token.strip_prefix("0X"))
+            .unwrap_or(token);
+        if hex.is_empty() {
+            return Err(format!("hex token '{}' has no digits", token));
+        }
+        if hex.len() % 2 != 0 {
+            return Err(format!("hex token '{}' has an odd number of digits", token));
+        }
+        for pos in (0..hex.len()).step_by(2) {
+            let pair = &hex[pos..pos + 2];
+            let byte = u8::from_str_radix(pair, 16).map_err(|_| format!("invalid hex byte '{}'", pair))?;
+            bytes.push(byte);
+        }
+    }
+    Ok(bytes)
+}
+
+/// TPG2200 text payload bytes. Characters outside ISO-8859-1 are represented as '?' because
+/// the tested Motorola payload is byte-oriented.
+pub fn iso_8859_1_or_ascii_bytes(text: &str) -> Vec<u8> {
+    text.chars()
+        .map(|c| {
+            let code = c as u32;
+            if code <= 0xFF { code as u8 } else { b'?' }
+        })
+        .collect()
+}
+
+pub fn tpg2200_incident_byte(incident: u16) -> u8 {
+    let incident = incident.clamp(1, 256);
+    // Confirmed on-air: 1..15 map to 0x11, 0x21, ... 0xF1. The extended range
+    // keeps those values and walks the second nibble so all 256 selector bytes
+    // are reachable; Raw Hex remains available for exact protocol experiments.
+    let zero_based = incident - 1;
+    let major = ((zero_based + 1) & 0x0F) as u8;
+    let minor = (((zero_based / 16) + 1) & 0x0F) as u8;
+    (major << 4) | minor
+}
+
+pub fn build_tpg2200_callout_payload(incident: u16, message: &str) -> Vec<u8> {
+    let mut payload = vec![
+        0xC3,
+        0x00,
+        0x09,
+        0x0D,
+        0x10,
+        tpg2200_incident_byte(incident),
+        0x27,
+        0x0F,
+        0x02,
+        0x30,
+        0x8D,
+    ];
+    payload.extend_from_slice(&iso_8859_1_or_ascii_bytes(message));
+    payload
+}
+
+/// Build the bare text payload expected by `ControlCommand::SendSds`. CMCE wraps this in the
+/// SDS-TL header and message reference before sending it over RF.
+pub fn build_sds_text_payload(text: &str) -> (u16, Vec<u8>) {
+    let all_latin = text.chars().all(|c| c as u32 <= 0xFF);
+    let (coding_scheme, text_bytes): (u8, Vec<u8>) = if all_latin {
+        let bytes: Vec<u8> = text.chars().map(|c| c as u8).collect();
+        (0x01, bytes)
+    } else {
+        let bytes: Vec<u8> = text.encode_utf16().flat_map(|u| u.to_be_bytes()).collect();
+        (0x02, bytes)
+    };
+    let mut payload = vec![coding_scheme];
+    payload.extend_from_slice(&text_bytes);
+    ((payload.len() * 8) as u16, payload)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        build_sds_text_payload, build_tpg2200_callout_payload, parse_hex_payload,
+        tpg2200_incident_byte,
+    };
+
+    #[test]
+    fn tpg2200_incident_byte_preserves_confirmed_values_and_covers_256_ids() {
+        assert_eq!(tpg2200_incident_byte(1), 0x11);
+        assert_eq!(tpg2200_incident_byte(2), 0x21);
+        assert_eq!(tpg2200_incident_byte(3), 0x31);
+        assert_eq!(tpg2200_incident_byte(4), 0x41);
+        assert_eq!(tpg2200_incident_byte(15), 0xF1);
+        assert_eq!(tpg2200_incident_byte(16), 0x01);
+        assert_eq!(tpg2200_incident_byte(256), 0x00);
+
+        let selectors = (1..=256)
+            .map(tpg2200_incident_byte)
+            .collect::<std::collections::HashSet<_>>();
+        assert_eq!(selectors.len(), 256);
+    }
+
+    #[test]
+    fn parse_hex_payload_accepts_common_separators_and_prefixes() {
+        assert_eq!(
+            parse_hex_payload("C3 00,0x09;0D:10-21").unwrap(),
+            vec![0xC3, 0x00, 0x09, 0x0D, 0x10, 0x21]
+        );
+        assert_eq!(
+            parse_hex_payload("C300090D").unwrap(),
+            vec![0xC3, 0x00, 0x09, 0x0D]
+        );
+        assert!(parse_hex_payload("C3 0X").is_err());
+        assert!(parse_hex_payload("C3 0").is_err());
+    }
+
+    #[test]
+    fn build_tpg2200_callout_payload_matches_known_alarm_shape() {
+        assert_eq!(
+            build_tpg2200_callout_payload(1, "ALARM"),
+            vec![
+                0xC3, 0x00, 0x09, 0x0D, 0x10, 0x11, 0x27, 0x0F, 0x02, 0x30, 0x8D, 0x41,
+                0x4C, 0x41, 0x52, 0x4D
+            ]
+        );
+        assert_eq!(
+            build_tpg2200_callout_payload(2, "ALARM"),
+            vec![
+                0xC3, 0x00, 0x09, 0x0D, 0x10, 0x21, 0x27, 0x0F, 0x02, 0x30, 0x8D, 0x41,
+                0x4C, 0x41, 0x52, 0x4D
+            ]
+        );
+    }
+
+    #[test]
+    fn sds_text_payload_selects_latin_or_utf16() {
+        assert_eq!(build_sds_text_payload("abc"), (32, vec![0x01, b'a', b'b', b'c']));
+        assert_eq!(build_sds_text_payload("日"), (24, vec![0x02, 0x65, 0xE5]));
+    }
+}

--- a/crates/tetra-entities/src/umac/umac_bs.rs
+++ b/crates/tetra-entities/src/umac/umac_bs.rs
@@ -1389,6 +1389,24 @@ impl UmacBs {
                     }
                 }
 
+                // Forward UL voice to Asterisk if the SIP bridge is enabled. The Asterisk entity
+                // keeps its own ts -> dialog map and ignores unrelated circuits, so we fan out to
+                // every enabled network entity and let each self-filter by active call.
+                #[cfg(feature = "asterisk")]
+                if self.config.config().asterisk.enabled {
+                    if self.channel_scheduler.circuit_is_active(Direction::Ul, ts) {
+                        let msg = SapMsg {
+                            sap: Sap::TmdSap,
+                            src: TetraEntity::Umac,
+                            dest: TetraEntity::Asterisk,
+                            msg: SapMsgInner::TmdCircuitDataInd(tetra_saps::tmd::TmdCircuitDataInd { ts, data: data.clone() }),
+                        };
+                        queue.push_back(msg);
+                    } else {
+                        tracing::trace!("rx_tmd_prim: no active UL circuit on ts={}, dropping UL voice to Asterisk", ts);
+                    }
+                }
+
                 // Determine DL target timeslot:
                 //   - Full-duplex P2P (local): UL on `ts` cross-routed to peer MS's DL on `peer_ts`.
                 //   - Group / simplex (LocalLoopback, no peer_ts): same-ts loopback so all members hear.

--- a/crates/tetra-entities/tests/common/default_stack.rs
+++ b/crates/tetra-entities/tests/common/default_stack.rs
@@ -1,5 +1,7 @@
 use tetra_config::bluestation::{
-    CfgCellInfo, CfgEmergency, CfgHealth, CfgNetInfo, CfgPhyIo, CfgRecovery, CfgSecurity, CfgWxService, PhyBackend, StackConfig, StackMode,
+    CfgAsterisk, CfgCellInfo, CfgDapnet, CfgEmergency, CfgGeoalarm, CfgHealth, CfgNetInfo, CfgPhyIo,
+    CfgRecovery, CfgSecurity, CfgSnomNotify, CfgTpg2200Action, CfgWxService, PhyBackend, StackConfig,
+    StackMode,
 };
 use tetra_core::{freqs::FreqInfo, ranges::SortedDisjointSsiRanges};
 
@@ -20,6 +22,11 @@ pub fn default_test_config_bs() -> StackConfig {
         net: net_info,
         cell: cell_info,
         brew: None,
+        asterisk: CfgAsterisk::default(),
+        dapnet: CfgDapnet::default(),
+        geoalarm: CfgGeoalarm::default(),
+        tpg2200_action: CfgTpg2200Action::default(),
+        snom_notify: CfgSnomNotify::default(),
         dashboard: None,
         telemetry: None,
         control: None,


### PR DESCRIPTION
Ports the integration work from [Torben-DJ2TH/flow](https://github.com/Torben-DJ2TH/flow) onto v0.3.5, adapting the hooks to the rewritten CMCE call-control core. Bridges TETRA to external networks and telephony.

## Included
- **net_dapnet** — DAPNET paging inbound forwarding (RWTH core-transmitter TCP) → SDS/Telegram, RIC group routing.
- **net_snom** — Snom desk-phone XML notifications via Asterisk AMI (PJSIPNotify).
- **net_geoalarm** — geofencing from decoded LIP positions → SDS/TPG2200/Snom/Telegram alerts.
- **tpg2200** — TPG2200 paging/callout payload builder + dashboard ActionURL trigger.
- **net_asterisk** — SIP/RTP voice bridge (TETRA ↔ SIP/PSTN). **Feature-gated** behind `asterisk` (default OFF) — it links the native `libtetra-codec` (ACELP).
- **dashboard** — pages/routes for each integration, LIP SDS positions as map links, SDS-log pagination/export.

## Call control
Generalized network-circuit routing from hardcoded Brew to a per-call `network_entity` (Brew, or Asterisk with the feature on). **Brew behaviour unchanged; all v0.3.5 call-control tests stay green.**

## Build
- **Default build is codec-free** — 334 tests green, no native deps beyond the existing ones.
- With `--features asterisk` — 339 tests green; **device build:** `cargo build --release --features asterisk` (requires `outerplane/tetra-codec` installed).

## Not ported
EchoLink and MeshCom from the fork were intentionally left out.

Original integration work by **Torben (DJ2TH)** — https://github.com/Torben-DJ2TH/flow