### PR TITLE
SS-DGNA over CMCE FACILITY (fix operator DGNA)

### DIFF
--- a/crates/tetra-config/src/bluestation/parsing.rs
+++ b/crates/tetra-config/src/bluestation/parsing.rs
@@ -654,6 +654,17 @@ main_carrier_number = 1586
     }
 
     #[test]
+    fn dgna_use_ss_facility_flag_defaults_on() {
+        // Absent flag => SS-DGNA D-FACILITY path (TS 100 392-12-22) is the default.
+        let cfg = from_toml_str(&minimal_toml("")).expect("parse");
+        assert!(cfg.cell.dgna_use_ss_facility, "absent flag => SS-DGNA path on");
+
+        // Explicitly rolled back to the legacy MM D-ATTACH path.
+        let cfg = from_toml_str(&minimal_toml("dgna_use_ss_facility = false")).expect("parse");
+        assert!(!cfg.cell.dgna_use_ss_facility, "false => legacy MM D-ATTACH path");
+    }
+
+    #[test]
     fn telegram_alerts_section_parses() {
         let toml = minimal_toml("")
             + r#"

--- a/crates/tetra-config/src/bluestation/sec_cell.rs
+++ b/crates/tetra-config/src/bluestation/sec_cell.rs
@@ -209,6 +209,15 @@ pub struct CfgCellInfo {
     /// the rest of the group hears as dead air. Default: false (modern radios reuse the circuit
     /// fine and benefit from the lower retake latency). Opt in only for fleets with legacy sets.
     pub release_group_on_same_speaker_retake: bool,
+
+    /// DGNA air-interface emission. When true (default), an operator regroup goes out as an
+    /// SS-DGNA ASSIGN/DEASSIGN carried in a CMCE D-FACILITY (TS 100 392-12-22 V1.5.1, transport
+    /// EN 300 392-9 V1.7.1) — the SS PDU both *defines* the group (mnemonic/parameters) and
+    /// attaches it, which is what makes a dynamic talkgroup appear and be selectable on a real
+    /// terminal. When false the stack falls back to the legacy MM-only D-ATTACH/DETACH GROUP
+    /// IDENTITY (EN 300 392-2 V2.4.1 cl.16.8) which only toggles the L2 attachment of a group the
+    /// radio already knows. Kept as a rollback switch for the SS-DGNA rollout.
+    pub dgna_use_ss_facility: bool,
 }
 
 #[derive(Default, Deserialize)]
@@ -284,6 +293,10 @@ pub struct CellInfoDto {
     /// Tear down a group call on a same-speaker hangtime retake (legacy-Motorola silent-over
     /// workaround). Default: false.
     pub release_group_on_same_speaker_retake: Option<bool>,
+
+    /// Emit operator DGNA as an SS-DGNA D-FACILITY. Absent = true (the SS-DGNA path is the
+    /// default); set false to roll back to the legacy MM D-ATTACH/DETACH GROUP IDENTITY path.
+    pub dgna_use_ss_facility: Option<bool>,
 
     #[serde(flatten)]
     pub extra: HashMap<String, Value>,
@@ -369,6 +382,7 @@ pub fn cell_dto_to_cfg(ci: CellInfoDto) -> CfgCellInfo {
                 .collect(),
         }),
         release_group_on_same_speaker_retake: ci.release_group_on_same_speaker_retake.unwrap_or(false),
+        dgna_use_ss_facility: ci.dgna_use_ss_facility.unwrap_or(true),
     }
 }
 

--- a/crates/tetra-entities/src/cmce/cmce_bs.rs
+++ b/crates/tetra-entities/src/cmce/cmce_bs.rs
@@ -261,6 +261,14 @@ impl TetraEntityTrait for CmceBs {
                 ControlRoute::SdsRc => {
                     self.sds.rx_sds_from_brew(queue, message);
                 }
+                ControlRoute::SsDgnaAssign => {
+                    let SapMsgInner::CmceSsDgnaAssign { issi, gssi, attach } = message.msg else {
+                        unreachable!();
+                    };
+                    // MM owns the group registry/affiliation; it has already committed the change and
+                    // asks CMCE only to put the SS-DGNA ASSIGN/DEASSIGN on the air as a D-FACILITY.
+                    self.ss.send_d_facility_dgna(queue, issi, gssi, attach);
+                }
                 ControlRoute::Unsupported => {
                     panic!("Unexpected control message: {:?}", message.msg);
                 }

--- a/crates/tetra-entities/src/cmce/components/pc_bs.rs
+++ b/crates/tetra-entities/src/cmce/components/pc_bs.rs
@@ -22,6 +22,8 @@ pub enum ControlRoute {
     CcSubscriberUpdate,
     /// rc/TNSDS-side SDS input from the local network bridge.
     SdsRc,
+    /// MM-requested SS-DGNA D-FACILITY emission, handled by the SS sub-entity.
+    SsDgnaAssign,
     Unsupported,
 }
 
@@ -73,6 +75,7 @@ impl PcBs {
             SapMsgInner::CmceCallControl(_) => ControlRoute::CcRa,
             SapMsgInner::MmSubscriberUpdate(_) => ControlRoute::CcSubscriberUpdate,
             SapMsgInner::CmceSdsData(_) => ControlRoute::SdsRc,
+            SapMsgInner::CmceSsDgnaAssign { .. } => ControlRoute::SsDgnaAssign,
             _ => ControlRoute::Unsupported,
         }
     }

--- a/crates/tetra-entities/src/cmce/subentities/ss_bs.rs
+++ b/crates/tetra-entities/src/cmce/subentities/ss_bs.rs
@@ -3,15 +3,122 @@ use tetra_core::tetra_entities::TetraEntity;
 use tetra_core::{BitBuffer, Layer2Service, Sap, SsiType, TetraAddress};
 use tetra_pdus::cmce::enums::cmce_pdu_type_ul::CmcePduTypeUl;
 use tetra_pdus::cmce::pdus::cmce_function_not_supported::CmceFunctionNotSupported;
+use tetra_pdus::cmce::pdus::d_facility::{DFacility, DFacilitySsBody};
+use tetra_pdus::cmce::pdus::u_facility::UFacility;
+use tetra_pdus::cmce::ss_dgna::enums::results::GroupIdentityAttachmentMode;
+use tetra_pdus::cmce::ss_dgna::fields::group_assignment::GroupAssignment;
+use tetra_pdus::cmce::ss_dgna::fields::group_deassignment::GroupDeassignment;
+use tetra_pdus::cmce::ss_dgna::pdus::assign::Assign;
+use tetra_pdus::cmce::ss_dgna::pdus::deassign::Deassign;
+use tetra_pdus::cmce::ss_dgna::ss_dgna_pdu::SsDgnaPdu;
 use tetra_saps::lcmc::LcmcMleUnitdataReq;
 use tetra_saps::{SapMsg, SapMsgInner};
 
-/// Clause 12 Supplementary Services CMCE sub-entity
+/// Clause 12 Supplementary Services CMCE sub-entity.
+///
+/// Hosts the BS side of SS-DGNA (TS 100 392-12-22 V1.5.1): it emits the
+/// SwMI-initiated ASSIGN/DEASSIGN as a CMCE D-FACILITY (the FE2 role,
+/// cl.4.1-4.2) and consumes the affected MS's ASSIGN ACK / DEASSIGN ACK off the
+/// uplink U-FACILITY. The group registry and affiliation state are owned by MM;
+/// this sub-entity only puts the SS PDU on the air and logs the ACK.
 pub struct SsBsSubentity {}
+
+/// Class of usage advertised in SS-DGNA group assignments. 4 mirrors the value
+/// the MM affiliation/ACK path uses (`mm_bs.rs` `DGNA_CLASS_OF_USAGE`), so an
+/// SS-DGNA-assigned group behaves identically to one the radio affiliated
+/// itself. EN 300 392-2 V2.4.1 cl.16.10.6.
+const DGNA_CLASS_OF_USAGE: u8 = 4;
 
 impl SsBsSubentity {
     pub fn new() -> Self {
         SsBsSubentity {}
+    }
+
+    /// Emit an SS-DGNA D-FACILITY to a single ISSI: an ASSIGN when `attach`, a
+    /// DEASSIGN otherwise. The SS PDU is wrapped in the EN 300 392-9 V1.7.1
+    /// Table 4 SS-PDU container (Routeing = 00, one SS PDU) inside the CMCE
+    /// D-FACILITY (EN 300 392-2 V2.4.1 cl.14.7.1.7).
+    ///
+    /// ASSIGN uses attachment mode 000 (attached permanently, TS Table 51) so
+    /// the PDU both defines and attaches the group in one step (cl.6.5.2.1) —
+    /// the same MLE handoff the MM D-ATTACH does, but only after the radio has
+    /// the group definition. No mnemonic is carried in v1: a real terminal shows
+    /// its own provisioned name for the GSSI, or the bare number.
+    ///
+    /// Reliability rests on the LLC ACK of the FACILITY transport, not a
+    /// DGNA-layer retransmit (cl.6.6 mandates no protocol timer), so this is sent
+    /// with `Layer2Service::Acknowledged` — the same choice the MM DGNA path made
+    /// for its individually-addressed D-ATTACH.
+    pub fn send_d_facility_dgna(&self, queue: &mut MessageQueue, issi: u32, gssi: u32, attach: bool) {
+        let ss_pdu = if attach {
+            SsDgnaPdu::Assign(Assign {
+                groups: vec![GroupAssignment {
+                    group_ssi: gssi,
+                    group_extension: None,
+                    // 000 = attached permanently: no re-attach at the next ITSI attach / location
+                    // update, matching the persistent (lifetime=0) MM D-ATTACH the legacy path sent.
+                    attachment_mode: GroupIdentityAttachmentMode::AttachedPermanently,
+                    class_of_usage: Some(DGNA_CLASS_OF_USAGE),
+                    // No group-name config in v1 — the radio displays its own provisioned name.
+                    mnemonic: None,
+                    security_related_information: None,
+                    additional_group_information: None,
+                    vgssi: None,
+                }],
+                // Request the ASSIGN ACK so the air-interface outcome is observable in logs;
+                // BS-side state is already committed by MM at issue time.
+                ack_requested: true,
+            })
+        } else {
+            SsDgnaPdu::Deassign(Deassign {
+                groups: vec![GroupDeassignment {
+                    group_ssi: gssi,
+                    group_extension: None,
+                }],
+                ack_requested: true,
+            })
+        };
+
+        let pdu = DFacility {
+            facility: Some(DFacilitySsBody { routeing: 0, ss_pdu }),
+        };
+
+        let mut sdu = BitBuffer::new_autoexpand(32);
+        if let Err(e) = pdu.to_bitbuf(&mut sdu) {
+            tracing::error!("CMCE: failed serializing SS-DGNA D-FACILITY for ISSI {}: {:?}", issi, e);
+            return;
+        }
+        sdu.seek(0);
+        tracing::debug!(
+            "-> D-FACILITY (SS-DGNA {}) gssi={} issi={} sdu {}",
+            if attach { "assign" } else { "deassign" },
+            gssi,
+            issi,
+            sdu.dump_bin()
+        );
+
+        queue.push_back(SapMsg {
+            sap: Sap::LcmcSap,
+            src: TetraEntity::Cmce,
+            dest: TetraEntity::Mle,
+            msg: SapMsgInner::LcmcMleUnitdataReq(LcmcMleUnitdataReq {
+                sdu,
+                // Unsolicited, BS-initiated — no inbound L2 context to echo.
+                handle: 0,
+                endpoint_id: 0,
+                link_id: 0,
+                // Individually-addressed SS PDU: acknowledged BL-DATA, so the LLC layer carries the
+                // delivery guarantee the SS-DGNA layer does not (TS 100 392-12-22 cl.6.6).
+                layer2service: Layer2Service::Acknowledged,
+                pdu_prio: 0,
+                layer2_qos: 0,
+                stealing_permission: false,
+                stealing_repeats_flag: false,
+                chan_alloc: None,
+                main_address: TetraAddress::new(issi, SsiType::Issi),
+                tx_reporter: None,
+            }),
+        });
     }
 
     pub fn route_re_deliver(&mut self, queue: &mut MessageQueue, mut message: SapMsg) {
@@ -21,16 +128,70 @@ impl SsBsSubentity {
             tracing::error!("BUG: unexpected message or state -- routing error");
             return;
         };
+        let issi = prim.received_tetra_address.ssi;
 
-        // ETSI EN 300 392-2 §14.7.2.5:
-        // BS does not support supplementary services (SS). Respond with
-        // D-CMCE-FUNCTION-NOT-SUPPORTED, function_not_supported_pointer=0
+        // Try to parse the U-FACILITY as an SS-DGNA carrier. An ASSIGN ACK /
+        // DEASSIGN ACK is the affected MS confirming a regroup we already issued;
+        // BS-side group state was committed optimistically by MM at issue time,
+        // so this is confirmation/telemetry only (mirrors MM's
+        // rx_u_attach_detach_group_identity_ack). We do NOT reply
+        // function-not-supported in that case.
+        match UFacility::from_bitbuf(&mut prim.sdu) {
+            Ok(UFacility {
+                facility: Some(body),
+            }) => {
+                match &body.ss_pdu {
+                    SsDgnaPdu::AssignAck(ack) => {
+                        for ie in &ack.acks {
+                            tracing::info!(
+                                "SS-DGNA: ISSI {} ASSIGN ACK gssi={} assignment={} attachment={}",
+                                issi,
+                                ie.group_ssi,
+                                ie.result_of_assignment,
+                                ie.result_of_attachment
+                            );
+                        }
+                    }
+                    SsDgnaPdu::DeassignAck(ack) => {
+                        for ie in &ack.acks {
+                            tracing::info!(
+                                "SS-DGNA: ISSI {} DEASSIGN ACK gssi={} deassignment={}",
+                                issi,
+                                ie.group_ssi,
+                                ie.result_of_deassignment
+                            );
+                        }
+                    }
+                    // An MS-originated ASSIGN/DEASSIGN would be the dispatcher (FE3) role, which the
+                    // BS does not act as in v1. Acknowledge nothing; the radio expects no reply to
+                    // an SS PDU we don't implement, and a function-not-supported here would be wrong
+                    // since the SS *is* recognised.
+                    other => {
+                        tracing::warn!("SS-DGNA: ignoring unsupported uplink SS-DGNA PDU from ISSI {}: {}", issi, other);
+                    }
+                }
+                return;
+            }
+            // Empty / non-DGNA U-FACILITY: a genuine SS request the BS does not support.
+            Ok(UFacility { facility: None }) => {
+                tracing::debug!(
+                    "CMCE: received empty U-FACILITY from ISSI {} — responding D-CMCE-FUNCTION-NOT-SUPPORTED",
+                    issi
+                );
+            }
+            Err(e) => {
+                tracing::debug!(
+                    "CMCE: U-FACILITY from ISSI {} not a recognised SS-DGNA PDU ({:?}) — responding D-CMCE-FUNCTION-NOT-SUPPORTED",
+                    issi,
+                    e
+                );
+            }
+        }
+
+        // ETSI EN 300 392-2 V2.4.1 cl.14.7.2.5:
+        // The BS does not support this supplementary service. Respond with
+        // D-CMCE-FUNCTION-NOT-SUPPORTED, function_not_supported_pointer = 0
         // (the PDU type itself is not supported, not a specific field).
-        tracing::debug!(
-            "CMCE: received U-FACILITY from ISSI {} — responding D-CMCE-FUNCTION-NOT-SUPPORTED",
-            prim.received_tetra_address.ssi
-        );
-
         let response = CmceFunctionNotSupported {
             not_supported_pdu_type: CmcePduTypeUl::UFacility.into_raw() as u8,
             call_identifier_present: false,
@@ -62,7 +223,7 @@ impl SsBsSubentity {
                 stealing_permission: false,
                 stealing_repeats_flag: false,
                 chan_alloc: None,
-                main_address: TetraAddress::new(prim.received_tetra_address.ssi, SsiType::Issi),
+                main_address: TetraAddress::new(issi, SsiType::Issi),
                 tx_reporter: None,
             }),
         });

--- a/crates/tetra-entities/src/mm/mm_bs.rs
+++ b/crates/tetra-entities/src/mm/mm_bs.rs
@@ -1473,13 +1473,15 @@ impl MmBs {
     const DGNA_CLASS_OF_USAGE: u8 = 4;
 
     /// DGNA (Dynamic Group Number Assignment) — BS-initiated group attach/detach for one terminal,
-    /// driven from the dashboard. ETSI EN 300 392-2 §16 (SS-DGNA).
+    /// driven from the dashboard. SS-DGNA = TS 100 392-12-22 V1.5.1; legacy fallback = EN 300 392-2
+    /// V2.4.1 cl.16.8.
     ///
     /// Local-only: updates the BS-side affiliation (so local group calls and group SDS route to the
-    /// terminal) and pushes an unsolicited D-ATTACH/DETACH GROUP IDENTITY to the radio so it adds or
-    /// removes the group in its own list. Brew is intentionally not involved.
+    /// terminal) and asks the air-interface to be updated. By default that is an SS-DGNA
+    /// ASSIGN/DEASSIGN handed to CMCE for a D-FACILITY; with `dgna_use_ss_facility = false` it falls
+    /// back to an unsolicited MM D-ATTACH/DETACH GROUP IDENTITY. Brew is intentionally not involved.
     ///
-    /// Returns `true` if the command was accepted and a PDU was sent to the terminal.
+    /// Returns `true` if the command was accepted and the regroup was put on the air.
     fn do_dgna(&mut self, queue: &mut MessageQueue, issi: u32, gssi: u32, attach: bool) -> bool {
         let verb = if attach { "assign" } else { "deassign" };
 
@@ -1515,8 +1517,24 @@ impl MmBs {
             }
         }
 
-        // Push the unsolicited D-ATTACH/DETACH GROUP IDENTITY to the terminal.
-        self.send_d_attach_detach_group_identity(queue, issi, gssi, attach);
+        // Put the regroup on the air. By default this is an SS-DGNA ASSIGN/DEASSIGN carried in a
+        // CMCE D-FACILITY (TS 100 392-12-22 V1.5.1; transport EN 300 392-9 V1.7.1) — that SS PDU
+        // both *defines* the group and attaches it (cl.6.5.2.1), which is what makes the dynamic
+        // talkgroup appear and be selectable on a real terminal. The group attach/detach state and
+        // affiliation above are unchanged; CMCE owns only the air-interface emission, so we hand the
+        // request off over the Control SAP. The `dgna_use_ss_facility = false` rollback keeps the
+        // legacy MM-only D-ATTACH/DETACH GROUP IDENTITY (EN 300 392-2 V2.4.1 cl.16.8), which only
+        // toggles the L2 attachment of a group the radio already knows.
+        if self.config.config().cell.dgna_use_ss_facility {
+            queue.push_back(SapMsg {
+                sap: Sap::Control,
+                src: TetraEntity::Mm,
+                dest: TetraEntity::Cmce,
+                msg: SapMsgInner::CmceSsDgnaAssign { issi, gssi, attach },
+            });
+        } else {
+            self.send_d_attach_detach_group_identity(queue, issi, gssi, attach);
+        }
 
         // Persist for restart recovery (debounced) and refresh the dashboard with the full group set.
         self.recovery_mark_dirty();

--- a/crates/tetra-entities/tests/common/default_stack.rs
+++ b/crates/tetra-entities/tests/common/default_stack.rs
@@ -95,6 +95,7 @@ pub fn default_cell_info(freq_info: FreqInfo) -> CfgCellInfo {
         periodic_registration_secs: 3600,
         sds_command_control: None,
         release_group_on_same_speaker_retake: false,
+        dgna_use_ss_facility: true,
     }
 }
 

--- a/crates/tetra-entities/tests/test_cmce_bs.rs
+++ b/crates/tetra-entities/tests/test_cmce_bs.rs
@@ -1868,7 +1868,9 @@ fn test_u_facility_answered_with_function_not_supported() {
 
     // Build and submit a U-FACILITY uplink PDU.
     let mut sdu = BitBuffer::new_autoexpand(16);
-    UFacility {}.to_bitbuf(&mut sdu).expect("Failed to serialize UFacility");
+    UFacility { facility: None }
+        .to_bitbuf(&mut sdu)
+        .expect("Failed to serialize UFacility");
     sdu.seek(0);
     test.submit_message(lcmc_ind(calling_issi, sdu));
     test.run_stack(Some(1));
@@ -1888,4 +1890,251 @@ fn test_u_facility_answered_with_function_not_supported() {
         pdu.function_not_supported_pointer, 0,
         "pointer 0 = the whole PDU type is not supported"
     );
+}
+
+// ── SS-DGNA over CMCE D-FACILITY (TS 100 392-12-22 V1.5.1; EN 300 392-9 V1.7.1) ────────────────
+//
+// These exercise the full operator-DGNA path: a dashboard `ControlCommand::Dgna` reaches MM, which
+// (SS-DGNA default) affiliates the GSSI and hands the air emission to CMCE, which puts an SS-DGNA
+// ASSIGN/DEASSIGN on the wire inside a D-FACILITY. Plus the uplink U-FACILITY ASSIGN ACK handling.
+mod ss_dgna_tests {
+    use super::*;
+    use tetra_config::bluestation::StackMode;
+    use tetra_core::BitBuffer;
+    use tetra_entities::cmce::cmce_bs::CmceBs;
+    use tetra_entities::mm::mm_bs::MmBs;
+    use tetra_entities::net_control::{ControlCommand, make_control_link};
+    use tetra_pdus::cmce::pdus::d_facility::DFacility;
+    use tetra_pdus::cmce::pdus::u_facility::{UFacility, UFacilitySsBody};
+    use tetra_pdus::cmce::ss_dgna::enums::results::{GroupIdentityAttachmentMode, ResultOfAssignment, ResultOfAttachment};
+    use tetra_pdus::cmce::ss_dgna::fields::group_assignment_ack::GroupAssignmentAck;
+    use tetra_pdus::cmce::ss_dgna::pdus::assign_ack::AssignAck;
+    use tetra_pdus::cmce::ss_dgna::ss_dgna_pdu::SsDgnaPdu;
+    use tetra_pdus::mm::enums::location_update_type::LocationUpdateType;
+    use tetra_pdus::mm::pdus::u_location_update_demand::ULocationUpdateDemand;
+    use tetra_saps::lmm::LmmMleUnitdataInd;
+
+    const DGNA_ISSI: u32 = 2260601;
+    const DGNA_GSSI: u32 = 4242;
+
+    /// Register a terminal in MM by feeding a minimal U-LOCATION-UPDATE-DEMAND, so it is "known"
+    /// and eligible for DGNA. (Self-contained copy of the MM-test helper; the two test binaries
+    /// don't share helpers.)
+    fn register_terminal_mm(test: &mut ComponentTest, issi: u32) {
+        let demand = ULocationUpdateDemand {
+            location_update_type: LocationUpdateType::RoamingLocationUpdating,
+            request_to_append_la: false,
+            cipher_control: false,
+            ciphering_parameters: None,
+            class_of_ms: None,
+            energy_saving_mode: None,
+            la_information: None,
+            ssi: Some(issi as u64),
+            address_extension: None,
+            group_identity_location_demand: None,
+            group_report_response: None,
+            authentication_uplink: None,
+            extended_capabilities: None,
+            proprietary: None,
+        };
+        let mut sdu = BitBuffer::new_autoexpand(32);
+        demand.to_bitbuf(&mut sdu).expect("serialize U-LOCATION-UPDATE-DEMAND");
+        sdu.seek(0);
+        test.submit_message(SapMsg {
+            sap: Sap::LmmSap,
+            src: TetraEntity::Mle,
+            dest: TetraEntity::Mm,
+            msg: SapMsgInner::LmmMleUnitdataInd(LmmMleUnitdataInd {
+                sdu,
+                handle: 0,
+                received_address: TetraAddress::new(issi, SsiType::Issi),
+            }),
+        });
+        test.run_stack(Some(2));
+    }
+
+    /// Pull the first D-FACILITY (and its addressed ISSI) out of a batch of captured MLE messages.
+    fn find_d_facility(msgs: &[SapMsg]) -> Option<(u32, DFacility)> {
+        for m in msgs {
+            if let SapMsgInner::LcmcMleUnitdataReq(ref req) = m.msg {
+                if dl_pdu_type(&req.sdu) != Some(CmcePduTypeDl::DFacility) {
+                    continue;
+                }
+                let mut sdu = BitBuffer::from_bitstr(&req.sdu.to_bitstr());
+                if let Ok(pdu) = DFacility::from_bitbuf(&mut sdu) {
+                    return Some((req.main_address.ssi, pdu));
+                }
+            }
+        }
+        None
+    }
+
+    /// Build a MM(+control)/CMCE stack with the Mle sink, register the terminal, drive a DGNA, and
+    /// return everything captured at the sinks.
+    fn run_dgna(attach: bool) -> (ComponentTest, Vec<SapMsg>) {
+        let mut test = ComponentTest::new(StackMode::Bs, Some(TdmaTime::default()));
+        test.populate_entities(vec![], vec![TetraEntity::Mle]);
+
+        // CMCE wired exactly like the binary wires the dashboard control link.
+        let (dispatcher, endpoint) = make_control_link();
+        let cmce = CmceBs::new(test.get_shared_config(), None, Some(endpoint));
+        test.register_entity(cmce);
+        // MM owns the group registry; it receives the forwarded MmDgnaRequest over the SAP.
+        let mm = MmBs::new(test.get_shared_config(), None, None);
+        test.register_entity(mm);
+
+        register_terminal_mm(&mut test, DGNA_ISSI);
+        let _ = test.dump_sinks();
+
+        if !attach {
+            // Assign first so there is something to deassign.
+            dispatcher.send(ControlCommand::Dgna {
+                issi: DGNA_ISSI,
+                gssi: DGNA_GSSI,
+                attach: true,
+            });
+            test.run_stack(Some(6));
+            let _ = test.dump_sinks();
+        }
+
+        dispatcher.send(ControlCommand::Dgna {
+            issi: DGNA_ISSI,
+            gssi: DGNA_GSSI,
+            attach,
+        });
+        // CMCE drains control -> MmDgnaRequest -> MM affiliates + CmceSsDgnaAssign -> CMCE D-FACILITY.
+        test.run_stack(Some(6));
+        let msgs = test.dump_sinks();
+        (test, msgs)
+    }
+
+    /// Operator DGNA assign on the SS-DGNA default emits exactly one D-FACILITY{ASSIGN} addressed to
+    /// the target ISSI, with the GSSI and attachment mode 000, and the registry affiliates.
+    #[test]
+    fn test_dgna_assign_emits_d_facility() {
+        debug::setup_logging_verbose();
+        let (test, msgs) = run_dgna(true);
+
+        let (addr_ssi, facility) =
+            find_d_facility(&msgs).unwrap_or_else(|| panic!("expected a D-FACILITY after DGNA assign, got {} msgs", msgs.len()));
+        assert_eq!(addr_ssi, DGNA_ISSI, "D-FACILITY must be addressed to the target ISSI");
+
+        let body = facility.facility.expect("D-FACILITY must carry an SS-DGNA body");
+        let SsDgnaPdu::Assign(assign) = body.ss_pdu else {
+            panic!("expected an ASSIGN, got {}", body.ss_pdu);
+        };
+        assert_eq!(assign.groups.len(), 1, "exactly one group assigned");
+        assert_eq!(assign.groups[0].group_ssi, DGNA_GSSI);
+        assert_eq!(
+            assign.groups[0].attachment_mode,
+            GroupIdentityAttachmentMode::AttachedPermanently,
+            "attachment mode 000 (attached permanently)"
+        );
+        assert!(assign.ack_requested, "ASSIGN must request an ACK");
+
+        assert!(
+            test.config
+                .state_read()
+                .subscribers
+                .attached_groups_of(DGNA_ISSI)
+                .contains(&DGNA_GSSI),
+            "DGNA assign must affiliate the GSSI in the subscriber registry"
+        );
+    }
+
+    /// Operator DGNA deassign emits a D-FACILITY{DEASSIGN} naming the GSSI and removes the
+    /// affiliation.
+    #[test]
+    fn test_dgna_deassign_emits_d_facility_deassign() {
+        debug::setup_logging_verbose();
+        let (test, msgs) = run_dgna(false);
+
+        let (addr_ssi, facility) = find_d_facility(&msgs)
+            .unwrap_or_else(|| panic!("expected a D-FACILITY after DGNA deassign, got {} msgs", msgs.len()));
+        assert_eq!(addr_ssi, DGNA_ISSI);
+
+        let body = facility.facility.expect("D-FACILITY must carry an SS-DGNA body");
+        let SsDgnaPdu::Deassign(deassign) = body.ss_pdu else {
+            panic!("expected a DEASSIGN, got {}", body.ss_pdu);
+        };
+        assert_eq!(deassign.groups.len(), 1);
+        assert_eq!(deassign.groups[0].group_ssi, DGNA_GSSI);
+
+        assert!(
+            !test
+                .config
+                .state_read()
+                .subscribers
+                .attached_groups_of(DGNA_ISSI)
+                .contains(&DGNA_GSSI),
+            "DGNA deassign must remove the GSSI from the subscriber registry"
+        );
+    }
+
+    /// DGNA to a terminal MM does not know is refused before any air emission: no D-FACILITY.
+    #[test]
+    fn test_dgna_to_unregistered_issi_emits_no_d_facility() {
+        debug::setup_logging_verbose();
+        let mut test = ComponentTest::new(StackMode::Bs, Some(TdmaTime::default()));
+        test.populate_entities(vec![], vec![TetraEntity::Mle]);
+
+        let (dispatcher, endpoint) = make_control_link();
+        let cmce = CmceBs::new(test.get_shared_config(), None, Some(endpoint));
+        test.register_entity(cmce);
+        let mm = MmBs::new(test.get_shared_config(), None, None);
+        test.register_entity(mm);
+
+        // No registration first — MM must drop the command, so CMCE never emits a D-FACILITY.
+        dispatcher.send(ControlCommand::Dgna {
+            issi: 9_999_002,
+            gssi: DGNA_GSSI,
+            attach: true,
+        });
+        test.run_stack(Some(6));
+        let msgs = test.dump_sinks();
+
+        assert!(
+            find_d_facility(&msgs).is_none(),
+            "DGNA to an unregistered ISSI must not emit a D-FACILITY"
+        );
+    }
+
+    /// An uplink U-FACILITY carrying an SS-DGNA ASSIGN ACK is recognised and consumed (it confirms a
+    /// regroup whose BS state is already committed). It must NOT trigger D-CMCE-FUNCTION-NOT-SUPPORTED.
+    #[test]
+    fn test_u_facility_assign_ack_handled() {
+        debug::setup_logging_verbose();
+
+        let mut test = ComponentTest::new(StackMode::Bs, Some(TdmaTime::default()));
+        test.populate_entities(vec![TetraEntity::Cmce], vec![TetraEntity::Mle, TetraEntity::Umac, TetraEntity::Brew]);
+
+        // Build a U-FACILITY{ASSIGN ACK} as the affected MS would send back.
+        let ack = AssignAck {
+            acks: vec![GroupAssignmentAck {
+                group_ssi: DGNA_GSSI,
+                group_extension: None,
+                result_of_assignment: ResultOfAssignment::Accepted,
+                result_of_attachment: ResultOfAttachment::Attached,
+            }],
+        };
+        let mut sdu = BitBuffer::new_autoexpand(32);
+        UFacility {
+            facility: Some(UFacilitySsBody {
+                routeing: 0,
+                ss_pdu: SsDgnaPdu::AssignAck(ack),
+            }),
+        }
+        .to_bitbuf(&mut sdu)
+        .expect("serialize U-FACILITY ASSIGN ACK");
+        sdu.seek(0);
+
+        test.submit_message(lcmc_ind(DGNA_ISSI, sdu));
+        test.run_stack(Some(1));
+        let msgs = test.dump_sinks();
+
+        assert!(
+            find_lcmc_req(&msgs, DGNA_ISSI, CmcePduTypeDl::CmceFunctionNotSupported).is_none(),
+            "an SS-DGNA ASSIGN ACK must be consumed, not answered with D-CMCE-FUNCTION-NOT-SUPPORTED"
+        );
+    }
 }

--- a/crates/tetra-entities/tests/test_mm_bs.rs
+++ b/crates/tetra-entities/tests/test_mm_bs.rs
@@ -3,6 +3,10 @@ mod common;
 use tetra_config::bluestation::StackMode;
 use tetra_core::tetra_entities::TetraEntity;
 use tetra_core::{BitBuffer, Sap, SsiType, TdmaTime, TetraAddress, debug};
+use tetra_pdus::cmce::enums::cmce_pdu_type_dl::CmcePduTypeDl;
+use tetra_pdus::cmce::pdus::d_facility::DFacility;
+use tetra_pdus::cmce::ss_dgna::enums::results::GroupIdentityAttachmentMode;
+use tetra_pdus::cmce::ss_dgna::ss_dgna_pdu::SsDgnaPdu;
 use tetra_pdus::mm::enums::location_update_type::LocationUpdateType;
 use tetra_pdus::mm::enums::mm_pdu_type_dl::MmPduTypeDl;
 use tetra_pdus::mm::pdus::d_attach_detach_group_identity::DAttachDetachGroupIdentity;
@@ -55,6 +59,35 @@ fn register_terminal(test: &mut ComponentTest, issi: u32) {
         msg: SapMsgInner::LmmMleUnitdataInd(prim),
     });
     test.run_stack(Some(2));
+}
+
+/// Pull the first MM->CMCE `CmceSsDgnaAssign` SAP request out of a batch of captured messages.
+/// This is the air-interface emission MM now makes by default for a DGNA: it hands the SS-DGNA
+/// ASSIGN/DEASSIGN to CMCE rather than sending an MM D-ATTACH itself.
+fn find_ss_dgna_request(msgs: &[SapMsg]) -> Option<(u32, u32, bool)> {
+    msgs.iter().find_map(|m| match m.msg {
+        SapMsgInner::CmceSsDgnaAssign { issi, gssi, attach } if m.dest == TetraEntity::Cmce => Some((issi, gssi, attach)),
+        _ => None,
+    })
+}
+
+/// Pull the first D-FACILITY (and its addressed ISSI) out of a batch of captured MLE messages.
+/// Matched on the 5-bit CMCE downlink PDU-type discriminator before parsing, so a non-FACILITY
+/// downlink PDU is skipped rather than mis-parsed.
+fn find_d_facility(msgs: &[SapMsg]) -> Option<(u32, DFacility)> {
+    let want = CmcePduTypeDl::DFacility;
+    for m in msgs {
+        if let SapMsgInner::LcmcMleUnitdataReq(ref req) = m.msg {
+            if CmcePduTypeDl::try_from(req.sdu.peek_bits(5)?).ok() != Some(want) {
+                continue;
+            }
+            let mut sdu = BitBuffer::from_bitstr(&req.sdu.to_bitstr());
+            if let Ok(pdu) = DFacility::from_bitbuf(&mut sdu) {
+                return Some((req.main_address.ssi, pdu));
+            }
+        }
+    }
+    None
 }
 
 /// Pull the first D-ATTACH/DETACH GROUP IDENTITY out of a batch of captured MLE messages, if any.
@@ -174,17 +207,20 @@ fn test_reactive_recovery_rate_limits_repeat_bursts() {
     );
 }
 
-/// End-to-end DGNA assign: a dashboard control command makes MM push an unsolicited
-/// D-ATTACH/DETACH GROUP IDENTITY (attach, ack requested) to the targeted terminal AND record the
-/// affiliation in the shared subscriber registry so local group calls/SDS route to it.
+/// DGNA assign (SS-DGNA default): a dashboard control command makes MM affiliate the GSSI in the
+/// shared subscriber registry (so local group calls/SDS route to it) AND hand the air-interface
+/// emission to CMCE as a `CmceSsDgnaAssign` request. MM no longer sends the legacy D-ATTACH itself
+/// — the actual D-FACILITY on the wire is asserted in test_cmce_bs (the full MM+CMCE path).
 #[test]
-fn test_dgna_assign_emits_attach_group_identity_and_affiliates() {
+fn test_dgna_assign_affiliates_and_requests_ss_dgna() {
     debug::setup_logging_verbose();
     const TEST_ISSI: u32 = 2260571;
     const TEST_GSSI: u32 = 100;
 
     let mut test = ComponentTest::new(StackMode::Bs, Some(TdmaTime::default()));
-    test.populate_entities(vec![], vec![TetraEntity::Mle]);
+    // Sink CMCE too: MM hands the air emission to CMCE over the Control SAP, so the
+    // CmceSsDgnaAssign request is captured there (no real CMCE in this MM-focused test).
+    test.populate_entities(vec![], vec![TetraEntity::Mle, TetraEntity::Cmce]);
 
     // Register our own MM wired to a control endpoint so we can drive DGNA through the dispatcher.
     let (dispatcher, endpoint) = make_control_link();
@@ -204,22 +240,14 @@ fn test_dgna_assign_emits_attach_group_identity_and_affiliates() {
     test.run_stack(Some(2));
     let msgs = test.dump_sinks();
 
-    let (addr_ssi, pdu) = find_attach_detach(&msgs).unwrap_or_else(|| {
-        panic!(
-            "expected a D-ATTACH/DETACH GROUP IDENTITY after DGNA assign, got {} msgs",
-            msgs.len()
-        )
-    });
+    let (issi, gssi, attach) = find_ss_dgna_request(&msgs)
+        .unwrap_or_else(|| panic!("expected a CmceSsDgnaAssign request after DGNA assign, got {} msgs", msgs.len()));
+    assert_eq!((issi, gssi, attach), (TEST_ISSI, TEST_GSSI, true));
 
-    assert_eq!(addr_ssi, TEST_ISSI, "DGNA PDU must be addressed to the target ISSI");
-    assert!(pdu.group_identity_acknowledgement_request, "DGNA must request an ACK");
-    assert!(!pdu.group_identity_attach_detach_mode, "DGNA must amend, not reset, the group list");
-    let gids = pdu.group_identity_downlink.expect("downlink groups present");
-    assert_eq!(gids.len(), 1);
-    assert_eq!(gids[0].gssi, Some(TEST_GSSI));
+    // On the SS-DGNA default MM must NOT also send a legacy MM D-ATTACH (that would double-attach).
     assert!(
-        gids[0].group_identity_attachment.is_some(),
-        "an assign carries a group identity attachment"
+        find_attach_detach(&msgs).is_none(),
+        "SS-DGNA default must not also emit the legacy D-ATTACH/DETACH GROUP IDENTITY"
     );
 
     // BS-side affiliation must be reflected for local call/SDS routing.
@@ -233,15 +261,17 @@ fn test_dgna_assign_emits_attach_group_identity_and_affiliates() {
     );
 }
 
-/// DGNA deassign of a previously-assigned group emits a detach and removes the affiliation.
+/// DGNA deassign of a previously-assigned group requests a DEASSIGN from CMCE and removes the
+/// affiliation.
 #[test]
-fn test_dgna_deassign_emits_detach_and_deaffiliates() {
+fn test_dgna_deassign_requests_ss_dgna_and_deaffiliates() {
     debug::setup_logging_verbose();
     const TEST_ISSI: u32 = 2260572;
     const TEST_GSSI: u32 = 101;
 
     let mut test = ComponentTest::new(StackMode::Bs, Some(TdmaTime::default()));
-    test.populate_entities(vec![], vec![TetraEntity::Mle]);
+    // Sink CMCE too so the MM->CMCE CmceSsDgnaAssign request is captured (see assign test).
+    test.populate_entities(vec![], vec![TetraEntity::Mle, TetraEntity::Cmce]);
     let (dispatcher, endpoint) = make_control_link();
     let mm = MmBs::new(test.get_shared_config(), None, Some(endpoint));
     test.register_entity(mm);
@@ -271,21 +301,9 @@ fn test_dgna_deassign_emits_detach_and_deaffiliates() {
     test.run_stack(Some(2));
     let msgs = test.dump_sinks();
 
-    let (addr_ssi, pdu) = find_attach_detach(&msgs).unwrap_or_else(|| {
-        panic!(
-            "expected a D-ATTACH/DETACH GROUP IDENTITY after DGNA deassign, got {} msgs",
-            msgs.len()
-        )
-    });
-    assert_eq!(addr_ssi, TEST_ISSI);
-    let gids = pdu.group_identity_downlink.expect("downlink groups present");
-    assert_eq!(gids.len(), 1);
-    assert_eq!(gids[0].gssi, Some(TEST_GSSI));
-    assert!(gids[0].group_identity_attachment.is_none(), "a deassign carries no attachment");
-    assert!(
-        gids[0].group_identity_detachment_uplink.is_some(),
-        "a deassign carries a detachment"
-    );
+    let (issi, gssi, attach) = find_ss_dgna_request(&msgs)
+        .unwrap_or_else(|| panic!("expected a CmceSsDgnaAssign request after DGNA deassign, got {} msgs", msgs.len()));
+    assert_eq!((issi, gssi, attach), (TEST_ISSI, TEST_GSSI, false));
 
     assert!(
         !test
@@ -298,12 +316,75 @@ fn test_dgna_deassign_emits_detach_and_deaffiliates() {
     );
 }
 
+/// Rollback path: with `dgna_use_ss_facility = false` the legacy MM-only D-ATTACH/DETACH GROUP
+/// IDENTITY (EN 300 392-2 V2.4.1 cl.16.8) must still be emitted, and CMCE must NOT be asked for an
+/// SS-DGNA D-FACILITY. Guards the rollout switch.
+#[test]
+fn test_dgna_legacy_flag_emits_mm_attach() {
+    debug::setup_logging_verbose();
+    const TEST_ISSI: u32 = 2260573;
+    const TEST_GSSI: u32 = 102;
+
+    // Build a config with the SS-DGNA path turned off.
+    let mut config = ComponentTest::get_default_test_config(StackMode::Bs);
+    config.cell.dgna_use_ss_facility = false;
+    let mut test = ComponentTest::from_config(config, Some(TdmaTime::default()));
+    test.populate_entities(vec![], vec![TetraEntity::Mle]);
+
+    let (dispatcher, endpoint) = make_control_link();
+    let mm = MmBs::new(test.get_shared_config(), None, Some(endpoint));
+    test.register_entity(mm);
+
+    register_terminal(&mut test, TEST_ISSI);
+    let _ = test.dump_sinks();
+
+    dispatcher.send(ControlCommand::Dgna {
+        issi: TEST_ISSI,
+        gssi: TEST_GSSI,
+        attach: true,
+    });
+    test.run_stack(Some(2));
+    let msgs = test.dump_sinks();
+
+    let (addr_ssi, pdu) = find_attach_detach(&msgs).unwrap_or_else(|| {
+        panic!(
+            "legacy DGNA flag must emit a D-ATTACH/DETACH GROUP IDENTITY, got {} msgs",
+            msgs.len()
+        )
+    });
+    assert_eq!(addr_ssi, TEST_ISSI, "DGNA PDU must be addressed to the target ISSI");
+    assert!(pdu.group_identity_acknowledgement_request, "DGNA must request an ACK");
+    assert!(!pdu.group_identity_attach_detach_mode, "DGNA must amend, not reset, the group list");
+    let gids = pdu.group_identity_downlink.expect("downlink groups present");
+    assert_eq!(gids.len(), 1);
+    assert_eq!(gids[0].gssi, Some(TEST_GSSI));
+    assert!(
+        gids[0].group_identity_attachment.is_some(),
+        "an assign carries a group identity attachment"
+    );
+
+    // The legacy path must NOT also hand an SS-DGNA request to CMCE.
+    assert!(
+        find_ss_dgna_request(&msgs).is_none(),
+        "legacy DGNA path must not also request an SS-DGNA D-FACILITY"
+    );
+
+    assert!(
+        test.config
+            .state_read()
+            .subscribers
+            .attached_groups_of(TEST_ISSI)
+            .contains(&TEST_GSSI),
+        "legacy DGNA assign must still affiliate the GSSI in the subscriber registry"
+    );
+}
+
 /// Regression for the dashboard path (FlowStation log 00:19:24 "CMCE: ignoring unsupported control
 /// command Dgna"): the dashboard's control channel terminates at CMCE, not MM. A DGNA command
-/// delivered to CMCE must be forwarded to MM, which then pushes the D-ATTACH/DETACH GROUP IDENTITY
-/// over the air — exactly the path a real dashboard click takes.
+/// delivered to CMCE must be forwarded to MM, which (SS-DGNA default) hands the emission back to
+/// CMCE as a D-FACILITY{ASSIGN} on the air — exactly the path a real dashboard click takes.
 #[test]
-fn test_dgna_from_cmce_control_reaches_mm_and_emits_pdu() {
+fn test_dgna_from_cmce_control_reaches_mm_and_emits_d_facility() {
     debug::setup_logging_verbose();
     const TEST_ISSI: u32 = 2260575;
     const TEST_GSSI: u32 = 20;
@@ -329,19 +410,28 @@ fn test_dgna_from_cmce_control_reaches_mm_and_emits_pdu() {
         gssi: TEST_GSSI,
         attach: true,
     });
-    test.run_stack(Some(4)); // CMCE drains control -> forwards MmDgnaRequest -> MM emits the PDU
+    // CMCE drains control -> forwards MmDgnaRequest -> MM affiliates + requests CmceSsDgnaAssign ->
+    // CMCE emits the D-FACILITY. Allow a few ticks for the multi-hop.
+    test.run_stack(Some(6));
     let msgs = test.dump_sinks();
 
-    let (addr_ssi, pdu) = find_attach_detach(&msgs).unwrap_or_else(|| {
+    let (addr_ssi, facility) = find_d_facility(&msgs).unwrap_or_else(|| {
         panic!(
-            "DGNA via CMCE must reach MM and emit a D-ATTACH/DETACH GROUP IDENTITY, got {} msgs",
+            "DGNA via CMCE must reach MM and emit a D-FACILITY (SS-DGNA), got {} msgs",
             msgs.len()
         )
     });
     assert_eq!(addr_ssi, TEST_ISSI);
-    let gids = pdu.group_identity_downlink.expect("downlink groups present");
-    assert_eq!(gids[0].gssi, Some(TEST_GSSI));
-    assert!(gids[0].group_identity_attachment.is_some());
+    let body = facility.facility.expect("D-FACILITY must carry an SS-DGNA body");
+    let SsDgnaPdu::Assign(assign) = body.ss_pdu else {
+        panic!("expected an ASSIGN, got {}", body.ss_pdu);
+    };
+    assert_eq!(assign.groups.len(), 1);
+    assert_eq!(assign.groups[0].group_ssi, TEST_GSSI);
+    assert_eq!(
+        assign.groups[0].attachment_mode,
+        GroupIdentityAttachmentMode::AttachedPermanently
+    );
 
     assert!(
         test.config
@@ -375,6 +465,10 @@ fn test_dgna_to_unregistered_issi_is_refused() {
     assert!(
         find_attach_detach(&msgs).is_none(),
         "DGNA to an unregistered ISSI must not emit a group identity PDU"
+    );
+    assert!(
+        find_ss_dgna_request(&msgs).is_none(),
+        "DGNA to an unregistered ISSI must not request an SS-DGNA D-FACILITY"
     );
 }
 

--- a/crates/tetra-pdus/src/cmce/mod.rs
+++ b/crates/tetra-pdus/src/cmce/mod.rs
@@ -1,4 +1,5 @@
 pub mod enums;
 pub mod fields;
 pub mod pdus;
+pub mod ss_dgna;
 pub mod structs;

--- a/crates/tetra-pdus/src/cmce/pdus/d_facility.rs
+++ b/crates/tetra-pdus/src/cmce/pdus/d_facility.rs
@@ -1,49 +1,225 @@
 use core::fmt;
 
 use crate::cmce::enums::cmce_pdu_type_dl::CmcePduTypeDl;
+use crate::cmce::ss_dgna::ss_dgna_pdu::SsDgnaPdu;
 use tetra_core::typed_pdu_fields::*;
 use tetra_core::{BitBuffer, expect_pdu_type, pdu_parse_error::PduParseErr};
 
-/// Representation of the D-FACILITY PDU (Clause 14.7.1.7).
-/// This PDU shall be used to send call unrelated SS information.
-/// Response expected: -
-/// Response to: -
+/// Representation of the D-FACILITY PDU (EN 300 392-2 V2.4.1 cl.14.7.1.7).
+/// Used to send call-unrelated supplementary-service information.
+///
+/// CMCE owns only the 5-bit PDU type (= 16); everything after it is the
+/// SS-protocol-defined body. For SS-DGNA we carry the EN 300 392-9 V1.7.1
+/// SS-PDU container (Table 4) directly in the body:
+///
+/// ```text
+///   PDU type           5b  = 10000 (16)          [EN 300 392-2 Table 114]
+///   --- SS body (EN 300 392-9 Table 4) ---
+///   Routeing           2b  = 00 (same SwMI; v1 fixed)
+///   Number of SS PDUs  4b  = 0001 (v1)
+///   Length indicator  11b  = bit-length of the SS PDU
+///   SS PDU contents    Nb  = the SS-DGNA PDU
+/// ```
+///
+/// Empty-body back-compat: a non-DGNA / legacy D-FACILITY carries no SS PDU.
+/// EN 300 392-9 does not mandate an O-bit/M-bit trailer on the FACILITY SS
+/// body, so we keep the original stub convention — a single trailing O-bit = 0
+/// — only for the empty case (`facility = None`). When a real SS PDU is present
+/// we follow Table 4 exactly (no trailing M-bit). On parse the two are
+/// distinguished by the Number-of-SS-PDUs field: a populated container has
+/// Number of SS PDUs >= 1, whereas the empty body has at most the single O-bit.
+///
+/// Note: EN 300 392-9 Table 4 also defines a 24-bit MNI that is only present
+/// when Routeing = 11. v1 always uses Routeing = 00, so the MNI is never
+/// emitted; non-zero Routeing on the wire is rejected rather than guessed.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DFacility {
+    /// The SS-DGNA SS-PDU container, or `None` for a legacy empty body.
+    pub facility: Option<DFacilitySsBody>,
+}
 
-// note 1: Contents of this PDU shall be defined by SS protocols.
-#[derive(Debug)]
-pub struct DFacility {}
+/// The EN 300 392-9 V1.7.1 Table 4 SS-PDU container as carried in D-FACILITY.
+/// v1 carries exactly one SS PDU and uses Routeing = 00 (same SwMI).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DFacilitySsBody {
+    /// Routeing, 2 bits. 00 = same SwMI (the only value supported in v1).
+    pub routeing: u8,
+    /// The single SS-DGNA PDU (Number of SS PDUs = 1).
+    pub ss_pdu: SsDgnaPdu,
+}
 
-#[allow(unreachable_code)] // TODO FIXME review, finalize and remove this
 impl DFacility {
-    /// Parse from BitBuffer
+    /// Parse from BitBuffer.
     pub fn from_bitbuf(buffer: &mut BitBuffer) -> Result<Self, PduParseErr> {
         let pdu_type = buffer.read_field(5, "pdu_type")?;
         expect_pdu_type!(pdu_type, CmcePduTypeDl::DFacility)?;
 
-        // obit designates presence of any further type2, type3 or type4 fields
-        let mut obit = delimiters::read_obit(buffer)?;
+        // Distinguish a populated SS-PDU container from a legacy empty body.
+        // The container starts with Routeing (2b) + Number of SS PDUs (4b);
+        // a real container always carries at least one SS PDU. An empty body
+        // has at most the single trailing O-bit, so it cannot supply 6 header
+        // bits with a non-zero Number of SS PDUs.
+        let has_container = match buffer.peek_bits(6) {
+            Some(header) => (header & 0b1111) >= 1,
+            None => false,
+        };
 
-        // Read trailing obit (if not previously encountered)
-        obit = if obit { buffer.read_field(1, "trailing_obit")? == 1 } else { obit };
-        if obit {
-            return Err(PduParseErr::InvalidTrailingMbitValue);
+        if !has_container {
+            // Legacy empty-body convention: trailing O-bit must be 0.
+            let obit = delimiters::read_obit(buffer)?;
+            if obit {
+                return Err(PduParseErr::InvalidTrailingMbitValue);
+            }
+            return Ok(DFacility { facility: None });
         }
 
-        Ok(DFacility {})
+        let routeing = buffer.read_field(2, "routeing")? as u8;
+        if routeing != 0 {
+            // Routeing 11 would introduce a 24-bit MNI; not handled in v1.
+            return Err(PduParseErr::InvalidValue {
+                field: "routeing",
+                value: routeing as u64,
+            });
+        }
+        let number_of_ss_pdus = buffer.read_field(4, "number_of_ss_pdus")?;
+        if number_of_ss_pdus != 1 {
+            return Err(PduParseErr::InvalidValue {
+                field: "number_of_ss_pdus",
+                value: number_of_ss_pdus,
+            });
+        }
+
+        let length_indicator = buffer.read_field(11, "length_indicator")? as usize;
+        let start_pos = buffer.get_pos();
+        let ss_pdu = SsDgnaPdu::from_bitbuf(buffer)?;
+        let parsed_bits = buffer.get_pos() - start_pos;
+        if parsed_bits != length_indicator {
+            return Err(PduParseErr::InconsistentLength {
+                expected: length_indicator,
+                found: parsed_bits,
+            });
+        }
+
+        Ok(DFacility {
+            facility: Some(DFacilitySsBody { routeing, ss_pdu }),
+        })
     }
 
     /// Serialize this PDU into the given BitBuffer.
     pub fn to_bitbuf(&self, buffer: &mut BitBuffer) -> Result<(), PduParseErr> {
-        // PDU Type
+        // PDU Type.
         buffer.write_bits(CmcePduTypeDl::DFacility.into_raw(), 5);
-        // Write terminating m-bit
-        delimiters::write_mbit(buffer, 0);
+
+        let Some(body) = &self.facility else {
+            // Legacy empty body: keep the original single trailing O-bit = 0.
+            delimiters::write_mbit(buffer, 0);
+            return Ok(());
+        };
+
+        // SS body (EN 300 392-9 Table 4).
+        buffer.write_bits(body.routeing as u64, 2);
+        buffer.write_bits(1, 4); // Number of SS PDUs = 1.
+
+        // Serialize the SS PDU into a scratch buffer first so we can write its
+        // exact bit length as the 11-bit Length indicator.
+        let mut scratch = BitBuffer::new_autoexpand(32);
+        body.ss_pdu.to_bitbuf(&mut scratch)?;
+        let ss_pdu_bits = scratch.get_pos();
+        if ss_pdu_bits > 0x7FF {
+            return Err(PduParseErr::InvalidValue {
+                field: "length_indicator",
+                value: ss_pdu_bits as u64,
+            });
+        }
+        buffer.write_bits(ss_pdu_bits as u64, 11);
+        scratch.seek(0);
+        buffer.copy_bits(&mut scratch, ss_pdu_bits);
+
         Ok(())
     }
 }
 
 impl fmt::Display for DFacility {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "DFacility {{ }}",)
+        match &self.facility {
+            None => write!(f, "DFacility {{ }}"),
+            Some(body) => write!(f, "DFacility {{ routeing: {} ss_pdu: {} }}", body.routeing, body.ss_pdu),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::cmce::ss_dgna::enums::results::GroupIdentityAttachmentMode;
+    use crate::cmce::ss_dgna::fields::group_assignment::GroupAssignment;
+    use crate::cmce::ss_dgna::pdus::assign::Assign;
+
+    /// Legacy empty body round-trips and stays `None` (back-compat).
+    #[test]
+    fn d_facility_empty_round_trips() {
+        let pdu = DFacility { facility: None };
+        let mut buf = BitBuffer::new_autoexpand(16);
+        pdu.to_bitbuf(&mut buf).expect("serialize");
+        buf.seek(0);
+        let parsed = DFacility::from_bitbuf(&mut buf).expect("parse");
+        assert_eq!(parsed, pdu);
+        assert!(parsed.facility.is_none());
+    }
+
+    /// A D-FACILITY wrapping an ASSIGN: the container parses, carries exactly
+    /// one SS PDU, and the 11-bit Length indicator equals the inner SS PDU's
+    /// bit length.
+    #[test]
+    fn d_facility_wraps_assign() {
+        let assign = Assign {
+            groups: vec![GroupAssignment {
+                group_ssi: 1234567,
+                group_extension: None,
+                attachment_mode: GroupIdentityAttachmentMode::AttachedPermanently,
+                class_of_usage: Some(4),
+                mnemonic: None,
+                security_related_information: None,
+                additional_group_information: None,
+                vgssi: None,
+            }],
+            ack_requested: true,
+        };
+
+        // Independently compute the inner SS PDU bit length.
+        let mut inner = BitBuffer::new_autoexpand(32);
+        assign.to_bitbuf(&mut inner).expect("serialize inner");
+        let inner_bits = inner.get_pos();
+
+        let pdu = DFacility {
+            facility: Some(DFacilitySsBody {
+                routeing: 0,
+                ss_pdu: SsDgnaPdu::Assign(assign.clone()),
+            }),
+        };
+
+        let mut buf = BitBuffer::new_autoexpand(64);
+        pdu.to_bitbuf(&mut buf).expect("serialize");
+
+        // Decode the framing fields by hand to assert their exact values.
+        buf.seek(0);
+        assert_eq!(buf.read_bits(5).unwrap(), 16, "PDU type = D-FACILITY (16)");
+        assert_eq!(buf.read_bits(2).unwrap(), 0, "Routeing = 00");
+        assert_eq!(buf.read_bits(4).unwrap(), 1, "Number of SS PDUs = 1");
+        assert_eq!(
+            buf.read_bits(11).unwrap() as usize,
+            inner_bits,
+            "Length indicator == inner SS PDU bit length"
+        );
+
+        // Full round-trip.
+        buf.seek(0);
+        let parsed = DFacility::from_bitbuf(&mut buf).expect("parse");
+        assert_eq!(parsed, pdu);
+        let body = parsed.facility.expect("container present");
+        match body.ss_pdu {
+            SsDgnaPdu::Assign(a) => assert_eq!(a, assign),
+            other => panic!("expected Assign, got {other}"),
+        }
     }
 }

--- a/crates/tetra-pdus/src/cmce/pdus/u_facility.rs
+++ b/crates/tetra-pdus/src/cmce/pdus/u_facility.rs
@@ -1,49 +1,194 @@
 use core::fmt;
 
 use crate::cmce::enums::cmce_pdu_type_ul::CmcePduTypeUl;
+use crate::cmce::ss_dgna::ss_dgna_pdu::SsDgnaPdu;
 use tetra_core::typed_pdu_fields::*;
 use tetra_core::{BitBuffer, expect_pdu_type, pdu_parse_error::PduParseErr};
 
-/// Representation of the U-FACILITY PDU (Clause 14.7.2.5).
-/// This PDU shall be used to send call unrelated SS information.
-/// Response expected: -
-/// Response to: -
+/// Representation of the U-FACILITY PDU (EN 300 392-2 V2.4.1 cl.14.7.2.5).
+/// Used to send call-unrelated supplementary-service information.
+///
+/// As with D-FACILITY, CMCE owns only the 5-bit PDU type (= 16); the body is
+/// the EN 300 392-9 V1.7.1 SS-PDU container (Table 4):
+///
+/// ```text
+///   PDU type           5b  = 10000 (16)          [EN 300 392-2 Table 114]
+///   --- SS body (EN 300 392-9 Table 4) ---
+///   Routeing           2b  = 00 (same SwMI; v1 fixed)
+///   Number of SS PDUs  4b  = 0001 (v1)
+///   Length indicator  11b  = bit-length of the SS PDU
+///   SS PDU contents    Nb  = the SS-DGNA PDU
+/// ```
+///
+/// Empty-body back-compat works exactly as in D-FACILITY: a legacy / non-DGNA
+/// U-FACILITY carries no SS PDU and keeps the original single trailing
+/// O-bit = 0 convention; a populated container follows Table 4 with no trailing
+/// M-bit. The two are distinguished on parse by the Number-of-SS-PDUs field.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UFacility {
+    /// The SS-DGNA SS-PDU container, or `None` for a legacy empty body.
+    pub facility: Option<UFacilitySsBody>,
+}
 
-// note 1: Contents of this PDU shall be defined by SS protocols.
-#[derive(Debug)]
-pub struct UFacility {}
+/// The EN 300 392-9 V1.7.1 Table 4 SS-PDU container as carried in U-FACILITY.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UFacilitySsBody {
+    /// Routeing, 2 bits. 00 = same SwMI (the only value supported in v1).
+    pub routeing: u8,
+    /// The single SS-DGNA PDU (Number of SS PDUs = 1).
+    pub ss_pdu: SsDgnaPdu,
+}
 
-#[allow(unreachable_code)] // TODO FIXME review, finalize and remove this
 impl UFacility {
-    /// Parse from BitBuffer
+    /// Parse from BitBuffer.
     pub fn from_bitbuf(buffer: &mut BitBuffer) -> Result<Self, PduParseErr> {
         let pdu_type = buffer.read_field(5, "pdu_type")?;
         expect_pdu_type!(pdu_type, CmcePduTypeUl::UFacility)?;
 
-        // obit designates presence of any further type2, type3 or type4 fields
-        let mut obit = delimiters::read_obit(buffer)?;
+        // Distinguish a populated container from a legacy empty body via the
+        // Number-of-SS-PDUs field (a real container always carries >= 1).
+        let has_container = match buffer.peek_bits(6) {
+            Some(header) => (header & 0b1111) >= 1,
+            None => false,
+        };
 
-        // Read trailing obit (if not previously encountered)
-        obit = if obit { buffer.read_field(1, "trailing_obit")? == 1 } else { obit };
-        if obit {
-            return Err(PduParseErr::InvalidTrailingMbitValue);
+        if !has_container {
+            // Legacy empty-body convention: trailing O-bit must be 0.
+            let obit = delimiters::read_obit(buffer)?;
+            if obit {
+                return Err(PduParseErr::InvalidTrailingMbitValue);
+            }
+            return Ok(UFacility { facility: None });
         }
 
-        Ok(UFacility {})
+        let routeing = buffer.read_field(2, "routeing")? as u8;
+        if routeing != 0 {
+            return Err(PduParseErr::InvalidValue {
+                field: "routeing",
+                value: routeing as u64,
+            });
+        }
+        let number_of_ss_pdus = buffer.read_field(4, "number_of_ss_pdus")?;
+        if number_of_ss_pdus != 1 {
+            return Err(PduParseErr::InvalidValue {
+                field: "number_of_ss_pdus",
+                value: number_of_ss_pdus,
+            });
+        }
+
+        let length_indicator = buffer.read_field(11, "length_indicator")? as usize;
+        let start_pos = buffer.get_pos();
+        let ss_pdu = SsDgnaPdu::from_bitbuf(buffer)?;
+        let parsed_bits = buffer.get_pos() - start_pos;
+        if parsed_bits != length_indicator {
+            return Err(PduParseErr::InconsistentLength {
+                expected: length_indicator,
+                found: parsed_bits,
+            });
+        }
+
+        Ok(UFacility {
+            facility: Some(UFacilitySsBody { routeing, ss_pdu }),
+        })
     }
 
     /// Serialize this PDU into the given BitBuffer.
     pub fn to_bitbuf(&self, buffer: &mut BitBuffer) -> Result<(), PduParseErr> {
-        // PDU Type
+        // PDU Type.
         buffer.write_bits(CmcePduTypeUl::UFacility.into_raw(), 5);
-        // Write terminating m-bit
-        delimiters::write_mbit(buffer, 0);
+
+        let Some(body) = &self.facility else {
+            // Legacy empty body: keep the original single trailing O-bit = 0.
+            delimiters::write_mbit(buffer, 0);
+            return Ok(());
+        };
+
+        // SS body (EN 300 392-9 Table 4).
+        buffer.write_bits(body.routeing as u64, 2);
+        buffer.write_bits(1, 4); // Number of SS PDUs = 1.
+
+        // Serialize the SS PDU into a scratch buffer to obtain its exact bit
+        // length for the 11-bit Length indicator.
+        let mut scratch = BitBuffer::new_autoexpand(32);
+        body.ss_pdu.to_bitbuf(&mut scratch)?;
+        let ss_pdu_bits = scratch.get_pos();
+        if ss_pdu_bits > 0x7FF {
+            return Err(PduParseErr::InvalidValue {
+                field: "length_indicator",
+                value: ss_pdu_bits as u64,
+            });
+        }
+        buffer.write_bits(ss_pdu_bits as u64, 11);
+        scratch.seek(0);
+        buffer.copy_bits(&mut scratch, ss_pdu_bits);
+
         Ok(())
     }
 }
 
 impl fmt::Display for UFacility {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "UFacility {{ }}",)
+        match &self.facility {
+            None => write!(f, "UFacility {{ }}"),
+            Some(body) => write!(f, "UFacility {{ routeing: {} ss_pdu: {} }}", body.routeing, body.ss_pdu),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::cmce::ss_dgna::enums::results::{ResultOfAssignment, ResultOfAttachment};
+    use crate::cmce::ss_dgna::fields::group_assignment_ack::GroupAssignmentAck;
+    use crate::cmce::ss_dgna::pdus::assign_ack::AssignAck;
+
+    /// Legacy empty body round-trips and stays `None`.
+    #[test]
+    fn u_facility_empty_round_trips() {
+        let pdu = UFacility { facility: None };
+        let mut buf = BitBuffer::new_autoexpand(16);
+        pdu.to_bitbuf(&mut buf).expect("serialize");
+        buf.seek(0);
+        let parsed = UFacility::from_bitbuf(&mut buf).expect("parse");
+        assert_eq!(parsed, pdu);
+        assert!(parsed.facility.is_none());
+    }
+
+    /// A U-FACILITY wrapping an ASSIGN ACK round-trips, with the Length
+    /// indicator matching the inner SS PDU's bit length.
+    #[test]
+    fn u_facility_wraps_assign_ack() {
+        let ack = AssignAck {
+            acks: vec![GroupAssignmentAck {
+                group_ssi: 1234567,
+                group_extension: None,
+                result_of_assignment: ResultOfAssignment::Accepted,
+                result_of_attachment: ResultOfAttachment::Attached,
+            }],
+        };
+
+        let mut inner = BitBuffer::new_autoexpand(32);
+        ack.to_bitbuf(&mut inner).expect("serialize inner");
+        let inner_bits = inner.get_pos();
+
+        let pdu = UFacility {
+            facility: Some(UFacilitySsBody {
+                routeing: 0,
+                ss_pdu: SsDgnaPdu::AssignAck(ack.clone()),
+            }),
+        };
+
+        let mut buf = BitBuffer::new_autoexpand(64);
+        pdu.to_bitbuf(&mut buf).expect("serialize");
+
+        buf.seek(0);
+        assert_eq!(buf.read_bits(5).unwrap(), 16, "PDU type = U-FACILITY (16)");
+        assert_eq!(buf.read_bits(2).unwrap(), 0, "Routeing = 00");
+        assert_eq!(buf.read_bits(4).unwrap(), 1, "Number of SS PDUs = 1");
+        assert_eq!(buf.read_bits(11).unwrap() as usize, inner_bits, "Length indicator");
+
+        buf.seek(0);
+        let parsed = UFacility::from_bitbuf(&mut buf).expect("parse");
+        assert_eq!(parsed, pdu);
     }
 }

--- a/crates/tetra-pdus/src/cmce/ss_dgna/enums/mod.rs
+++ b/crates/tetra-pdus/src/cmce/ss_dgna/enums/mod.rs
@@ -1,0 +1,3 @@
+pub mod results;
+pub mod ss_dgna_pdu_type;
+pub mod ss_type;

--- a/crates/tetra-pdus/src/cmce/ss_dgna/enums/results.rs
+++ b/crates/tetra-pdus/src/cmce/ss_dgna/enums/results.rs
@@ -1,0 +1,248 @@
+//! Result and mode code points used in the SS-DGNA ACK PDUs and the Group
+//! assignment IE, all from TS 100 392-12-22 V1.5.1.
+//!
+//! Each follows the same `TryFrom<u64>` / `into_raw` / `From` shape as the
+//! other CMCE enums so they slot into `write_bits` / `read_field` directly.
+
+/// Result of assignment, TS 100 392-12-22 V1.5.1 Table 65.
+///
+/// Reported per group in the ASSIGN ACK (one entry per Group assignment Ack IE).
+///
+/// Bits: 2
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+pub enum ResultOfAssignment {
+    /// Assignment rejected (unspecified reason).
+    Rejected = 0,
+    /// Group successfully assigned.
+    Accepted = 1,
+    /// Assignment rejected for a security reason.
+    SecurityRejected = 2,
+    /// Assignment rejected, no capacity for further groups.
+    CapacityRejected = 3,
+}
+
+impl std::convert::TryFrom<u64> for ResultOfAssignment {
+    type Error = ();
+    fn try_from(x: u64) -> Result<Self, Self::Error> {
+        match x {
+            0 => Ok(ResultOfAssignment::Rejected),
+            1 => Ok(ResultOfAssignment::Accepted),
+            2 => Ok(ResultOfAssignment::SecurityRejected),
+            3 => Ok(ResultOfAssignment::CapacityRejected),
+            _ => Err(()),
+        }
+    }
+}
+
+impl ResultOfAssignment {
+    pub fn into_raw(self) -> u64 {
+        match self {
+            ResultOfAssignment::Rejected => 0,
+            ResultOfAssignment::Accepted => 1,
+            ResultOfAssignment::SecurityRejected => 2,
+            ResultOfAssignment::CapacityRejected => 3,
+        }
+    }
+}
+
+impl From<ResultOfAssignment> for u64 {
+    fn from(e: ResultOfAssignment) -> Self {
+        e.into_raw()
+    }
+}
+
+impl core::fmt::Display for ResultOfAssignment {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            ResultOfAssignment::Rejected => write!(f, "Rejected"),
+            ResultOfAssignment::Accepted => write!(f, "Accepted"),
+            ResultOfAssignment::SecurityRejected => write!(f, "SecurityRejected"),
+            ResultOfAssignment::CapacityRejected => write!(f, "CapacityRejected"),
+        }
+    }
+}
+
+/// Result of attachment, TS 100 392-12-22 V1.5.1 Table 66.
+///
+/// Reported per group in the ASSIGN ACK alongside the result of assignment.
+///
+/// Bits: 1
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+pub enum ResultOfAttachment {
+    /// Group was not attached.
+    NotAttached = 0,
+    /// Group was attached.
+    Attached = 1,
+}
+
+impl std::convert::TryFrom<u64> for ResultOfAttachment {
+    type Error = ();
+    fn try_from(x: u64) -> Result<Self, Self::Error> {
+        match x {
+            0 => Ok(ResultOfAttachment::NotAttached),
+            1 => Ok(ResultOfAttachment::Attached),
+            _ => Err(()),
+        }
+    }
+}
+
+impl ResultOfAttachment {
+    pub fn into_raw(self) -> u64 {
+        match self {
+            ResultOfAttachment::NotAttached => 0,
+            ResultOfAttachment::Attached => 1,
+        }
+    }
+}
+
+impl From<ResultOfAttachment> for u64 {
+    fn from(e: ResultOfAttachment) -> Self {
+        e.into_raw()
+    }
+}
+
+impl core::fmt::Display for ResultOfAttachment {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            ResultOfAttachment::NotAttached => write!(f, "NotAttached"),
+            ResultOfAttachment::Attached => write!(f, "Attached"),
+        }
+    }
+}
+
+/// Result of deassignment, TS 100 392-12-22 V1.5.1 Table 67.
+///
+/// Reported per group in the DEASSIGN ACK. Code points 2 and 3 are reserved.
+///
+/// Bits: 2
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+pub enum ResultOfDeassignment {
+    /// Group definition kept in the MS, but the group was detached.
+    DefinitionKeptDetached = 0,
+    /// Group definition removed from the MS.
+    DefinitionRemoved = 1,
+}
+
+impl std::convert::TryFrom<u64> for ResultOfDeassignment {
+    type Error = ();
+    fn try_from(x: u64) -> Result<Self, Self::Error> {
+        match x {
+            0 => Ok(ResultOfDeassignment::DefinitionKeptDetached),
+            1 => Ok(ResultOfDeassignment::DefinitionRemoved),
+            _ => Err(()),
+        }
+    }
+}
+
+impl ResultOfDeassignment {
+    pub fn into_raw(self) -> u64 {
+        match self {
+            ResultOfDeassignment::DefinitionKeptDetached => 0,
+            ResultOfDeassignment::DefinitionRemoved => 1,
+        }
+    }
+}
+
+impl From<ResultOfDeassignment> for u64 {
+    fn from(e: ResultOfDeassignment) -> Self {
+        e.into_raw()
+    }
+}
+
+impl core::fmt::Display for ResultOfDeassignment {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            ResultOfDeassignment::DefinitionKeptDetached => write!(f, "DefinitionKeptDetached"),
+            ResultOfDeassignment::DefinitionRemoved => write!(f, "DefinitionRemoved"),
+        }
+    }
+}
+
+/// Group identity attachment mode, TS 100 392-12-22 V1.5.1 Table 51.
+///
+/// Carries the same attachment-lifetime semantics as the MM group identity
+/// attachment lifetime (EN 300 392-2 V2.4.1 cl.16.10.16). `AttachedPermanently`
+/// is the mode used for the SwMI-initiated regroup push: the group stays
+/// attached without a re-attach at the next ITSI attach or location update.
+/// Codes 6 and 7 are reserved.
+///
+/// Bits: 3
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+pub enum GroupIdentityAttachmentMode {
+    /// Attached permanently (no re-attach required).
+    AttachedPermanently = 0,
+    /// Attachment requested at next ITSI attach.
+    AttachRequestedNextItsiAttach = 1,
+    /// Attachment not allowed at next ITSI attach.
+    AttachNotAllowedNextItsiAttach = 2,
+    /// Attachment requested at next location update.
+    AttachRequestedNextLocationUpdate = 3,
+    /// Not attached; the MS may request attachment.
+    NotAttachedMayRequest = 4,
+    /// Not attached; the MS may not request attachment.
+    NotAttachedMayNotRequest = 5,
+}
+
+impl std::convert::TryFrom<u64> for GroupIdentityAttachmentMode {
+    type Error = ();
+    fn try_from(x: u64) -> Result<Self, Self::Error> {
+        match x {
+            0 => Ok(GroupIdentityAttachmentMode::AttachedPermanently),
+            1 => Ok(GroupIdentityAttachmentMode::AttachRequestedNextItsiAttach),
+            2 => Ok(GroupIdentityAttachmentMode::AttachNotAllowedNextItsiAttach),
+            3 => Ok(GroupIdentityAttachmentMode::AttachRequestedNextLocationUpdate),
+            4 => Ok(GroupIdentityAttachmentMode::NotAttachedMayRequest),
+            5 => Ok(GroupIdentityAttachmentMode::NotAttachedMayNotRequest),
+            _ => Err(()),
+        }
+    }
+}
+
+impl GroupIdentityAttachmentMode {
+    pub fn into_raw(self) -> u64 {
+        match self {
+            GroupIdentityAttachmentMode::AttachedPermanently => 0,
+            GroupIdentityAttachmentMode::AttachRequestedNextItsiAttach => 1,
+            GroupIdentityAttachmentMode::AttachNotAllowedNextItsiAttach => 2,
+            GroupIdentityAttachmentMode::AttachRequestedNextLocationUpdate => 3,
+            GroupIdentityAttachmentMode::NotAttachedMayRequest => 4,
+            GroupIdentityAttachmentMode::NotAttachedMayNotRequest => 5,
+        }
+    }
+
+    /// True for the attachment modes (0..3) that EN 300 392-2 cl.16.10.6 pairs
+    /// with a Class of usage field in the Group assignment IE (Table 45). The
+    /// "not attached" modes (4, 5) carry no class of usage.
+    pub fn carries_class_of_usage(self) -> bool {
+        matches!(
+            self,
+            GroupIdentityAttachmentMode::AttachedPermanently
+                | GroupIdentityAttachmentMode::AttachRequestedNextItsiAttach
+                | GroupIdentityAttachmentMode::AttachNotAllowedNextItsiAttach
+                | GroupIdentityAttachmentMode::AttachRequestedNextLocationUpdate
+        )
+    }
+}
+
+impl From<GroupIdentityAttachmentMode> for u64 {
+    fn from(e: GroupIdentityAttachmentMode) -> Self {
+        e.into_raw()
+    }
+}
+
+impl core::fmt::Display for GroupIdentityAttachmentMode {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            GroupIdentityAttachmentMode::AttachedPermanently => write!(f, "AttachedPermanently"),
+            GroupIdentityAttachmentMode::AttachRequestedNextItsiAttach => write!(f, "AttachRequestedNextItsiAttach"),
+            GroupIdentityAttachmentMode::AttachNotAllowedNextItsiAttach => write!(f, "AttachNotAllowedNextItsiAttach"),
+            GroupIdentityAttachmentMode::AttachRequestedNextLocationUpdate => write!(f, "AttachRequestedNextLocationUpdate"),
+            GroupIdentityAttachmentMode::NotAttachedMayRequest => write!(f, "NotAttachedMayRequest"),
+            GroupIdentityAttachmentMode::NotAttachedMayNotRequest => write!(f, "NotAttachedMayNotRequest"),
+        }
+    }
+}

--- a/crates/tetra-pdus/src/cmce/ss_dgna/enums/ss_dgna_pdu_type.rs
+++ b/crates/tetra-pdus/src/cmce/ss_dgna/enums/ss_dgna_pdu_type.rs
@@ -1,0 +1,85 @@
+/// SS-DGNA PDU type, TS 100 392-12-22 V1.5.1 Table 74.
+///
+/// Selects the DGNA operation carried in the SS PDU body. Codes 0..4 are
+/// reserved by TS 100 392-12-22 for the generic EN 300 392-9 responses
+/// (SS-not-supported / action-not-supported) and are not represented here.
+///
+/// v1 implements ASSIGN / ASSIGN ACK / DEASSIGN / DEASSIGN ACK; the
+/// DEFINE / DELETE / MODIFY families are listed for completeness so the parser
+/// can name them, but their bodies are out of scope for now.
+///
+/// Bits: 5
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+pub enum SsDgnaPduType {
+    Define = 5,
+    DefineAck = 6,
+    Assign = 7,
+    AssignAck = 8,
+    Deassign = 9,
+    DeassignAck = 10,
+    Delete = 13,
+    DeleteAck = 14,
+    Modify = 15,
+    ModifyAck = 16,
+}
+
+impl std::convert::TryFrom<u64> for SsDgnaPduType {
+    type Error = ();
+    fn try_from(x: u64) -> Result<Self, Self::Error> {
+        match x {
+            5 => Ok(SsDgnaPduType::Define),
+            6 => Ok(SsDgnaPduType::DefineAck),
+            7 => Ok(SsDgnaPduType::Assign),
+            8 => Ok(SsDgnaPduType::AssignAck),
+            9 => Ok(SsDgnaPduType::Deassign),
+            10 => Ok(SsDgnaPduType::DeassignAck),
+            13 => Ok(SsDgnaPduType::Delete),
+            14 => Ok(SsDgnaPduType::DeleteAck),
+            15 => Ok(SsDgnaPduType::Modify),
+            16 => Ok(SsDgnaPduType::ModifyAck),
+            _ => Err(()),
+        }
+    }
+}
+
+impl SsDgnaPduType {
+    /// Convert this enum back into the raw integer value.
+    pub fn into_raw(self) -> u64 {
+        match self {
+            SsDgnaPduType::Define => 5,
+            SsDgnaPduType::DefineAck => 6,
+            SsDgnaPduType::Assign => 7,
+            SsDgnaPduType::AssignAck => 8,
+            SsDgnaPduType::Deassign => 9,
+            SsDgnaPduType::DeassignAck => 10,
+            SsDgnaPduType::Delete => 13,
+            SsDgnaPduType::DeleteAck => 14,
+            SsDgnaPduType::Modify => 15,
+            SsDgnaPduType::ModifyAck => 16,
+        }
+    }
+}
+
+impl From<SsDgnaPduType> for u64 {
+    fn from(e: SsDgnaPduType) -> Self {
+        e.into_raw()
+    }
+}
+
+impl core::fmt::Display for SsDgnaPduType {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            SsDgnaPduType::Define => write!(f, "Define"),
+            SsDgnaPduType::DefineAck => write!(f, "DefineAck"),
+            SsDgnaPduType::Assign => write!(f, "Assign"),
+            SsDgnaPduType::AssignAck => write!(f, "AssignAck"),
+            SsDgnaPduType::Deassign => write!(f, "Deassign"),
+            SsDgnaPduType::DeassignAck => write!(f, "DeassignAck"),
+            SsDgnaPduType::Delete => write!(f, "Delete"),
+            SsDgnaPduType::DeleteAck => write!(f, "DeleteAck"),
+            SsDgnaPduType::Modify => write!(f, "Modify"),
+            SsDgnaPduType::ModifyAck => write!(f, "ModifyAck"),
+        }
+    }
+}

--- a/crates/tetra-pdus/src/cmce/ss_dgna/enums/ss_type.rs
+++ b/crates/tetra-pdus/src/cmce/ss_dgna/enums/ss_type.rs
@@ -1,0 +1,47 @@
+/// Supplementary service type, EN 300 392-9 V1.7.1 Table 5 ("SS type").
+///
+/// Identifies which supplementary service a FACILITY-borne SS PDU belongs to.
+/// Only DGNA (Dynamic Group Number Assignment) is carried today; the remaining
+/// SS types fall through to `TryFrom` errors and are answered with the generic
+/// "SS not supported" path by the receiver.
+///
+/// Bits: 6
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+pub enum SsType {
+    /// Dynamic Group Number Assignment, TS 100 392-12-22 V1.5.1.
+    Dgna = 22,
+}
+
+impl std::convert::TryFrom<u64> for SsType {
+    type Error = ();
+    fn try_from(x: u64) -> Result<Self, Self::Error> {
+        match x {
+            22 => Ok(SsType::Dgna),
+            _ => Err(()),
+        }
+    }
+}
+
+impl SsType {
+    /// Convert this enum back into the raw integer value.
+    pub fn into_raw(self) -> u64 {
+        match self {
+            SsType::Dgna => 22,
+        }
+    }
+}
+
+impl From<SsType> for u64 {
+    fn from(e: SsType) -> Self {
+        e.into_raw()
+    }
+}
+
+impl core::fmt::Display for SsType {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            SsType::Dgna => write!(f, "Dgna"),
+        }
+    }
+}

--- a/crates/tetra-pdus/src/cmce/ss_dgna/fields/group_assignment.rs
+++ b/crates/tetra-pdus/src/cmce/ss_dgna/fields/group_assignment.rs
@@ -1,0 +1,212 @@
+use core::fmt;
+
+use tetra_core::typed_pdu_fields::*;
+use tetra_core::{BitBuffer, pdu_parse_error::PduParseErr};
+
+use crate::cmce::ss_dgna::enums::results::GroupIdentityAttachmentMode;
+
+/// Group assignment IE, TS 100 392-12-22 V1.5.1 Table 45.
+///
+/// This is the per-group definition carried (repeated) in the ASSIGN PDU
+/// (Table 18). It is the superset of the MM group-attach element: in addition
+/// to the GSSI and attachment mode it carries the mnemonic display name and the
+/// security / additional-group fields the MS needs to materialise and name a
+/// dynamic talkgroup.
+///
+/// Layout:
+/// ```text
+///   Group SSI                          24b  M
+///   Group extension present             1b  M
+///   Group extension                    24b  C  (only if present = 1; CC 10b + NC 14b, Table 49)
+///   Group identity attachment mode      3b  M  (Table 51)
+///   --- O-bit (Annex E) gating the type-2 region ---
+///   Class of usage                      3b  O/t2 (P-bit; EN 300 392-2 cl.16.10.6)
+///   Mnemonic group name                var  O/t2 (P-bit; 6b length + length*8b ISO-8859-1)
+///   Length of security related info     6b  O/t2 (P-bit) ─┐ paired length + value
+///   Security related information       var  C            ─┘
+///   Length of additional group info     6b  O/t2 (P-bit) ─┐ paired length + value
+///   Additional group information        var  C            ─┘
+///   (V)GSSI                            24b  O/t2 (P-bit)
+/// ```
+///
+/// Type-2 framing follows EN 300 392-2 V2.4.1 Annex E: a single O-bit after the
+/// fixed (type-1) region signals that any optional element may follow, and each
+/// defined type-2 element is then preceded by its own P-bit, written in the
+/// table order above. When every optional is absent the O-bit is 0 and no
+/// P-bits are emitted.
+///
+/// Mnemonic character encoding: TS 100 392-12-22 leaves this implementation
+/// defined; we use 8-bit ISO-8859-1, one octet per character, which is the
+/// common vendor choice.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GroupAssignment {
+    /// Group SSI (GSSI), 24 bits.
+    pub group_ssi: u32,
+    /// Group extension, 24 bits (CC 10b + NC 14b). `Some` sets the
+    /// "Group extension present" bit; `None` clears it.
+    pub group_extension: Option<u32>,
+    /// Group identity attachment mode, 3 bits (Table 51).
+    pub attachment_mode: GroupIdentityAttachmentMode,
+    /// Class of usage, 3 bits (type-2). Reuses the EN 300 392-2 cl.16.10.6
+    /// value table; absent when the attachment mode does not carry it.
+    pub class_of_usage: Option<u8>,
+    /// Mnemonic group name (type-2), the alias the radio displays. Held as the
+    /// raw ISO-8859-1 octets; `None` = absent.
+    pub mnemonic: Option<Vec<u8>>,
+    /// Security related information (type-2), opaque octets. `None` = absent.
+    pub security_related_information: Option<Vec<u8>>,
+    /// Additional group information (type-2), opaque octets. `None` = absent.
+    pub additional_group_information: Option<Vec<u8>>,
+    /// (V)GSSI, 24 bits (type-2). `None` = absent.
+    pub vgssi: Option<u32>,
+}
+
+impl GroupAssignment {
+    pub fn from_bitbuf(buf: &mut BitBuffer) -> Result<Self, PduParseErr> {
+        // Fixed (type-1) region.
+        let group_ssi = buf.read_field(24, "group_ssi")? as u32;
+        let ext_present = buf.read_field(1, "group_extension_present")? == 1;
+        let group_extension = if ext_present {
+            Some(buf.read_field(24, "group_extension")? as u32)
+        } else {
+            None
+        };
+        let attachment_mode_raw = buf.read_field(3, "attachment_mode")?;
+        let attachment_mode = GroupIdentityAttachmentMode::try_from(attachment_mode_raw)
+            .map_err(|_| PduParseErr::InvalidValue {
+                field: "attachment_mode",
+                value: attachment_mode_raw,
+            })?;
+
+        // O-bit gating the type-2 region (Annex E). If clear, every optional is
+        // absent and no P-bits follow.
+        let obit = delimiters::read_obit(buf)?;
+
+        // Class of usage (type-2), 3b.
+        let class_of_usage = typed::parse_type2_generic(obit, buf, 3, "class_of_usage")?.map(|v| v as u8);
+
+        // Mnemonic group name (type-2): P-bit, then 6b length (octet count),
+        // then length octets of ISO-8859-1.
+        let mnemonic = Self::parse_type2_octets(obit, buf, "mnemonic")?;
+
+        // Security related information (type-2): same length+value shape.
+        let security_related_information = Self::parse_type2_octets(obit, buf, "security_related_information")?;
+
+        // Additional group information (type-2): same length+value shape.
+        let additional_group_information = Self::parse_type2_octets(obit, buf, "additional_group_information")?;
+
+        // (V)GSSI (type-2), 24b.
+        let vgssi = typed::parse_type2_generic(obit, buf, 24, "vgssi")?.map(|v| v as u32);
+
+        Ok(GroupAssignment {
+            group_ssi,
+            group_extension,
+            attachment_mode,
+            class_of_usage,
+            mnemonic,
+            security_related_information,
+            additional_group_information,
+            vgssi,
+        })
+    }
+
+    pub fn to_bitbuf(&self, buf: &mut BitBuffer) -> Result<(), PduParseErr> {
+        if let Some(cou) = self.class_of_usage {
+            if cou > 0b111 {
+                return Err(PduParseErr::InvalidValue {
+                    field: "class_of_usage",
+                    value: cou as u64,
+                });
+            }
+        }
+
+        // Fixed (type-1) region.
+        buf.write_bits(self.group_ssi as u64, 24);
+        buf.write_bits(self.group_extension.is_some() as u64, 1);
+        if let Some(ext) = self.group_extension {
+            buf.write_bits(ext as u64, 24);
+        }
+        buf.write_bits(self.attachment_mode.into_raw(), 3);
+
+        // O-bit: set if any type-2 optional is present.
+        let obit = self.class_of_usage.is_some()
+            || self.mnemonic.is_some()
+            || self.security_related_information.is_some()
+            || self.additional_group_information.is_some()
+            || self.vgssi.is_some();
+        delimiters::write_obit(buf, obit as u8);
+        if !obit {
+            return Ok(());
+        }
+
+        // Type-2 elements, each preceded by its P-bit, in Table 45 order.
+        typed::write_type2_generic(obit, buf, self.class_of_usage.map(|v| v as u64), 3);
+        Self::write_type2_octets(obit, buf, &self.mnemonic)?;
+        Self::write_type2_octets(obit, buf, &self.security_related_information)?;
+        Self::write_type2_octets(obit, buf, &self.additional_group_information)?;
+        typed::write_type2_generic(obit, buf, self.vgssi.map(|v| v as u64), 24);
+
+        Ok(())
+    }
+
+    /// Parse a type-2 element whose value is a 6-bit octet count followed by
+    /// that many octets (mnemonic / security / additional-group fields).
+    fn parse_type2_octets(obit: bool, buf: &mut BitBuffer, field: &'static str) -> Result<Option<Vec<u8>>, PduParseErr> {
+        if !obit {
+            return Ok(None);
+        }
+        if !delimiters::read_pbit(buf)? {
+            return Ok(None);
+        }
+        let octet_count = buf.read_field(6, field)? as usize;
+        let mut bytes = Vec::with_capacity(octet_count);
+        for _ in 0..octet_count {
+            bytes.push(buf.read_field(8, field)? as u8);
+        }
+        Ok(Some(bytes))
+    }
+
+    /// Write a type-2 element as P-bit, 6-bit octet count, then the octets.
+    fn write_type2_octets(obit: bool, buf: &mut BitBuffer, value: &Option<Vec<u8>>) -> Result<(), PduParseErr> {
+        if !obit {
+            assert!(value.is_none(), "Type2 element cannot be present when obit is false");
+            return Ok(());
+        }
+        match value {
+            Some(bytes) => {
+                if bytes.len() > 0b11_1111 {
+                    return Err(PduParseErr::InvalidValue {
+                        field: "type2_octets_length",
+                        value: bytes.len() as u64,
+                    });
+                }
+                delimiters::write_pbit(buf, 1);
+                buf.write_bits(bytes.len() as u64, 6);
+                for b in bytes {
+                    buf.write_bits(*b as u64, 8);
+                }
+            }
+            None => {
+                delimiters::write_pbit(buf, 0);
+            }
+        }
+        Ok(())
+    }
+}
+
+impl fmt::Display for GroupAssignment {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "GroupAssignment {{ group_ssi: {} group_extension: {:?} attachment_mode: {} class_of_usage: {:?} mnemonic: {:?} security_related_information: {:?} additional_group_information: {:?} vgssi: {:?} }}",
+            self.group_ssi,
+            self.group_extension,
+            self.attachment_mode,
+            self.class_of_usage,
+            self.mnemonic,
+            self.security_related_information,
+            self.additional_group_information,
+            self.vgssi
+        )
+    }
+}

--- a/crates/tetra-pdus/src/cmce/ss_dgna/fields/group_assignment_ack.rs
+++ b/crates/tetra-pdus/src/cmce/ss_dgna/fields/group_assignment_ack.rs
@@ -1,0 +1,82 @@
+use core::fmt;
+
+use tetra_core::{BitBuffer, pdu_parse_error::PduParseErr};
+
+use crate::cmce::ss_dgna::enums::results::{ResultOfAssignment, ResultOfAttachment};
+
+/// Group assignment Ack IE, TS 100 392-12-22 V1.5.1 Table 46.
+///
+/// Carried (repeated) in the ASSIGN ACK PDU (Table 19), one entry per group the
+/// affected MS reports on.
+///
+/// Layout:
+/// ```text
+///   Group SSI               24b  M
+///   Group extension present  1b  M
+///   Group extension         24b  C  (only if present = 1)
+///   Result of assignment     2b  M  (Table 65)
+///   Result of attachment     1b  M  (Table 66)
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GroupAssignmentAck {
+    /// Group SSI (GSSI), 24 bits.
+    pub group_ssi: u32,
+    /// Group extension, 24 bits. `Some` sets the present bit.
+    pub group_extension: Option<u32>,
+    /// Result of assignment, 2 bits (Table 65).
+    pub result_of_assignment: ResultOfAssignment,
+    /// Result of attachment, 1 bit (Table 66).
+    pub result_of_attachment: ResultOfAttachment,
+}
+
+impl GroupAssignmentAck {
+    pub fn from_bitbuf(buf: &mut BitBuffer) -> Result<Self, PduParseErr> {
+        let group_ssi = buf.read_field(24, "group_ssi")? as u32;
+        let ext_present = buf.read_field(1, "group_extension_present")? == 1;
+        let group_extension = if ext_present {
+            Some(buf.read_field(24, "group_extension")? as u32)
+        } else {
+            None
+        };
+
+        let roa_raw = buf.read_field(2, "result_of_assignment")?;
+        let result_of_assignment = ResultOfAssignment::try_from(roa_raw).map_err(|_| PduParseErr::InvalidValue {
+            field: "result_of_assignment",
+            value: roa_raw,
+        })?;
+
+        let rot_raw = buf.read_field(1, "result_of_attachment")?;
+        let result_of_attachment = ResultOfAttachment::try_from(rot_raw).map_err(|_| PduParseErr::InvalidValue {
+            field: "result_of_attachment",
+            value: rot_raw,
+        })?;
+
+        Ok(GroupAssignmentAck {
+            group_ssi,
+            group_extension,
+            result_of_assignment,
+            result_of_attachment,
+        })
+    }
+
+    pub fn to_bitbuf(&self, buf: &mut BitBuffer) -> Result<(), PduParseErr> {
+        buf.write_bits(self.group_ssi as u64, 24);
+        buf.write_bits(self.group_extension.is_some() as u64, 1);
+        if let Some(ext) = self.group_extension {
+            buf.write_bits(ext as u64, 24);
+        }
+        buf.write_bits(self.result_of_assignment.into_raw(), 2);
+        buf.write_bits(self.result_of_attachment.into_raw(), 1);
+        Ok(())
+    }
+}
+
+impl fmt::Display for GroupAssignmentAck {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "GroupAssignmentAck {{ group_ssi: {} group_extension: {:?} result_of_assignment: {} result_of_attachment: {} }}",
+            self.group_ssi, self.group_extension, self.result_of_assignment, self.result_of_attachment
+        )
+    }
+}

--- a/crates/tetra-pdus/src/cmce/ss_dgna/fields/group_deassignment.rs
+++ b/crates/tetra-pdus/src/cmce/ss_dgna/fields/group_deassignment.rs
@@ -1,0 +1,55 @@
+use core::fmt;
+
+use tetra_core::{BitBuffer, pdu_parse_error::PduParseErr};
+
+/// Group deassignment IE, TS 100 392-12-22 V1.5.1 Table 47.
+///
+/// Carried (repeated) in the DEASSIGN PDU (Table 20), one entry per group to
+/// remove/detach. It names the group only; the action (detach vs. remove) is
+/// decided by the MS and reported back in the DEASSIGN ACK.
+///
+/// Layout:
+/// ```text
+///   Group SSI               24b  M
+///   Group extension present  1b  M
+///   Group extension         24b  C  (only if present = 1)
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GroupDeassignment {
+    /// Group SSI (GSSI), 24 bits.
+    pub group_ssi: u32,
+    /// Group extension, 24 bits. `Some` sets the present bit.
+    pub group_extension: Option<u32>,
+}
+
+impl GroupDeassignment {
+    pub fn from_bitbuf(buf: &mut BitBuffer) -> Result<Self, PduParseErr> {
+        let group_ssi = buf.read_field(24, "group_ssi")? as u32;
+        let ext_present = buf.read_field(1, "group_extension_present")? == 1;
+        let group_extension = if ext_present {
+            Some(buf.read_field(24, "group_extension")? as u32)
+        } else {
+            None
+        };
+        Ok(GroupDeassignment { group_ssi, group_extension })
+    }
+
+    pub fn to_bitbuf(&self, buf: &mut BitBuffer) -> Result<(), PduParseErr> {
+        buf.write_bits(self.group_ssi as u64, 24);
+        buf.write_bits(self.group_extension.is_some() as u64, 1);
+        if let Some(ext) = self.group_extension {
+            buf.write_bits(ext as u64, 24);
+        }
+        Ok(())
+    }
+}
+
+impl fmt::Display for GroupDeassignment {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "GroupDeassignment {{ group_ssi: {} group_extension: {:?} }}",
+            self.group_ssi, self.group_extension
+        )
+    }
+}

--- a/crates/tetra-pdus/src/cmce/ss_dgna/fields/group_deassignment_ack.rs
+++ b/crates/tetra-pdus/src/cmce/ss_dgna/fields/group_deassignment_ack.rs
@@ -1,0 +1,70 @@
+use core::fmt;
+
+use tetra_core::{BitBuffer, pdu_parse_error::PduParseErr};
+
+use crate::cmce::ss_dgna::enums::results::ResultOfDeassignment;
+
+/// Group deassignment Ack IE, TS 100 392-12-22 V1.5.1 Table 48.
+///
+/// Carried (repeated) in the DEASSIGN ACK PDU (Table 21), one entry per group.
+///
+/// Layout:
+/// ```text
+///   Group SSI               24b  M
+///   Group extension present  1b  M
+///   Group extension         24b  C  (only if present = 1)
+///   Result of deassignment   2b  M  (Table 67)
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GroupDeassignmentAck {
+    /// Group SSI (GSSI), 24 bits.
+    pub group_ssi: u32,
+    /// Group extension, 24 bits. `Some` sets the present bit.
+    pub group_extension: Option<u32>,
+    /// Result of deassignment, 2 bits (Table 67).
+    pub result_of_deassignment: ResultOfDeassignment,
+}
+
+impl GroupDeassignmentAck {
+    pub fn from_bitbuf(buf: &mut BitBuffer) -> Result<Self, PduParseErr> {
+        let group_ssi = buf.read_field(24, "group_ssi")? as u32;
+        let ext_present = buf.read_field(1, "group_extension_present")? == 1;
+        let group_extension = if ext_present {
+            Some(buf.read_field(24, "group_extension")? as u32)
+        } else {
+            None
+        };
+
+        let rod_raw = buf.read_field(2, "result_of_deassignment")?;
+        let result_of_deassignment = ResultOfDeassignment::try_from(rod_raw).map_err(|_| PduParseErr::InvalidValue {
+            field: "result_of_deassignment",
+            value: rod_raw,
+        })?;
+
+        Ok(GroupDeassignmentAck {
+            group_ssi,
+            group_extension,
+            result_of_deassignment,
+        })
+    }
+
+    pub fn to_bitbuf(&self, buf: &mut BitBuffer) -> Result<(), PduParseErr> {
+        buf.write_bits(self.group_ssi as u64, 24);
+        buf.write_bits(self.group_extension.is_some() as u64, 1);
+        if let Some(ext) = self.group_extension {
+            buf.write_bits(ext as u64, 24);
+        }
+        buf.write_bits(self.result_of_deassignment.into_raw(), 2);
+        Ok(())
+    }
+}
+
+impl fmt::Display for GroupDeassignmentAck {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "GroupDeassignmentAck {{ group_ssi: {} group_extension: {:?} result_of_deassignment: {} }}",
+            self.group_ssi, self.group_extension, self.result_of_deassignment
+        )
+    }
+}

--- a/crates/tetra-pdus/src/cmce/ss_dgna/fields/mod.rs
+++ b/crates/tetra-pdus/src/cmce/ss_dgna/fields/mod.rs
@@ -1,0 +1,4 @@
+pub mod group_assignment;
+pub mod group_assignment_ack;
+pub mod group_deassignment;
+pub mod group_deassignment_ack;

--- a/crates/tetra-pdus/src/cmce/ss_dgna/mod.rs
+++ b/crates/tetra-pdus/src/cmce/ss_dgna/mod.rs
@@ -1,0 +1,14 @@
+//! SS-DGNA (Dynamic Group Number Assignment) supplementary service.
+//!
+//! Implements the SS-DGNA PDUs and information elements from
+//! TS 100 392-12-22 V1.5.1, carried over the CMCE U/D-FACILITY mechanism
+//! (EN 300 392-9 V1.7.1 transport, EN 300 392-2 V2.4.1 CMCE framing).
+//!
+//! Scope today: ASSIGN / ASSIGN ACK / DEASSIGN / DEASSIGN ACK. The
+//! DEFINE / DELETE / MODIFY / INTERROGATE families are not yet implemented;
+//! the module layout mirrors `cmce/pdus` + `cmce/fields` so they slot in later.
+
+pub mod enums;
+pub mod fields;
+pub mod pdus;
+pub mod ss_dgna_pdu;

--- a/crates/tetra-pdus/src/cmce/ss_dgna/pdus/assign.rs
+++ b/crates/tetra-pdus/src/cmce/ss_dgna/pdus/assign.rs
@@ -1,0 +1,197 @@
+use core::fmt;
+
+use tetra_core::{BitBuffer, expect_pdu_type, pdu_parse_error::PduParseErr};
+
+use crate::cmce::ss_dgna::enums::ss_dgna_pdu_type::SsDgnaPduType;
+use crate::cmce::ss_dgna::enums::ss_type::SsType;
+use crate::cmce::ss_dgna::fields::group_assignment::GroupAssignment;
+
+/// ASSIGN PDU, TS 100 392-12-22 V1.5.1 Table 18 (downlink, carried in
+/// D-FACILITY).
+///
+/// Adds groups and their parameters to the affected user(s). Each group is a
+/// Group assignment IE (Table 45); the per-PDU "Acknowledgement requested" bit
+/// is written once at the end, after all the IEs, not per group.
+///
+/// Wire layout:
+/// ```text
+///   SS type                   6b  = 22 (DGNA)              [EN 300 392-9 Table 5]
+///   SS-DGNA PDU type           5b  = 00111 (ASSIGN)        [TS Table 74]
+///   Number of groups           5b  = groups.len() (1..31)
+///   Group assignment IE       var  repeated, Number of groups times  [Table 45]
+///   Acknowledgement requested  1b  once, at the end
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Assign {
+    /// One Group assignment IE per group being assigned. Number of groups is
+    /// derived from `groups.len()`; must be 1..=31.
+    pub groups: Vec<GroupAssignment>,
+    /// "Acknowledgement requested from affected user(s)" — request an ASSIGN ACK.
+    pub ack_requested: bool,
+}
+
+impl Assign {
+    pub fn from_bitbuf(buf: &mut BitBuffer) -> Result<Self, PduParseErr> {
+        let ss_type = buf.read_field(6, "ss_type")?;
+        expect_pdu_type!(ss_type, SsType::Dgna)?;
+        let pdu_type = buf.read_field(5, "ss_dgna_pdu_type")?;
+        expect_pdu_type!(pdu_type, SsDgnaPduType::Assign)?;
+
+        let number_of_groups = buf.read_field(5, "number_of_groups")? as usize;
+        let mut groups = Vec::with_capacity(number_of_groups);
+        for _ in 0..number_of_groups {
+            groups.push(GroupAssignment::from_bitbuf(buf)?);
+        }
+
+        let ack_requested = buf.read_field(1, "ack_requested")? == 1;
+
+        Ok(Assign { groups, ack_requested })
+    }
+
+    pub fn to_bitbuf(&self, buf: &mut BitBuffer) -> Result<(), PduParseErr> {
+        if self.groups.is_empty() || self.groups.len() > 31 {
+            return Err(PduParseErr::InvalidValue {
+                field: "number_of_groups",
+                value: self.groups.len() as u64,
+            });
+        }
+
+        buf.write_bits(SsType::Dgna.into_raw(), 6);
+        buf.write_bits(SsDgnaPduType::Assign.into_raw(), 5);
+        buf.write_bits(self.groups.len() as u64, 5);
+        for group in &self.groups {
+            group.to_bitbuf(buf)?;
+        }
+        buf.write_bits(self.ack_requested as u64, 1);
+        Ok(())
+    }
+}
+
+impl fmt::Display for Assign {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "Assign {{ groups: {:?} ack_requested: {} }}", self.groups, self.ack_requested)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::cmce::ss_dgna::enums::results::GroupIdentityAttachmentMode;
+
+    /// The SwMI-initiated regroup push: one GSSI, attachment mode 000 (attached
+    /// permanently), class of usage 4, no mnemonic. Round-trips and matches the
+    /// exact bit string of the header plus minimal IE.
+    #[test]
+    fn assign_round_trips() {
+        for mnemonic in [None, Some(b"DISPATCH".to_vec())] {
+            let pdu = Assign {
+                groups: vec![GroupAssignment {
+                    group_ssi: 1234567,
+                    group_extension: None,
+                    attachment_mode: GroupIdentityAttachmentMode::AttachedPermanently,
+                    class_of_usage: Some(4),
+                    mnemonic: mnemonic.clone(),
+                    security_related_information: None,
+                    additional_group_information: None,
+                    vgssi: None,
+                }],
+                ack_requested: true,
+            };
+
+            let mut buf = BitBuffer::new_autoexpand(32);
+            pdu.to_bitbuf(&mut buf).expect("serialize");
+            buf.seek(0);
+            let parsed = Assign::from_bitbuf(&mut buf).expect("parse");
+            assert_eq!(parsed, pdu);
+        }
+    }
+
+    /// Exact bit-vector for a known minimal ASSIGN with no type-2 optionals:
+    /// SS type = 22 (010110), PDU type = ASSIGN (00111), Number of groups = 1
+    /// (00001), then the single Group assignment IE and the trailing ack bit.
+    ///
+    /// IE: Group SSI = 1 (24b), ext present = 0, attachment mode = 000, O-bit = 0.
+    /// Trailing "Acknowledgement requested" = 1.
+    #[test]
+    fn assign_exact_bits() {
+        let pdu = Assign {
+            groups: vec![GroupAssignment {
+                group_ssi: 1,
+                group_extension: None,
+                attachment_mode: GroupIdentityAttachmentMode::AttachedPermanently,
+                class_of_usage: None,
+                mnemonic: None,
+                security_related_information: None,
+                additional_group_information: None,
+                vgssi: None,
+            }],
+            ack_requested: true,
+        };
+
+        let mut buf = BitBuffer::new_autoexpand(64);
+        pdu.to_bitbuf(&mut buf).expect("serialize");
+
+        let expected = concat!(
+            "010110", // SS type = 22
+            "00111",  // SS-DGNA PDU type = ASSIGN (7)
+            "00001",  // Number of groups = 1
+            // Group assignment IE:
+            "000000000000000000000001", // Group SSI = 1
+            "0",                        // Group extension present = 0
+            "000",                      // Group identity attachment mode = 000
+            "0",                        // O-bit (no type-2 optionals)
+            "1",                        // Acknowledgement requested = 1
+        );
+        assert_eq!(buf.to_bitstr(), expected);
+    }
+
+    /// Type-2 framing: mnemonic present vs absent must produce the right O/P
+    /// bits and round-trip identically. With only a present mnemonic the IE
+    /// ends O-bit=1, P(class)=0, P(mnemonic)=1, length, octets, P(sec)=0,
+    /// P(add)=0, P(vgssi)=0.
+    #[test]
+    fn group_assignment_ie_optionals() {
+        // Absent: O-bit clear, no P-bits.
+        let absent = GroupAssignment {
+            group_ssi: 42,
+            group_extension: None,
+            attachment_mode: GroupIdentityAttachmentMode::AttachedPermanently,
+            class_of_usage: None,
+            mnemonic: None,
+            security_related_information: None,
+            additional_group_information: None,
+            vgssi: None,
+        };
+        let mut buf = BitBuffer::new_autoexpand(32);
+        absent.to_bitbuf(&mut buf).expect("serialize");
+        // 24 (ssi) + 1 (ext) + 3 (mode) + 1 (o-bit) = 29 bits, last bit = O-bit = 0.
+        assert_eq!(buf.get_pos(), 29);
+        assert!(buf.to_bitstr().ends_with('0'), "O-bit must be clear when no optionals");
+
+        // Present mnemonic only: O-bit set, P(class)=0, P(mnemonic)=1.
+        let present = GroupAssignment {
+            mnemonic: Some(b"AB".to_vec()),
+            ..absent.clone()
+        };
+        let mut buf2 = BitBuffer::new_autoexpand(32);
+        present.to_bitbuf(&mut buf2).expect("serialize");
+        let s = buf2.to_bitstr();
+        // Fixed region: 24 + 1 + 3 = 28 bits, then O-bit=1, P(class)=0, P(mnemonic)=1.
+        assert_eq!(&s[28..29], "1", "O-bit set");
+        assert_eq!(&s[29..30], "0", "P-bit for class of usage = 0 (absent)");
+        assert_eq!(&s[30..31], "1", "P-bit for mnemonic = 1 (present)");
+        // 6-bit length = 2 octets.
+        assert_eq!(&s[31..37], "000010", "mnemonic length = 2");
+        assert_eq!(&s[37..45], "01000001", "first octet 'A' (0x41)");
+        assert_eq!(&s[45..53], "01000010", "second octet 'B' (0x42)");
+
+        // Round-trip both.
+        for ga in [absent, present] {
+            let mut b = BitBuffer::new_autoexpand(32);
+            ga.to_bitbuf(&mut b).expect("serialize");
+            b.seek(0);
+            let parsed = GroupAssignment::from_bitbuf(&mut b).expect("parse");
+            assert_eq!(parsed, ga);
+        }
+    }
+}

--- a/crates/tetra-pdus/src/cmce/ss_dgna/pdus/assign_ack.rs
+++ b/crates/tetra-pdus/src/cmce/ss_dgna/pdus/assign_ack.rs
@@ -1,0 +1,99 @@
+use core::fmt;
+
+use tetra_core::{BitBuffer, expect_pdu_type, pdu_parse_error::PduParseErr};
+
+use crate::cmce::ss_dgna::enums::ss_dgna_pdu_type::SsDgnaPduType;
+use crate::cmce::ss_dgna::enums::ss_type::SsType;
+use crate::cmce::ss_dgna::fields::group_assignment_ack::GroupAssignmentAck;
+
+/// ASSIGN ACK PDU, TS 100 392-12-22 V1.5.1 Table 19 (uplink, carried in
+/// U-FACILITY).
+///
+/// Sent by the affected MS in response to an ASSIGN with the acknowledgement
+/// bit set. Reports the assignment/attachment result per group.
+///
+/// Wire layout:
+/// ```text
+///   SS type                  6b  = 22 (DGNA)              [EN 300 392-9 Table 5]
+///   SS-DGNA PDU type          5b  = 01000 (ASSIGN ACK)    [TS Table 74]
+///   Number of groups          5b  = acks.len()
+///   Group assignment Ack IE  var  repeated, Number of groups times  [Table 46]
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AssignAck {
+    /// One Group assignment Ack IE per group reported on. Number of groups is
+    /// derived from `acks.len()`.
+    pub acks: Vec<GroupAssignmentAck>,
+}
+
+impl AssignAck {
+    pub fn from_bitbuf(buf: &mut BitBuffer) -> Result<Self, PduParseErr> {
+        let ss_type = buf.read_field(6, "ss_type")?;
+        expect_pdu_type!(ss_type, SsType::Dgna)?;
+        let pdu_type = buf.read_field(5, "ss_dgna_pdu_type")?;
+        expect_pdu_type!(pdu_type, SsDgnaPduType::AssignAck)?;
+
+        let number_of_groups = buf.read_field(5, "number_of_groups")? as usize;
+        let mut acks = Vec::with_capacity(number_of_groups);
+        for _ in 0..number_of_groups {
+            acks.push(GroupAssignmentAck::from_bitbuf(buf)?);
+        }
+
+        Ok(AssignAck { acks })
+    }
+
+    pub fn to_bitbuf(&self, buf: &mut BitBuffer) -> Result<(), PduParseErr> {
+        if self.acks.len() > 31 {
+            return Err(PduParseErr::InvalidValue {
+                field: "number_of_groups",
+                value: self.acks.len() as u64,
+            });
+        }
+
+        buf.write_bits(SsType::Dgna.into_raw(), 6);
+        buf.write_bits(SsDgnaPduType::AssignAck.into_raw(), 5);
+        buf.write_bits(self.acks.len() as u64, 5);
+        for ack in &self.acks {
+            ack.to_bitbuf(buf)?;
+        }
+        Ok(())
+    }
+}
+
+impl fmt::Display for AssignAck {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "AssignAck {{ acks: {:?} }}", self.acks)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::cmce::ss_dgna::enums::results::{ResultOfAssignment, ResultOfAttachment};
+
+    #[test]
+    fn assign_ack_round_trips() {
+        let pdu = AssignAck {
+            acks: vec![
+                GroupAssignmentAck {
+                    group_ssi: 1234567,
+                    group_extension: None,
+                    result_of_assignment: ResultOfAssignment::Accepted,
+                    result_of_attachment: ResultOfAttachment::Attached,
+                },
+                GroupAssignmentAck {
+                    group_ssi: 7654321,
+                    group_extension: Some(0xABCDE),
+                    result_of_assignment: ResultOfAssignment::CapacityRejected,
+                    result_of_attachment: ResultOfAttachment::NotAttached,
+                },
+            ],
+        };
+
+        let mut buf = BitBuffer::new_autoexpand(32);
+        pdu.to_bitbuf(&mut buf).expect("serialize");
+        buf.seek(0);
+        let parsed = AssignAck::from_bitbuf(&mut buf).expect("parse");
+        assert_eq!(parsed, pdu);
+    }
+}

--- a/crates/tetra-pdus/src/cmce/ss_dgna/pdus/deassign.rs
+++ b/crates/tetra-pdus/src/cmce/ss_dgna/pdus/deassign.rs
@@ -1,0 +1,113 @@
+use core::fmt;
+
+use tetra_core::{BitBuffer, expect_pdu_type, pdu_parse_error::PduParseErr};
+
+use crate::cmce::ss_dgna::enums::ss_dgna_pdu_type::SsDgnaPduType;
+use crate::cmce::ss_dgna::enums::ss_type::SsType;
+use crate::cmce::ss_dgna::fields::group_deassignment::GroupDeassignment;
+
+/// DEASSIGN PDU, TS 100 392-12-22 V1.5.1 Table 20 (downlink, carried in
+/// D-FACILITY).
+///
+/// Removes/detaches groups from the affected user(s). A "Number of groups in
+/// deassign request" of 00000 means "deassign all groups" (Table 64): in that
+/// case `groups` is empty and no Group deassignment IE follows.
+///
+/// Wire layout:
+/// ```text
+///   SS type                                6b  = 22 (DGNA)
+///   SS-DGNA PDU type                        5b  = 01001 (DEASSIGN)    [TS Table 74]
+///   Number of groups in deassign request    5b  = groups.len() (00000 = ALL)
+///   Group deassignment IE                  var  repeated, that many times  [Table 47]
+///   Acknowledgement requested               1b  once, at the end
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Deassign {
+    /// One Group deassignment IE per group; empty means "deassign all" (the
+    /// Number-of-groups field is encoded as 00000).
+    pub groups: Vec<GroupDeassignment>,
+    /// "Acknowledgement requested from affected user(s)" — request a DEASSIGN ACK.
+    pub ack_requested: bool,
+}
+
+impl Deassign {
+    pub fn from_bitbuf(buf: &mut BitBuffer) -> Result<Self, PduParseErr> {
+        let ss_type = buf.read_field(6, "ss_type")?;
+        expect_pdu_type!(ss_type, SsType::Dgna)?;
+        let pdu_type = buf.read_field(5, "ss_dgna_pdu_type")?;
+        expect_pdu_type!(pdu_type, SsDgnaPduType::Deassign)?;
+
+        let number_of_groups = buf.read_field(5, "number_of_groups")? as usize;
+        let mut groups = Vec::with_capacity(number_of_groups);
+        for _ in 0..number_of_groups {
+            groups.push(GroupDeassignment::from_bitbuf(buf)?);
+        }
+
+        let ack_requested = buf.read_field(1, "ack_requested")? == 1;
+
+        Ok(Deassign { groups, ack_requested })
+    }
+
+    pub fn to_bitbuf(&self, buf: &mut BitBuffer) -> Result<(), PduParseErr> {
+        if self.groups.len() > 31 {
+            return Err(PduParseErr::InvalidValue {
+                field: "number_of_groups",
+                value: self.groups.len() as u64,
+            });
+        }
+
+        buf.write_bits(SsType::Dgna.into_raw(), 6);
+        buf.write_bits(SsDgnaPduType::Deassign.into_raw(), 5);
+        buf.write_bits(self.groups.len() as u64, 5);
+        for group in &self.groups {
+            group.to_bitbuf(buf)?;
+        }
+        buf.write_bits(self.ack_requested as u64, 1);
+        Ok(())
+    }
+}
+
+impl fmt::Display for Deassign {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "Deassign {{ groups: {:?} ack_requested: {} }}", self.groups, self.ack_requested)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn deassign_round_trips() {
+        let pdu = Deassign {
+            groups: vec![GroupDeassignment {
+                group_ssi: 7654321,
+                group_extension: None,
+            }],
+            ack_requested: true,
+        };
+
+        let mut buf = BitBuffer::new_autoexpand(32);
+        pdu.to_bitbuf(&mut buf).expect("serialize");
+        buf.seek(0);
+        let parsed = Deassign::from_bitbuf(&mut buf).expect("parse");
+        assert_eq!(parsed, pdu);
+    }
+
+    /// "Deassign all" — Number of groups = 00000, no IE follows, then the ack bit.
+    #[test]
+    fn deassign_all_round_trips() {
+        let pdu = Deassign {
+            groups: vec![],
+            ack_requested: false,
+        };
+
+        let mut buf = BitBuffer::new_autoexpand(32);
+        pdu.to_bitbuf(&mut buf).expect("serialize");
+        // SS type 6 + PDU type 5 + number of groups 5 + ack 1 = 17 bits.
+        assert_eq!(buf.get_pos(), 17);
+        buf.seek(0);
+        let parsed = Deassign::from_bitbuf(&mut buf).expect("parse");
+        assert_eq!(parsed, pdu);
+    }
+}

--- a/crates/tetra-pdus/src/cmce/ss_dgna/pdus/deassign_ack.rs
+++ b/crates/tetra-pdus/src/cmce/ss_dgna/pdus/deassign_ack.rs
@@ -1,0 +1,96 @@
+use core::fmt;
+
+use tetra_core::{BitBuffer, expect_pdu_type, pdu_parse_error::PduParseErr};
+
+use crate::cmce::ss_dgna::enums::ss_dgna_pdu_type::SsDgnaPduType;
+use crate::cmce::ss_dgna::enums::ss_type::SsType;
+use crate::cmce::ss_dgna::fields::group_deassignment_ack::GroupDeassignmentAck;
+
+/// DEASSIGN ACK PDU, TS 100 392-12-22 V1.5.1 Table 21 (uplink, carried in
+/// U-FACILITY).
+///
+/// Sent by the affected MS in response to a DEASSIGN. Reports the deassignment
+/// result per group and a final "Acknowledgement complete" bit.
+///
+/// Wire layout:
+/// ```text
+///   SS type                       6b  = 22 (DGNA)
+///   SS-DGNA PDU type               5b  = 01010 (DEASSIGN ACK)   [TS Table 74]
+///   Number of groups in deassign ack 5b = acks.len()
+///   Group deassignment Ack IE     var  repeated, that many times  [Table 48]
+///   Acknowledgement complete       1b  once, at the end
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DeassignAck {
+    /// One Group deassignment Ack IE per group reported on.
+    pub acks: Vec<GroupDeassignmentAck>,
+    /// "Acknowledgement complete" — the MS has finished processing the request.
+    pub ack_complete: bool,
+}
+
+impl DeassignAck {
+    pub fn from_bitbuf(buf: &mut BitBuffer) -> Result<Self, PduParseErr> {
+        let ss_type = buf.read_field(6, "ss_type")?;
+        expect_pdu_type!(ss_type, SsType::Dgna)?;
+        let pdu_type = buf.read_field(5, "ss_dgna_pdu_type")?;
+        expect_pdu_type!(pdu_type, SsDgnaPduType::DeassignAck)?;
+
+        let number_of_groups = buf.read_field(5, "number_of_groups")? as usize;
+        let mut acks = Vec::with_capacity(number_of_groups);
+        for _ in 0..number_of_groups {
+            acks.push(GroupDeassignmentAck::from_bitbuf(buf)?);
+        }
+
+        let ack_complete = buf.read_field(1, "ack_complete")? == 1;
+
+        Ok(DeassignAck { acks, ack_complete })
+    }
+
+    pub fn to_bitbuf(&self, buf: &mut BitBuffer) -> Result<(), PduParseErr> {
+        if self.acks.len() > 31 {
+            return Err(PduParseErr::InvalidValue {
+                field: "number_of_groups",
+                value: self.acks.len() as u64,
+            });
+        }
+
+        buf.write_bits(SsType::Dgna.into_raw(), 6);
+        buf.write_bits(SsDgnaPduType::DeassignAck.into_raw(), 5);
+        buf.write_bits(self.acks.len() as u64, 5);
+        for ack in &self.acks {
+            ack.to_bitbuf(buf)?;
+        }
+        buf.write_bits(self.ack_complete as u64, 1);
+        Ok(())
+    }
+}
+
+impl fmt::Display for DeassignAck {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "DeassignAck {{ acks: {:?} ack_complete: {} }}", self.acks, self.ack_complete)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::cmce::ss_dgna::enums::results::ResultOfDeassignment;
+
+    #[test]
+    fn deassign_ack_round_trips() {
+        let pdu = DeassignAck {
+            acks: vec![GroupDeassignmentAck {
+                group_ssi: 7654321,
+                group_extension: None,
+                result_of_deassignment: ResultOfDeassignment::DefinitionRemoved,
+            }],
+            ack_complete: true,
+        };
+
+        let mut buf = BitBuffer::new_autoexpand(32);
+        pdu.to_bitbuf(&mut buf).expect("serialize");
+        buf.seek(0);
+        let parsed = DeassignAck::from_bitbuf(&mut buf).expect("parse");
+        assert_eq!(parsed, pdu);
+    }
+}

--- a/crates/tetra-pdus/src/cmce/ss_dgna/pdus/mod.rs
+++ b/crates/tetra-pdus/src/cmce/ss_dgna/pdus/mod.rs
@@ -1,0 +1,4 @@
+pub mod assign;
+pub mod assign_ack;
+pub mod deassign;
+pub mod deassign_ack;

--- a/crates/tetra-pdus/src/cmce/ss_dgna/ss_dgna_pdu.rs
+++ b/crates/tetra-pdus/src/cmce/ss_dgna/ss_dgna_pdu.rs
@@ -1,0 +1,84 @@
+use core::fmt;
+
+use tetra_core::{BitBuffer, pdu_parse_error::PduParseErr};
+
+use crate::cmce::ss_dgna::enums::ss_dgna_pdu_type::SsDgnaPduType;
+use crate::cmce::ss_dgna::enums::ss_type::SsType;
+use crate::cmce::ss_dgna::pdus::assign::Assign;
+use crate::cmce::ss_dgna::pdus::assign_ack::AssignAck;
+use crate::cmce::ss_dgna::pdus::deassign::Deassign;
+use crate::cmce::ss_dgna::pdus::deassign_ack::DeassignAck;
+
+/// One SS-DGNA PDU as carried inside a FACILITY SS-PDU container.
+///
+/// The variant is chosen from the SS header (SS type 6b + SS-DGNA PDU type 5b,
+/// §3.3): on parse we peek those 11 bits before dispatching to the right
+/// `from_bitbuf`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SsDgnaPdu {
+    Assign(Assign),
+    AssignAck(AssignAck),
+    Deassign(Deassign),
+    DeassignAck(DeassignAck),
+}
+
+impl SsDgnaPdu {
+    /// Serialize the inner SS-DGNA PDU (SS header + body, no FACILITY framing).
+    pub fn to_bitbuf(&self, buf: &mut BitBuffer) -> Result<(), PduParseErr> {
+        match self {
+            SsDgnaPdu::Assign(p) => p.to_bitbuf(buf),
+            SsDgnaPdu::AssignAck(p) => p.to_bitbuf(buf),
+            SsDgnaPdu::Deassign(p) => p.to_bitbuf(buf),
+            SsDgnaPdu::DeassignAck(p) => p.to_bitbuf(buf),
+        }
+    }
+
+    /// Parse one SS-DGNA PDU. Peeks the SS type (6b) and SS-DGNA PDU type (5b)
+    /// to select the variant, then runs the matching `from_bitbuf` (which
+    /// re-reads the header and validates it).
+    pub fn from_bitbuf(buf: &mut BitBuffer) -> Result<Self, PduParseErr> {
+        let ss_type_raw = buf.peek_bits(6).ok_or(PduParseErr::BufferEnded { field: Some("ss_type") })?;
+        SsType::try_from(ss_type_raw).map_err(|_| PduParseErr::InvalidValue {
+            field: "ss_type",
+            value: ss_type_raw,
+        })?;
+
+        let pdu_type_raw = buf
+            .peek_bits_posoffset(6, 5)
+            .ok_or(PduParseErr::BufferEnded { field: Some("ss_dgna_pdu_type") })?;
+        let pdu_type = SsDgnaPduType::try_from(pdu_type_raw).map_err(|_| PduParseErr::InvalidValue {
+            field: "ss_dgna_pdu_type",
+            value: pdu_type_raw,
+        })?;
+
+        match pdu_type {
+            SsDgnaPduType::Assign => Ok(SsDgnaPdu::Assign(Assign::from_bitbuf(buf)?)),
+            SsDgnaPduType::AssignAck => Ok(SsDgnaPdu::AssignAck(AssignAck::from_bitbuf(buf)?)),
+            SsDgnaPduType::Deassign => Ok(SsDgnaPdu::Deassign(Deassign::from_bitbuf(buf)?)),
+            SsDgnaPduType::DeassignAck => Ok(SsDgnaPdu::DeassignAck(DeassignAck::from_bitbuf(buf)?)),
+            // DEFINE / DELETE / MODIFY families are recognised but not yet decoded.
+            other => Err(PduParseErr::NotImplemented {
+                field: Some(match other {
+                    SsDgnaPduType::Define => "SS-DGNA DEFINE",
+                    SsDgnaPduType::DefineAck => "SS-DGNA DEFINE ACK",
+                    SsDgnaPduType::Delete => "SS-DGNA DELETE",
+                    SsDgnaPduType::DeleteAck => "SS-DGNA DELETE ACK",
+                    SsDgnaPduType::Modify => "SS-DGNA MODIFY",
+                    SsDgnaPduType::ModifyAck => "SS-DGNA MODIFY ACK",
+                    _ => "SS-DGNA PDU",
+                }),
+            }),
+        }
+    }
+}
+
+impl fmt::Display for SsDgnaPdu {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            SsDgnaPdu::Assign(p) => write!(f, "{}", p),
+            SsDgnaPdu::AssignAck(p) => write!(f, "{}", p),
+            SsDgnaPdu::Deassign(p) => write!(f, "{}", p),
+            SsDgnaPdu::DeassignAck(p) => write!(f, "{}", p),
+        }
+    }
+}

--- a/crates/tetra-saps/src/sapmsg.rs
+++ b/crates/tetra-saps/src/sapmsg.rs
@@ -91,6 +91,17 @@ pub enum SapMsgInner {
         attach: bool,
     },
 
+    /// MM -> CMCE: emit an SS-DGNA D-FACILITY for one terminal — an ASSIGN when `attach`, a
+    /// DEASSIGN otherwise (TS 100 392-12-22 V1.5.1 cl.6.2.2/6.2.3, carried over the CMCE
+    /// U/D-FACILITY mechanism, EN 300 392-9 V1.7.1 cl.7.3). MM keeps owning the group registry and
+    /// affiliation state; this only asks CMCE to put the Group assignment IE on the air. v1 carries
+    /// no mnemonic — the radio displays its own provisioned name for the GSSI, or the number.
+    CmceSsDgnaAssign {
+        issi: u32,
+        gssi: u32,
+        attach: bool,
+    },
+
     /// Sent by UMAC to MM when a UL burst is received from a known MS.
     /// MM stores the RSSI value per MS for logging and future handover decisions.
     MsRssiUpdate {
@@ -142,6 +153,9 @@ impl Display for SapMsgInner {
             SapMsgInner::MmSubscriberUpdate(_) => write!(f, "MmSubscriberUpdate"),
             SapMsgInner::MmDgnaRequest { issi, gssi, attach } => {
                 write!(f, "MmDgnaRequest(issi={}, gssi={}, attach={})", issi, gssi, attach)
+            }
+            SapMsgInner::CmceSsDgnaAssign { issi, gssi, attach } => {
+                write!(f, "CmceSsDgnaAssign(issi={}, gssi={}, attach={})", issi, gssi, attach)
             }
             SapMsgInner::MsRssiUpdate { issi, rssi_dbfs } => write!(f, "MsRssiUpdate(issi={}, rssi={:.1}dBFS)", issi, rssi_dbfs),
             SapMsgInner::BrewReconnected => write!(f, "BrewReconnected"),

--- a/example_config/config.toml
+++ b/example_config/config.toml
@@ -173,6 +173,19 @@ voice_service = true
 # latency, so enable this only on cells that still run those legacy sets.
 # release_group_on_same_speaker_retake = false
 
+# DGNA (Dynamic Group Number Assignment) air-interface mechanism.
+# ON (default): an operator regroup goes out as an SS-DGNA ASSIGN/DEASSIGN carried in a CMCE
+# D-FACILITY (ETSI TS 100 392-12-22 V1.5.1; transport EN 300 392-9 V1.7.1). That SS PDU both
+# *defines* the group (mnemonic/parameters) AND attaches it in one step, which is what makes a
+# dynamic talkgroup appear and be selectable on a real terminal.
+# OFF: falls back to the legacy MM-only D-ATTACH/DETACH GROUP IDENTITY (EN 300 392-2 V2.4.1
+# cl.16.8), which only toggles the L2 attachment of a group the radio already knows — a bare GSSI
+# the radio was never told about has nothing to name or select. Kept as a rollback switch.
+# NB: even a correct SS-DGNA shows nothing unless DGNA notification is provisioned in the terminal
+# codeplug — that is a codeplug gap, not a stack bug.
+# Absent = true. Set false only to roll back to the legacy path.
+# dgna_use_ss_facility = true
+
 # Maximum active call duration in seconds — ETSI EN 300 392-2 §14.9.1 T310 equivalent (FlowStation).
 # After this time the BS sends D-RELEASE regardless of call activity.
 # 0 = no limit (infinite — call runs until U-DISCONNECT or hangtime).


### PR DESCRIPTION
Makes operator DGNA actually work on real terminals by implementing SS-DGNA (the ETSI supplementary service) over the CMCE FACILITY mechanism.

## Why DGNA didn't work
The stack only pushed an MM **D-ATTACH/DETACH GROUP IDENTITY** (EN 300 392-2 cl.16.8). That PDU just toggles the attachment state of a group the radio is presumed to **already know** — it carries no group *definition* (no name, no display/security info). So pushing a bare D-ATTACH for a GSSI the radio was never told about gives it nothing to materialise: real Motorola/Sepura terminals ignore it or create a silent, unnamed, unselectable attachment.

## What this adds
**SS-DGNA** (TS 100 392-12-22) is a CMCE supplementary service carried over **D-FACILITY / U-FACILITY**. The **ASSIGN** PDU *defines and attaches* the group in one step (cl.6.5.2.1), then the radio confirms with a **U-FACILITY ASSIGN-ACK**.

- **`tetra-pdus`**: SS-DGNA PDUs (ASSIGN / ASSIGN-ACK / DEASSIGN / DEASSIGN-ACK) + the Group assignment IE; the empty D/U-FACILITY stubs replaced with the EN 300 392-9 SS-PDU container. Round-trip + exact-bit-vector tests.
- **CMCE**: a new SS sub-entity emits the SS-DGNA D-FACILITY to the target ISSI (LLC acknowledged) and consumes the MS's ASSIGN/DEASSIGN ACK.
- **MM**: `do_dgna` keeps all registry/affiliation/telemetry logic and now emits the SS-DGNA D-FACILITY instead of the bare D-ATTACH. Gated by a new `cell_info.dgna_use_ss_facility` flag (default `true`) with a fall-back to the legacy MM D-ATTACH path.

Spec versions are pinned in the code (TS 100 392-12-22 V1.5.1, EN 300 392-9 V1.7.1, EN 300 392-2 V2.4.1).

## Notes
- **No group name (mnemonic) is sent.** SS-DGNA can carry a display alias, but there's no per-GSSI name config in the stack. The IE supports it per ETSI; v1 sends it absent, so the radio shows its own provisioned name for the GSSI (or the number). A `[[talkgroup]]` name table can be added later.
- **Needs on-radio validation** (flagged in code): the FACILITY SS-body framing convention and the type-2 optional bit order are implemented to spec and round-trip-tested, but should be confirmed against a real air capture before relying on them.
- **Terminal side:** even a correct ASSIGN is silent unless DGNA notification is enabled in the radio's codeplug — that's a provisioning step, not a stack issue.

`cargo test --workspace --all-targets`: 390 passed, 0 failed, 6 ignored.
