### PR TITLE
Fix correctness & security bugs found in code review

### DIFF
--- a/crates/tetra-entities/src/cmce/components/circuit_mgr.rs
+++ b/crates/tetra-entities/src/cmce/components/circuit_mgr.rs
@@ -113,8 +113,8 @@ impl CircuitMgr {
     pub fn get_next_call_id(&mut self) -> CallId {
         let call_id = self.next_call_identifier;
         self.next_call_identifier += 1;
-        if self.next_call_identifier > 0x3FF {
-            self.next_call_identifier = 1; // Wrap around, skip reserved zero value
+        if self.next_call_identifier > 0x3FFF {
+            self.next_call_identifier = 1; // Wrap around (14-bit field), skip reserved zero value
         }
         call_id
     }

--- a/crates/tetra-entities/src/cmce/subentities/cc_bs/procedures/isi.rs
+++ b/crates/tetra-entities/src/cmce/subentities/cc_bs/procedures/isi.rs
@@ -667,7 +667,19 @@ impl CcBsSubentity {
         dest_gssi: u32,
         priority: u8,
     ) {
-        assert!(brew::is_brew_gssi_routable(&self.config, dest_gssi));
+        // Never assert on peer-supplied data. Admit inbound network calls with the
+        // inbound predicate which — unlike is_brew_gssi_routable — must NOT apply the
+        // outbound whitelist (see brew_routable::is_brew_inbound_allowed). A GSSI that
+        // is not admissible is dropped gracefully instead of crashing the base station.
+        if !brew::is_brew_inbound_allowed(&self.config, dest_gssi) {
+            tracing::info!(
+                "CMCE: ignoring network call start uuid={} gssi={} (inbound not allowed)",
+                brew_uuid,
+                dest_gssi
+            );
+            self.notify_network_call_end(queue, brew_uuid);
+            return;
+        }
 
         if !self.has_listener(dest_gssi) {
             tracing::info!(

--- a/crates/tetra-entities/src/llc/components/fcs.rs
+++ b/crates/tetra-entities/src/llc/components/fcs.rs
@@ -8,7 +8,11 @@ pub fn compute_fcs(bitbuf: &BitBuffer, start: usize, end: usize) -> u32 {
 
     let mut crc: u32 = 0xFFFFFFFF;
     let len = end - start;
-    if len < 32 {
+    // Guard against a 32-bit shift overflow when the protected region is empty
+    // (e.g. an FCS-flagged PDU with no payload): `crc <<= 32` panics in debug and is
+    // a silent no-op in release. Skipping the pre-shift makes such a PDU simply fail
+    // the FCS comparison and be rejected, which is the desired outcome.
+    if len > 0 && len < 32 {
         crc <<= 32 - len;
     }
 
@@ -46,6 +50,10 @@ mod tests {
     use tetra_pdus::llc::pdus::bl_data::BlData;
 
     use super::*;
+
+
+
+
 
     #[test]
     fn fcs_test() {

--- a/crates/tetra-entities/src/mm/mm_bs.rs
+++ b/crates/tetra-entities/src/mm/mm_bs.rs
@@ -1052,6 +1052,23 @@ impl MmBs {
             }
         };
 
+        // Access control: apply the same [security] issi_whitelist gate as registration
+        // (rx_u_location_update_demand). Without this, an unknown ISSI can self-register
+        // via the group-attach path below, bypassing the whitelist and growing the client
+        // registry without bound.
+        let issi_allowed = {
+            let state = self.config.state_read();
+            match &state.issi_whitelist_override {
+                Some(list) => list.is_empty() || list.contains(&issi),
+                None => self.config.config().security.is_issi_allowed(issi),
+            }
+        };
+        if !issi_allowed {
+            tracing::warn!("MM: ISSI {} not in whitelist, rejecting group attach/detach", issi);
+            self.send_d_attach_detach_ack_reject(queue, issi, prim.handle);
+            return;
+        }
+
         // Check if we can satisfy this request, print unsupported stuff
         if !Self::feature_check_u_attach_detach_group_identity(&pdu) {
             // group_identity_uplink missing — terminal is sending a group report response

--- a/crates/tetra-entities/src/net_brew/worker.rs
+++ b/crates/tetra-entities/src/net_brew/worker.rs
@@ -749,6 +749,19 @@ impl<T: NetworkTransport> BrewWorker<T> {
                     return;
                 }
 
+                // Reject frames whose declared bit-length exceeds the actual payload:
+                // length_bits and data are independent wire fields, and the downstream
+                // D-SDS-DATA serializer indexes the payload by length_bits — an
+                // over-claimed length would otherwise panic the base station (OOB).
+                if (frame.length_bits as usize).div_ceil(8) > frame.data.len() {
+                    tracing::warn!(
+                        "BrewWorker: ignoring SDS_TRANSFER with length_bits={} exceeding payload of {} bytes",
+                        frame.length_bits,
+                        frame.data.len()
+                    );
+                    return;
+                }
+
                 // Match with pending SHORT_TRANSFER by UUID
                 if let Some(pending) = self.pending_sds.remove(&frame.identifier) {
                     tracing::info!(

--- a/crates/tetra-entities/src/net_dashboard/html.rs
+++ b/crates/tetra-entities/src/net_dashboard/html.rs
@@ -4401,7 +4401,7 @@ let ws=null,state={ms:{},calls:{},emergencies:{},lastHeard:[],sdsLog:[],dapnetLo
 let callsigns={};
 let _csInflight=false;
 // Render an ISSI with its RadioID callsign (and country flag, when known) appended.
-function idCell(issi){const c=callsigns[issi];if(!c||!c.cs)return `<code>${issi}</code>`;const fl=c.fl?c.fl+' ':'';return `<code>${issi}</code> <span class="callsign">${fl}${c.cs}</span>`;}
+function idCell(issi){const c=callsigns[issi];if(!c||!c.cs)return `<code>${issi}</code>`;const fl=c.fl?c.fl+' ':'';return `<code>${issi}</code> <span class="callsign">${fl}${escHtml(c.cs)}</span>`;}
 // Resolve callsigns for every ISSI currently on screen we have not looked up yet. On-demand: the
 // server fetches unknowns from RadioID in the background and caches them locally; pending IDs are
 // omitted from the response and retried on the next tick. Found/absent results are cached here.

--- a/crates/tetra-entities/src/net_dashboard/server.rs
+++ b/crates/tetra-entities/src/net_dashboard/server.rs
@@ -1344,7 +1344,7 @@ fn handle_connection(
                     .trim_end_matches("\r\n").trim_end_matches('\n').parse().unwrap_or(0);
             }
         }
-        let mut body = vec![0u8; content_length];
+        let mut body = vec![0u8; content_length.min(512 * 1024)];
         let _ = buf.read_exact(&mut body);
         let profile = String::from_utf8_lossy(&body).trim().to_string();
         match activate_config_profile(&config_path, &profile) {
@@ -1488,7 +1488,7 @@ fn handle_connection(
                     .parse().unwrap_or(0);
             }
         }
-        let mut body = vec![0u8; content_length];
+        let mut body = vec![0u8; content_length.min(512 * 1024)];
         let _ = buf.read_exact(&mut body);
         let body_str = String::from_utf8_lossy(&body);
         // Write backup of current config before overwriting
@@ -1541,7 +1541,7 @@ fn handle_connection(
                     .parse().unwrap_or(0);
             }
         }
-        let mut body = vec![0u8; content_length];
+        let mut body = vec![0u8; content_length.min(512 * 1024)];
         let _ = buf.read_exact(&mut body);
         let body_str = String::from_utf8_lossy(&body);
         serve_whitelist_post(buf.into_inner(), &shared_config, &config_path, body_str.as_ref(), &cmd_tx);
@@ -1567,7 +1567,7 @@ fn handle_connection(
                     .parse().unwrap_or(0);
             }
         }
-        let mut body = vec![0u8; content_length];
+        let mut body = vec![0u8; content_length.min(512 * 1024)];
         let _ = buf.read_exact(&mut body);
         let body_str = String::from_utf8_lossy(&body);
         serve_wx_post(buf.into_inner(), &shared_config, &config_path, body_str.as_ref());
@@ -3004,7 +3004,7 @@ fn read_http_body(stream: &mut TcpStream) -> Vec<u8> {
         }
     }
     if content_length == 0 { return Vec::new(); }
-    let mut body = vec![0u8; content_length];
+    let mut body = vec![0u8; content_length.min(512 * 1024)];
     let _ = stream.read_exact(&mut body);
     body
 }

--- a/crates/tetra-entities/src/umac/subcomp/bs_sched.rs
+++ b/crates/tetra-entities/src/umac/subcomp/bs_sched.rs
@@ -1047,11 +1047,23 @@ impl BsChannelScheduler {
     fn dl_build_traffic_block(&mut self, ts: TdmaTime) -> (BitBuffer, Option<BitBuffer>) {
         // Get speech data or silence
         let tch_buf = if let Some(block) = self.circuits.take_block(ts.t) {
-            let mut buf = BitBuffer::from_vec(block);
-            // Raw ACELP speech (274 bits for TCH/S).
-            // Clamp to TCH_S_CAP as Vec may be larger (e.g. 280 bits).
-            buf.set_raw_end(buf.get_raw_start() + TCH_S_CAP);
-            buf
+            // Raw ACELP speech (274 bits for TCH/S). The Vec may be LARGER (e.g. 280
+            // bits) and is clamped down to TCH_S_CAP. But a SHORTER block (e.g. a
+            // truncated/garbage frame off the network) must not be clamped UP — that
+            // would push set_raw_end past capacity and panic. Fall back to silence.
+            if block.len() * 8 >= TCH_S_CAP {
+                let mut buf = BitBuffer::from_vec(block);
+                buf.set_raw_end(buf.get_raw_start() + TCH_S_CAP);
+                buf
+            } else {
+                tracing::warn!(
+                    "DL traffic ts={}: queued voice block only {} bytes (<{} bits), sending silence",
+                    ts.t,
+                    block.len(),
+                    TCH_S_CAP
+                );
+                BitBuffer::new(TCH_S_CAP)
+            }
         } else {
             // No voice data queued — send silence frame (all zeros).
             // This is normal during hangtime or between voice bursts.

--- a/crates/tetra-pdus/src/cmce/pdus/d_sds_data.rs
+++ b/crates/tetra-pdus/src/cmce/pdus/d_sds_data.rs
@@ -123,14 +123,18 @@ impl DSdsData {
             SdsUserData::Type2(value) => buffer.write_bits(*value as u64, 32),
             SdsUserData::Type3(value) => buffer.write_bits(*value, 64),
             SdsUserData::Type4(len_bits, data) => {
+                // Defensive: never index past the payload, even if len_bits over-claims
+                // the length. The Brew ingress path (worker.rs) already rejects such
+                // frames; this guards any other caller from an out-of-bounds panic.
+                let used_bits = (*len_bits as usize).min(data.len() * 8);
                 buffer.write_bits(*len_bits as u64, 11);
-                let full_bytes = (*len_bits as usize) / 8;
-                let remaining_bits = len_bits % 8;
+                let full_bytes = used_bits / 8;
+                let remaining_bits = used_bits % 8;
                 for i in 0..full_bytes {
                     buffer.write_bits(data[i] as u64, 8);
                 }
                 if remaining_bits > 0 {
-                    buffer.write_bits((data[full_bytes] >> (8 - remaining_bits)) as u64, remaining_bits as usize);
+                    buffer.write_bits((data[full_bytes] >> (8 - remaining_bits)) as u64, remaining_bits);
                 }
             }
         }
@@ -179,6 +183,25 @@ mod tests {
         pdu.to_bitbuf(&mut buf).expect("serialize failed");
         buf.seek(0);
         DSdsData::from_bitbuf(&mut buf).expect("parse failed")
+    }
+
+    /// Regression: a Type4 SDS whose declared `length_bits` exceeds the actual payload
+    /// must NOT panic the serializer. The Brew ingress path can hand us a length/data
+    /// pair that disagrees; the encoder previously indexed `data[i]` out of bounds and
+    /// crashed the base station. The clamp caps reads at the available payload.
+    #[test]
+    fn type4_overclaimed_length_does_not_panic() {
+        let pdu = DSdsData {
+            calling_party_type_identifier: PartyTypeIdentifier::Ssi,
+            calling_party_address_ssi: Some(1000001),
+            calling_party_extension: None,
+            user_defined_data: SdsUserData::Type4(2047, vec![0xAB]), // claims 2047 bits, 1 byte payload
+            external_subscriber_number: None,
+            dm_ms_address: None,
+        };
+        let mut buf = BitBuffer::new_autoexpand(512);
+        // The point of this test is simply that this returns instead of panicking.
+        let _ = pdu.to_bitbuf(&mut buf);
     }
 
     #[test]

--- a/crates/tetra-pdus/src/umac/pdus/mac_end_ul.rs
+++ b/crates/tetra-pdus/src/umac/pdus/mac_end_ul.rs
@@ -33,8 +33,8 @@ impl MacEndUl {
         } else if length_ind_cap_req < 0b101111 {
             // Length indication
             (Some(length_ind_cap_req as u8), None)
-        } else if length_ind_cap_req < 0x110000 {
-            // reserved value, return error
+        } else if length_ind_cap_req < 0b110000 {
+            // reserved value (47), return error
             return expect_failed!(length_ind_cap_req, "length_ind_cap_req reserved value");
         } else {
             // 0x110000 or higher, cap req
@@ -87,5 +87,51 @@ impl fmt::Display for MacEndUl {
             write!(f, "  reservation_req: {}", reservation_req)?;
         }
         write!(f, "}}")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn round_trip(pdu: &MacEndUl) -> MacEndUl {
+        let mut buf = BitBuffer::new_autoexpand(16);
+        pdu.to_bitbuf(&mut buf).expect("serialize failed");
+        buf.seek(0);
+        MacEndUl::from_bitbuf(&mut buf).expect("parse failed")
+    }
+
+    /// Regression: the decode ladder compared against `0x110000` (hex = 1_114_112)
+    /// instead of `0b110000` (48). Since the field is only 6 bits (max 63), every
+    /// value was `< 0x110000`, so the cap-request branch was dead code and every
+    /// reservation requirement decoded as "reserved value". Verify all 16 round-trip.
+    #[test]
+    fn reservation_req_round_trips() {
+        for raw in 0u64..16 {
+            let res_req = ReservationRequirement::try_from(raw).unwrap();
+            let pdu = MacEndUl {
+                fill_bits: false,
+                length_ind: None,
+                reservation_req: Some(res_req),
+            };
+            let parsed = round_trip(&pdu);
+            assert_eq!(parsed.reservation_req, Some(res_req), "raw={raw}");
+            assert_eq!(parsed.length_ind, None, "raw={raw}");
+        }
+    }
+
+    /// A length-indication MAC-END-UL must still decode as a length indication.
+    #[test]
+    fn length_ind_round_trips() {
+        for li in 1u8..0b101110 {
+            let pdu = MacEndUl {
+                fill_bits: true,
+                length_ind: Some(li),
+                reservation_req: None,
+            };
+            let parsed = round_trip(&pdu);
+            assert_eq!(parsed.length_ind, Some(li), "li={li}");
+            assert_eq!(parsed.reservation_req, None, "li={li}");
+        }
     }
 }


### PR DESCRIPTION
Fixes found during a full review of the codebase. Each was verified against the source, and the two most error-prone paths now have regression coverage. Workspace builds; `tetra-entities` + `tetra-pdus` test suites green (279 tests).

## 🔴 Critical — a single frame from the network can crash the whole BS
- **SDS Type4 OOB panic via Brew** — `net_brew/worker.rs` only checked `length_bits > 2047`, then forwarded the peer's `length_bits` and `data` independently; the D-SDS-DATA serializer indexes `data[i]` up to `length_bits/8`, so an over-claimed length panics (index out of bounds). The worker now rejects frames whose declared length exceeds the payload, and the `Type4` serializer clamps reads to the available bytes.
- **`assert!` on a peer-supplied GSSI** — `cmce/.../isi.rs` asserted `is_brew_gssi_routable` on a Brew-supplied `dest_gssi`; a GSSI in `local_ssi_ranges` (or absent from a configured whitelist) crashed the process. Replaced with the correct inbound predicate (`is_brew_inbound_allowed`) and a graceful drop.

## 🟠 High
- **Uplink reservation broken** — `umac/mac_end_ul.rs` compared against `0x110000` (hex = 1,114,112) instead of `0b110000` (48) on a 6-bit field, making the cap-request branch dead code; every MAC-END carrying a reservation requirement hit the "reserved value" error. One-character fix + round-trip tests (this path had none, which is why it went unnoticed).
- **Whitelist bypass via group-attach** — `mm/mm_bs.rs` registered unknown ISSIs on the U-ATTACH-DETACH-GROUP-IDENTITY path with no `issi_whitelist` check, defeating the only access-control gate and growing the client registry without bound. Added the same gate registration uses.
- **Dashboard body-allocation DoS** — `net_dashboard/server.rs` allocated `vec![0u8; content_length]` from the unvalidated client header at 5 sites. All capped at 512 KiB (3 sibling sites already capped).

## 🟡 Medium
- **Call-ID** wrapped at `0x3FF` (10-bit) for a 14-bit wire field → `0x3FFF`, to avoid premature reuse/collision.
- **XSS** — `idCell` interpolated the RadioID callsign into HTML unescaped → wrapped in `escHtml`.
- **FCS shift overflow** on an empty FCS-protected PDU (`crc <<= 32`) → guarded.
- **Scheduler panic** on a short queued voice block (`set_raw_end` past capacity) → fall back to silence.

## Deliberately not in this PR (decisions, not quick fixes)
- Default dashboard `bind = "0.0.0.0"` with auth off — tightening it could break remote dashboard access; this is a deployment/usability call.
- `d_tx_granted` type-2 vs bare-field encoding — needs ETSI spec confirmation before changing (risk of breaking interop).
- A few medium codec items: `length_ind=0` underflow in `umac_bs`, `mac_sysinfo` TS-mode re-encode unwrap, `d_location_update_accept` enum, unbounded Brew channels.
