### PR TITLE
Meshcom Node and OpenStreetMap integration + DAPNET fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -913,14 +913,10 @@ Asterisk AMI; it does not require the feature-gated SIP/RTP bridge.
 
 ### GeoAlarm
 
-GeoAlarm watches decoded TETRA LIP SDS positions. When an allowed device enters
-the configured radius around FlowStation, it can trigger TPG2200 Call-Out,
-normal SDS, Snom/SIP display notification, and Telegram forwarding. Blacklists
-always win; empty whitelists mean "all".
-
-The `*_meshcom*` toggles below are accepted by the parser but inert in this
-build: FlowStation does not ship a MeshCom source, so positions come from TETRA
-LIP only. Leave the MeshCom options at their defaults.
+GeoAlarm watches decoded TETRA LIP SDS positions and MeshCom position packets.
+When an allowed device enters the configured radius around FlowStation, it can
+trigger TPG2200 Call-Out, normal SDS, Snom/SIP display notification, and
+Telegram forwarding. Blacklists always win; empty whitelists mean "all".
 
 ```toml
 [geoalarm]
@@ -940,7 +936,7 @@ forward_telegram = false
 
 tetra_issi_whitelist = []       # empty = all TETRA ISSIs
 tetra_issi_blacklist = []
-meshcom_source_whitelist = []   # inert: no MeshCom source in this build
+meshcom_source_whitelist = []   # empty = all MeshCom sources
 meshcom_source_blacklist = []
 
 sds_source_issi = 9999
@@ -987,6 +983,10 @@ station list, connect/disconnect controls, and last error.
 
 **MeshCom** — extUDP receive/transmit settings, live MeshCom node table, message
 log, and forwarding controls for SDS, SIP/Snom, and Telegram.
+
+**Maps** — OpenStreetMap overview combining TETRA LIP, MeshCom, GeoAlarm, and
+configured FlowStation coordinates. Position links throughout the dashboard
+open the corresponding location in this view.
 
 **Telegram** — bot token, chat detection, destination chat IDs, and alert
 category toggles.

--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ Built in Rust on top of [tetra-bluestation](https://github.com/MidnightBlueLabs/
 | Max call duration with forced D-RELEASE | ✅ |
 | UL inactivity detection (forced TX-CEASED) | ✅ |
 | Echo service (local loopback, ISSI 999) | ✅ |
+| Asterisk SIP/RTP bridge for phone calls | ✅ |
+| EchoLink bridge with directory login and routing | ✅ |
 | Coordinated handover | 🔜 |
 | Emergency call pre-emption (priority calls pre-empt a lower-priority call when the cell is full) | ✅ |
 
@@ -49,11 +51,19 @@ Built in Rust on top of [tetra-bluestation](https://github.com/MidnightBlueLabs/
 | Home Mode Display (PID 220 callsign on radio screen) | ✅ |
 | Supplemental SDS broadcast (custom PID) | ✅ |
 | Emergency status alarm (U-STATUS) — persistent dashboard banner + Telegram alert, LOCAL-only | ✅ |
+| DAPNET receive/forward to SDS, TPG2200 Call-Out, Telegram | ✅ |
+| MeshCom extUDP messages with forwarding to SDS, SIP/Snom, Telegram | ✅ |
+| Snom XML display notifications for SDS, DAPNET, Telegram, MeshCom | ✅ |
+| SDS and DAPNET log paging, clear, text export | ✅ |
 
 ### Network & Interconnect
 | Feature | Status |
 |---|---|
 | Brew / TetraPack / BrandMeister interconnect | ✅ |
+| Asterisk PJSIP interconnect | ✅ |
+| DAPNET RWTH core receive path + Hampager API send endpoint | ✅ |
+| EchoLink directory/QSO integration | ✅ |
+| MeshCom external UDP bridge | ✅ |
 | UTC time broadcast (D-NWRK-BROADCAST) | ✅ |
 | Neighbor cell broadcast | ✅ |
 | T351 periodic re-registration | ✅ |
@@ -81,12 +91,127 @@ Built in Rust on top of [tetra-bluestation](https://github.com/MidnightBlueLabs/
 | Remote control via U-STATUS from radio (restart, shutdown, kick_all) | ✅ |
 | OTA update (pull latest, rebuild, restart — one button) | ✅ |
 | System tab: uptime, CPU, RAM, temperature, RF hardware info | ✅ |
+| Integration pages: Asterisk SIP, DAPNET, EchoLink, MeshCom, Telegram | ✅ |
+| Health view for Brew, Asterisk, DAPNET, EchoLink, MeshCom | ✅ |
+| Restart recovery cache for known radios after BS process restart | ✅ |
 
 ---
 
 ## Installation
 
 Full step-by-step installation guide (Raspberry Pi + LimeSDR): **[install.flowstation.dev](https://install.flowstation.dev)**
+
+### System dependencies
+
+FlowStation itself is a Rust application, but several integrations need native
+packages. On Debian, Ubuntu, and Raspberry Pi OS, start with:
+
+```bash
+sudo apt update
+sudo apt install -y \
+  git curl ca-certificates build-essential pkg-config cmake clang \
+  libssl-dev \
+  soapysdr-tools libsoapysdr-dev \
+  uhd-host libuhd-dev \
+  libgsm1 libgsm1-dev
+```
+
+Install Rust if it is not present yet:
+
+```bash
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+. "$HOME/.cargo/env"
+rustup default stable
+```
+
+Optional integrations need these additional packages:
+
+```bash
+# Asterisk SIP, AMI, and Snom SIP NOTIFY support
+sudo apt install -y asterisk
+
+# EchoLink GSM-FR audio support
+sudo apt install -y libgsm1 libgsm1-dev
+```
+
+If you run FlowStation behind a firewall, open the ports that match your config:
+
+| Component | Default port(s) | Direction |
+|---|---:|---|
+| Dashboard | TCP 8080 | inbound |
+| FlowStation SIP | UDP/TCP 5062 | inbound from Asterisk |
+| FlowStation RTP | UDP 30000-30100 | inbound/outbound to Asterisk |
+| Asterisk SIP | UDP/TCP 5060 | outbound/inbound to PBX |
+| EchoLink audio/control | UDP 5198/5199 | inbound/outbound |
+| EchoLink directory | TCP 5200 | outbound |
+| MeshCom extUDP | UDP 1799 | inbound/outbound |
+| DAPNET RWTH core | TCP 43434 | outbound |
+
+### TETRA ACELP codec
+
+Voice bridges need a TETRA ACELP codec implementation so FlowStation can convert
+between TETRA ACELP and PCM audio. One tested implementation is
+`outerplane/tetra-codec`:
+
+```bash
+git clone https://github.com/outerplane/tetra-codec
+cd tetra-codec
+cmake -B build -DCMAKE_BUILD_TYPE=Release
+cmake --build build --parallel
+sudo cmake --install build
+sudo ldconfig
+```
+
+After installation, verify both directions before enabling audio bridges:
+
+```bash
+# Exact command names depend on the codec project version.
+# Follow the codec project's README and confirm:
+# - TETRA ACELP -> PCM decoding works
+# - PCM -> TETRA ACELP encoding works
+```
+
+### Asterisk packages and modules
+
+Install Asterisk when using the SIP bridge or Snom display notifications:
+
+```bash
+sudo apt install -y asterisk
+sudo systemctl enable --now asterisk
+```
+
+For Snom XML display notifications, Asterisk must be able to load
+`res_pjsip_notify.so`. Some distributions refuse to load it if
+`pjsip_notify.conf` is missing, so create the file:
+
+```bash
+sudo touch /etc/asterisk/pjsip_notify.conf
+sudo asterisk -rx "module load res_pjsip_notify.so"
+sudo asterisk -rx "module show like pjsip_notify"
+```
+
+Enable AMI in `/etc/asterisk/manager.conf` for FlowStation's Snom notify worker:
+
+```ini
+[general]
+enabled = yes
+webenabled = no
+bindaddr = 127.0.0.1
+port = 5038
+
+[flowstation]
+secret = change-this-password
+read = system,call,log,verbose,command,agent,user
+write = system,call,command,agent,user,originate
+```
+
+Reload Asterisk after edits:
+
+```bash
+sudo asterisk -rx "manager reload"
+sudo asterisk -rx "module reload res_pjsip.so"
+sudo asterisk -rx "dialplan reload"
+```
 
 ### Quick start (from source)
 
@@ -151,6 +276,326 @@ port = 9000
 tls = true
 username = 123456700
 password = "your_password"
+```
+
+### Asterisk SIP/RTP bridge
+
+FlowStation can register as a PJSIP endpoint and bridge calls between TETRA
+terminals and Asterisk phones. Brew remains available in parallel; only configured
+service numbers are routed to Asterisk.
+
+```toml
+[asterisk]
+enabled = true
+outbound_prefix = "91"          # TETRA -> SIP: 91385 calls SIP user 385
+strip_outbound_prefix = true
+inbound_prefix = "T"            # SIP -> TETRA: Dial PJSIP/T2632585@flowstation
+register = true
+codec = "PCMU"                  # currently the only supported SIP codec
+service_numbers = ["385", "600", "601"]
+rtp_port_min = 30000
+rtp_port_max = 30100
+bind_addr = "0.0.0.0"
+bind_port = 5062
+remote_host = "127.0.0.1"
+remote_port = 5060
+contact_host = "127.0.0.1"
+from_domain = "127.0.0.1"
+local_user = "flowstation"
+auth_user = "flowstation"
+password = "change-me"
+realm = "asterisk"
+```
+
+Minimal Asterisk dialplan shape:
+
+```ini
+[intern]
+; Snom/internal phone -> TETRA
+_91X. => 1,Dial(PJSIP/T${EXTEN:2}@flowstation,60)
+ same => n,Hangup()
+
+[tetra]
+; TETRA -> Snom/internal phone
+385 => 1,Dial(PJSIP/snom385,30)
+ same => n,Hangup()
+```
+
+Minimal PJSIP endpoint shape for FlowStation:
+
+```ini
+; /etc/asterisk/pjsip.conf
+[flowstation]
+type=endpoint
+transport=transport-udp
+context=tetra
+disallow=all
+allow=ulaw
+aors=flowstation
+auth=flowstation
+
+[flowstation]
+type=auth
+auth_type=userpass
+username=flowstation
+password=change-me
+
+[flowstation]
+type=aor
+max_contacts=1
+remove_existing=yes
+qualify_frequency=30
+```
+
+`service_numbers` is deliberately an allowlist. If a TETRA user dials `91385`,
+FlowStation strips `91`, checks that `385` is listed, then calls SIP user `385`.
+
+### Telegram alerts
+
+Telegram is used both for station alerts and as a forwarding target for DAPNET
+and MeshCom. Create a bot with BotFather, send it one message, then detect or
+enter the chat ID in the dashboard.
+
+```toml
+[telegram]
+enabled = true
+bot_token = "123456789:AAExampleBotTokenStringFromBotFather"
+chat_ids = [123456789]
+alert_connect = true
+alert_disconnect = true
+alert_t351 = true
+alert_lip = true
+alert_backhaul = true
+alert_critical_logs = true
+alert_health = true
+```
+
+### DAPNET integration
+
+DAPNET receive uses the RWTH core feed. Messages can be routed independently to:
+
+- normal TETRA SDS
+- Motorola TPG2200 Call-Out / Type-4 SDS
+- Telegram
+
+RIC routing is important: a DAPNET RIC may be a single-user RIC or a group RIC.
+Use the route maps and allowlists to decide which RICs are forwarded and where.
+
+```toml
+[dapnet]
+enabled = true
+api_url = "https://hampager.de/api/calls"
+username = "YOURCALL"
+password = "your-hampager-password"
+poll_interval_secs = 30
+
+forward_sds = true
+forward_callout = false
+forward_telegram = true
+
+sds_source_issi = 9999
+sds_dest_issi = 0
+sds_dest_is_group = false
+ric_issi_routes = { "0632585" = 2632585 }
+ric_gssi_routes = { "0004520" = 80 }
+sds_allowed_rics = ["0632585", "0004520"]
+callout_allowed_rics = []
+telegram_allowed_rics = []
+
+callout_source_issi = 9999
+callout_dest_issi = 0
+callout_incident_base = 2
+callout_text_prefix = "DAPNET"
+
+telegram_prefix = "DAPNET"
+
+rwth_core_enabled = true
+rwth_core_host = "dapnet.afu.rwth-aachen.de"
+rwth_core_port = 43434
+rwth_core_device = "FlowStation"
+rwth_core_version = "1.0"
+rwth_core_callsign = "YOURCALL"
+rwth_core_authkey = "your-rwth-core-authkey"
+rwth_messages_limit = 100
+```
+
+Keep `password` and `rwth_core_authkey` private and out of commits.
+
+### Motorola TPG2200 ActionURL trigger
+
+FlowStation can expose a token-protected HTTP endpoint so a Snom function key
+can trigger a Motorola TPG2200 Call-Out. Every accepted request increments the
+incident number in memory and wraps after 256.
+
+```toml
+[tpg2200_action]
+enabled = true
+token = "long-random-token"
+source_issi = 9999
+dest_issi = 2632585
+incident_base = 1
+default_text = "ALARM"
+max_text_chars = 80
+```
+
+Snom ActionURL examples:
+
+```text
+http://<flowstation>:8080/api/action/tpg2200?token=<token>
+http://<flowstation>:8080/api/action/tpg2200?token=<token>&text=ALARM
+```
+
+### Snom XML display notifications
+
+FlowStation can show SDS, DAPNET, Telegram, and MeshCom messages on Snom phones
+as `SnomIPPhoneText`. FlowStation does not send direct SIP NOTIFY to the phone;
+it asks Asterisk over AMI to execute `PJSIPNotify`, so Asterisk remains the SIP
+sender.
+
+```toml
+[snom_notify]
+enabled = true
+ami_host = "127.0.0.1"
+ami_port = 5038
+ami_username = "flowstation"
+ami_password = "change-me"
+endpoints = ["385"]
+notify_sds = true
+notify_dapnet = true
+notify_telegram = true
+sds_directions = ["rx", "net", "tx"]
+dapnet_allowed_rics = []       # empty = all RICs
+sds_allowed_issis = []         # empty = all source/destination ISSIs
+title_prefix = "FlowStation"
+notify_event = "xml"
+content_type = "application/snomxml"
+subscription_state = "active;expires=30000"
+max_text_chars = 240
+connect_timeout_secs = 3
+```
+
+Snom phone settings must allow XML/minibrowser notifications. In Asterisk, make
+sure AMI is enabled and `res_pjsip_notify.so` loads.
+
+### EchoLink bridge
+
+EchoLink uses the public directory servers for login/status and UDP 5198/5199
+for QSO audio/control. GSM-FR audio requires `libgsm1-dev` at build time and the
+TETRA ACELP codec for TETRA audio conversion.
+
+```toml
+[echolink]
+enabled = true
+callsign = "YOURCALL-L"
+password = "your-echolink-password"
+location = "FlowStation"
+status_text = "FlowStation EchoLink bridge"
+directory_servers = ["servers.echolink.org", "backup.echolink.org"]
+directory_port = 5200
+bind_addr = "0.0.0.0"
+audio_port = 5198
+control_port = 5199
+
+inbound_enabled = true
+outbound_enabled = true
+outbound_prefix = "92"          # TETRA dial 92700 -> EchoLink service 700
+strip_outbound_prefix = true
+service_numbers = ["700"]
+routes = { "700" = "ECHOTEST" }
+allowed_callsigns = ["ECHOTEST"]
+allowed_node_ids = []
+auto_connect = ""
+reconnect_interval_secs = 30
+max_session_secs = 3600
+
+default_tetra_source_issi = 9999
+default_tetra_dest_issi = 2632585
+default_tetra_dest_is_group = false
+```
+
+The EchoLink dashboard page shows directory status, station count, QSO status,
+current route, last TX/error, and the downloaded directory list.
+
+### MeshCom external UDP bridge
+
+MeshCom nodes can send JSON packets to FlowStation using MeshCom extUDP. The
+dashboard shows live nodes and messages. Incoming MeshCom text messages can be
+forwarded independently to normal SDS, SIP/Snom, and Telegram.
+
+```toml
+[meshcom]
+enabled = true
+bind_addr = "0.0.0.0"
+bind_port = 1799
+tx_host = "255.255.255.255"
+tx_port = 1799
+allow_broadcast = true
+max_messages = 500
+max_nodes = 1000
+
+forward_sds = true
+forward_sip = true
+forward_telegram = true
+
+sds_source_issi = 9999
+sds_dest_issi = 2632585
+sds_dest_is_group = false
+sds_allowed_sources = []        # empty = all MeshCom src values
+
+sip_title_prefix = "MeshCom"
+sip_allowed_sources = []        # empty = all MeshCom src values
+
+telegram_prefix = "MeshCom"
+telegram_allowed_sources = []   # empty = all MeshCom src values
+```
+
+On the MeshCom node, enable extUDP and point it at the FlowStation host, for
+example:
+
+```bash
+--extudpip <flowstation-ip>
+--extudp on
+```
+
+### Restart recovery
+
+After a BS process restart, radios may still be RF-camped while FlowStation's
+in-memory registry is empty. Restart recovery persists a small terminal cache
+and sends D-LOCATION-UPDATE-COMMAND on startup so radios re-register quickly.
+
+```toml
+[recovery]
+enabled = true
+issi_allowlist = []             # empty = recover every cached ISSI
+cache_path = ""                 # default: <config-dir>/recovery_cache.json
+max_replay_attempts = 150
+replay_per_frame = 1
+debounce_secs = 5
+max_cached_issis = 1024
+```
+
+Leave this disabled on very busy cells unless you want the extra startup MCCH
+load.
+
+### Health monitor
+
+The health monitor samples the core loop, Brew, radios, queues, and integrations
+and exposes the result in the dashboard. It can optionally request a service
+restart if the core loop stalls.
+
+```toml
+[health]
+enabled = true
+snapshot_interval_secs = 5
+restart_on_core_stall = false
+core_stall_secs = 10
+restart_after_critical_secs = 30
+restart_cooldown_secs = 600
+radios_silent_secs = 900
+dl_queue_degraded = 64
+dl_queue_critical = 192
+sds_queue_degraded = 32
+sds_queue_critical = 128
 ```
 
 ### Access control
@@ -524,11 +969,36 @@ Available at `http://<bts-ip>:8080` when `[dashboard]` is configured.
 
 **Last Heard** — rolling history of call starts and SDS activity.
 
+**SDS Log** — received, transmitted, and network SDS history with paging, clear,
+and text export. LIP position entries are rendered as map links when coordinates
+are available.
+
 **Log** — live log stream with level filter and autoscroll.
+
+**DAPNET** — incoming DAPNET log, outgoing DAPNET send form, RIC routing, and
+per-target forwarding toggles for SDS, TPG2200 Call-Out, and Telegram. Includes
+paging, clear, and text export.
+
+**Asterisk SIP** — SIP account, RTP range, service-number routing, and Snom XML
+notification settings.
+
+**EchoLink** — directory login/status, QSO state, route configuration, directory
+station list, connect/disconnect controls, and last error.
+
+**MeshCom** — extUDP receive/transmit settings, live MeshCom node table, message
+log, and forwarding controls for SDS, SIP/Snom, and Telegram.
+
+**Telegram** — bot token, chat detection, destination chat IDs, and alert
+category toggles.
+
+**Health** — station health plus Brew, Asterisk, DAPNET, EchoLink, and MeshCom
+integration status.
 
 **Config** — edit `config.toml` in-browser. Save, backup, restore. Edit inactive config profiles in a modal without switching them live.
 
-**System** — BTS and Brew connection status · uptime · hostname · CPU model, cores, load bar · RAM usage · CPU temperature · RF hardware info (SoapySDR probe) · SDS broadcast queue · OTA update button.
+**System** — BTS and Brew connection status · uptime · hostname · CPU model,
+cores, load bar · RAM usage · CPU temperature · RF hardware info (SoapySDR
+probe) · SDS broadcast queue · OTA update button.
 
 ---
 

--- a/bins/bluestation-bs/src/main.rs
+++ b/bins/bluestation-bs/src/main.rs
@@ -19,6 +19,7 @@ use tetra_entities::net_brew::new_websocket_transport;
 use tetra_entities::net_dapnet::spawn_dapnet_worker;
 use tetra_entities::net_dashboard::DashboardServer;
 use tetra_entities::net_geoalarm::{GeoAlarmSink, spawn_geoalarm_worker};
+use tetra_entities::net_meshcom::spawn_meshcom_worker;
 use tetra_entities::net_snom::{snom_notify_channel, spawn_snom_notify_worker};
 use tetra_entities::net_telegram::{TelegramAlertSink, TelegramAlerter, telegram_alert_channel};
 use tetra_entities::net_telemetry::worker::TelemetryWorker;
@@ -590,6 +591,12 @@ fn main() {
     };
 
     // DAPNET worker — off-path; idles when disabled and reads settings live.
+    spawn_meshcom_worker(
+        cfg.clone(),
+        dapnet_cmd_tx.clone(),
+        dapnet_telegram_sink.clone(),
+        snom_notify_sink.clone(),
+    );
     spawn_dapnet_worker(cfg.clone(), dapnet_cmd_tx, dapnet_telegram_sink, dapnet_telemetry_sink);
 
     // Set up Ctrl+C handler for graceful shutdown.

--- a/bins/bluestation-bs/src/main.rs
+++ b/bins/bluestation-bs/src/main.rs
@@ -596,6 +596,7 @@ fn main() {
         dapnet_cmd_tx.clone(),
         dapnet_telegram_sink.clone(),
         snom_notify_sink.clone(),
+        geoalarm_sink.clone(),
     );
     spawn_dapnet_worker(cfg.clone(), dapnet_cmd_tx, dapnet_telegram_sink, dapnet_telemetry_sink);
 

--- a/crates/tetra-config/src/bluestation/config.rs
+++ b/crates/tetra-config/src/bluestation/config.rs
@@ -4,7 +4,8 @@ use tetra_core::freqs::FreqInfo;
 
 use crate::bluestation::{
     CfgAsterisk, CfgCellInfo, CfgControl, CfgDapnet, CfgEmergency, CfgGeoalarm, CfgHealth, CfgNetInfo, CfgPhyIo, CfgRecovery, CfgSecurity,
-    CfgSnomNotify, CfgTpg2200Action, CfgWxService, PhyBackend, StackState,
+    CfgMeshcom, CfgSnomNotify, CfgTpg2200Action,
+    CfgWxService, PhyBackend, StackState,
 };
 
 use super::sec_brew::CfgBrew;
@@ -83,6 +84,9 @@ pub struct StackConfig {
 
     /// Geo-fence alarm configuration for TETRA/MeshCom positions.
     pub geoalarm: CfgGeoalarm,
+
+    /// MeshCom external UDP bridge configuration.
+    pub meshcom: CfgMeshcom,
 
     /// Token-protected ActionURL trigger for Motorola TPG2200 Call-Out.
     pub tpg2200_action: CfgTpg2200Action,
@@ -480,6 +484,37 @@ impl SharedConfig {
                 tpg2200_max_text_chars: o.tpg2200_max_text_chars.clamp(8, 160),
                 sip_title_prefix: o.sip_title_prefix.clone(),
                 telegram_prefix: o.telegram_prefix.clone(),
+            }
+        } else {
+            base
+        }
+    }
+
+    /// Effective MeshCom settings: the dashboard runtime override if present, otherwise the
+    /// config file values. Returns an owned [`CfgMeshcom`] so callers don't hold the state lock.
+    pub fn effective_meshcom(&self) -> crate::bluestation::CfgMeshcom {
+        let base = self.cfg.meshcom.clone();
+        if let Some(o) = self.state_read().meshcom_override.as_ref() {
+            crate::bluestation::CfgMeshcom {
+                enabled: o.enabled,
+                bind_addr: o.bind_addr.clone(),
+                bind_port: if o.bind_port == 0 { base.bind_port } else { o.bind_port },
+                tx_host: o.tx_host.clone(),
+                tx_port: if o.tx_port == 0 { base.tx_port } else { o.tx_port },
+                allow_broadcast: o.allow_broadcast,
+                max_messages: o.max_messages.clamp(10, 10_000),
+                max_nodes: o.max_nodes.clamp(10, 65_535),
+                forward_sds: o.forward_sds,
+                forward_sip: o.forward_sip,
+                forward_telegram: o.forward_telegram,
+                sds_source_issi: o.sds_source_issi.max(1),
+                sds_dest_issi: o.sds_dest_issi,
+                sds_dest_is_group: o.sds_dest_is_group,
+                sds_allowed_sources: o.sds_allowed_sources.clone(),
+                sip_title_prefix: o.sip_title_prefix.clone(),
+                sip_allowed_sources: o.sip_allowed_sources.clone(),
+                telegram_prefix: o.telegram_prefix.clone(),
+                telegram_allowed_sources: o.telegram_allowed_sources.clone(),
             }
         } else {
             base

--- a/crates/tetra-config/src/bluestation/config.rs
+++ b/crates/tetra-config/src/bluestation/config.rs
@@ -3,9 +3,8 @@ use std::sync::{Arc, RwLock};
 use tetra_core::freqs::FreqInfo;
 
 use crate::bluestation::{
-    CfgAsterisk, CfgCellInfo, CfgControl, CfgDapnet, CfgEmergency, CfgGeoalarm, CfgHealth, CfgNetInfo, CfgPhyIo, CfgRecovery, CfgSecurity,
-    CfgMeshcom, CfgSnomNotify, CfgTpg2200Action,
-    CfgWxService, PhyBackend, StackState,
+    CfgAsterisk, CfgCellInfo, CfgControl, CfgDapnet, CfgEmergency, CfgGeoalarm, CfgHealth, CfgMeshcom, CfgNetInfo, CfgPhyIo, CfgRecovery,
+    CfgSecurity, CfgSnomNotify, CfgTpg2200Action, CfgWxService, PhyBackend, StackState,
 };
 
 use super::sec_brew::CfgBrew;

--- a/crates/tetra-config/src/bluestation/mod.rs
+++ b/crates/tetra-config/src/bluestation/mod.rs
@@ -28,6 +28,9 @@ pub use sec_dapnet::*;
 pub mod sec_geoalarm;
 pub use sec_geoalarm::*;
 
+pub mod sec_meshcom;
+pub use sec_meshcom::*;
+
 pub mod sec_tpg2200_action;
 pub use sec_tpg2200_action::*;
 

--- a/crates/tetra-config/src/bluestation/parsing.rs
+++ b/crates/tetra-config/src/bluestation/parsing.rs
@@ -13,11 +13,11 @@ use super::config::{StackConfig, StackMode};
 use super::sec_asterisk::{CfgAsteriskDto, apply_asterisk_patch};
 use super::sec_brew::{CfgBrewDto, apply_brew_patch};
 use super::sec_dapnet::{CfgDapnetDto, apply_dapnet_patch};
-use super::sec_meshcom::{CfgMeshcomDto, apply_meshcom_patch};
 use super::sec_dashboard::{CfgDashboardDto, apply_dashboard_patch};
 use super::sec_emergency::{CfgEmergencyDto, apply_emergency_patch};
 use super::sec_geoalarm::{CfgGeoalarmDto, apply_geoalarm_patch};
 use super::sec_health::{CfgHealthDto, apply_health_patch};
+use super::sec_meshcom::{CfgMeshcomDto, apply_meshcom_patch};
 use super::sec_recovery::{CfgRecoveryDto, apply_recovery_patch};
 use super::sec_security::{CfgSecurityDto, apply_security_patch};
 use super::sec_snom_notify::{CfgSnomNotifyDto, apply_snom_notify_patch};
@@ -146,9 +146,10 @@ pub fn from_toml_str(toml_str: &str) -> Result<StackConfig, Box<dyn std::error::
 
     // Optional meshcom section
     if let Some(ref meshcom) = root.meshcom
-        && !meshcom.extra.is_empty() {
-            return Err(format!("Unrecognized fields in meshcom config: {:?}", sorted_keys(&meshcom.extra)).into());
-        }
+        && !meshcom.extra.is_empty()
+    {
+        return Err(format!("Unrecognized fields in meshcom config: {:?}", sorted_keys(&meshcom.extra)).into());
+    }
 
     // Optional tpg2200_action section
     if let Some(ref action) = root.tpg2200_action

--- a/crates/tetra-config/src/bluestation/parsing.rs
+++ b/crates/tetra-config/src/bluestation/parsing.rs
@@ -13,6 +13,7 @@ use super::config::{StackConfig, StackMode};
 use super::sec_asterisk::{CfgAsteriskDto, apply_asterisk_patch};
 use super::sec_brew::{CfgBrewDto, apply_brew_patch};
 use super::sec_dapnet::{CfgDapnetDto, apply_dapnet_patch};
+use super::sec_meshcom::{CfgMeshcomDto, apply_meshcom_patch};
 use super::sec_dashboard::{CfgDashboardDto, apply_dashboard_patch};
 use super::sec_emergency::{CfgEmergencyDto, apply_emergency_patch};
 use super::sec_geoalarm::{CfgGeoalarmDto, apply_geoalarm_patch};
@@ -143,6 +144,12 @@ pub fn from_toml_str(toml_str: &str) -> Result<StackConfig, Box<dyn std::error::
         return Err(format!("Unrecognized fields in geoalarm config: {:?}", sorted_keys(&geoalarm.extra)).into());
     }
 
+    // Optional meshcom section
+    if let Some(ref meshcom) = root.meshcom
+        && !meshcom.extra.is_empty() {
+            return Err(format!("Unrecognized fields in meshcom config: {:?}", sorted_keys(&meshcom.extra)).into());
+        }
+
     // Optional tpg2200_action section
     if let Some(ref action) = root.tpg2200_action
         && !action.extra.is_empty()
@@ -232,6 +239,7 @@ pub fn from_toml_str(toml_str: &str) -> Result<StackConfig, Box<dyn std::error::
         asterisk: apply_asterisk_patch(root.asterisk.unwrap_or_default())?,
         dapnet: apply_dapnet_patch(root.dapnet.unwrap_or_default())?,
         geoalarm: apply_geoalarm_patch(root.geoalarm.unwrap_or_default())?,
+        meshcom: apply_meshcom_patch(root.meshcom.unwrap_or_default())?,
         tpg2200_action: apply_tpg2200_action_patch(root.tpg2200_action.unwrap_or_default())?,
         snom_notify: apply_snom_notify_patch(root.snom_notify.unwrap_or_default())?,
         dashboard: None,
@@ -308,6 +316,7 @@ struct TomlConfigRoot {
     asterisk: Option<CfgAsteriskDto>,
     dapnet: Option<CfgDapnetDto>,
     geoalarm: Option<CfgGeoalarmDto>,
+    meshcom: Option<CfgMeshcomDto>,
     tpg2200_action: Option<CfgTpg2200ActionDto>,
     snom_notify: Option<CfgSnomNotifyDto>,
     dashboard: Option<CfgDashboardDto>,
@@ -472,6 +481,27 @@ rwth_messages_limit = 100
 [geoalarm]
 enabled = true
 
+[meshcom]
+enabled = true
+bind_addr = "0.0.0.0"
+bind_port = 1799
+tx_host = "255.255.255.255"
+tx_port = 1799
+allow_broadcast = true
+max_messages = 500
+max_nodes = 1000
+forward_sds = true
+forward_sip = true
+forward_telegram = true
+sds_source_issi = 9999
+sds_dest_issi = 2632585
+sds_dest_is_group = false
+sds_allowed_sources = ["DJ2TH", "OE1ABC-12"]
+sip_title_prefix = "MeshCom"
+sip_allowed_sources = ["DJ2TH"]
+telegram_prefix = "MeshCom"
+telegram_allowed_sources = ["OE1ABC-12"]
+
 [tpg2200_action]
 enabled = true
 token = "example-token"
@@ -550,6 +580,16 @@ sds_queue_critical = 128
         assert!(cfg.dapnet.telegram_allowed_rics.contains(&200));
         assert!(cfg.dapnet.telegram_allowed_rics.contains(&0x1C40));
         assert!(cfg.geoalarm.enabled);
+        assert!(cfg.meshcom.enabled);
+        assert_eq!(cfg.meshcom.bind_port, 1799);
+        assert_eq!(cfg.meshcom.tx_host, "255.255.255.255");
+        assert!(cfg.meshcom.forward_sds);
+        assert!(cfg.meshcom.forward_sip);
+        assert!(cfg.meshcom.forward_telegram);
+        assert_eq!(cfg.meshcom.sds_dest_issi, 2632585);
+        assert!(cfg.meshcom.sds_allowed_sources.contains("DJ2TH"));
+        assert!(cfg.meshcom.sip_allowed_sources.contains("DJ2TH"));
+        assert!(cfg.meshcom.telegram_allowed_sources.contains("OE1ABC-12"));
     }
 
     fn minimal_toml(extra_cell: &str) -> String {

--- a/crates/tetra-config/src/bluestation/sec_meshcom.rs
+++ b/crates/tetra-config/src/bluestation/sec_meshcom.rs
@@ -1,0 +1,232 @@
+use serde::Deserialize;
+use std::collections::{BTreeSet, HashMap};
+use toml::Value;
+
+/// MeshCom external UDP bridge configuration.
+///
+/// Disabled by default. When enabled, FlowStation listens for MeshCom JSON packets on the
+/// configured UDP socket and can send JSON text messages back to a node using the documented
+/// external-client format.
+#[derive(Debug, Clone)]
+pub struct CfgMeshcom {
+    pub enabled: bool,
+    pub bind_addr: String,
+    pub bind_port: u16,
+    pub tx_host: String,
+    pub tx_port: u16,
+    pub allow_broadcast: bool,
+    pub max_messages: usize,
+    pub max_nodes: usize,
+    pub forward_sds: bool,
+    pub forward_sip: bool,
+    pub forward_telegram: bool,
+    pub sds_source_issi: u32,
+    pub sds_dest_issi: u32,
+    pub sds_dest_is_group: bool,
+    pub sds_allowed_sources: BTreeSet<String>,
+    pub sip_title_prefix: String,
+    pub sip_allowed_sources: BTreeSet<String>,
+    pub telegram_prefix: String,
+    pub telegram_allowed_sources: BTreeSet<String>,
+}
+
+impl Default for CfgMeshcom {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            bind_addr: default_bind_addr(),
+            bind_port: default_udp_port(),
+            tx_host: default_tx_host(),
+            tx_port: default_udp_port(),
+            allow_broadcast: true,
+            max_messages: default_max_messages(),
+            max_nodes: default_max_nodes(),
+            forward_sds: false,
+            forward_sip: false,
+            forward_telegram: false,
+            sds_source_issi: default_source_issi(),
+            sds_dest_issi: 0,
+            sds_dest_is_group: false,
+            sds_allowed_sources: BTreeSet::new(),
+            sip_title_prefix: default_meshcom_prefix(),
+            sip_allowed_sources: BTreeSet::new(),
+            telegram_prefix: default_meshcom_prefix(),
+            telegram_allowed_sources: BTreeSet::new(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct CfgMeshcomDto {
+    #[serde(default)]
+    pub enabled: bool,
+    #[serde(default = "default_bind_addr")]
+    pub bind_addr: String,
+    #[serde(default = "default_udp_port")]
+    pub bind_port: u16,
+    #[serde(default = "default_tx_host")]
+    pub tx_host: String,
+    #[serde(default = "default_udp_port")]
+    pub tx_port: u16,
+    #[serde(default = "default_true")]
+    pub allow_broadcast: bool,
+    #[serde(default = "default_max_messages")]
+    pub max_messages: usize,
+    #[serde(default = "default_max_nodes")]
+    pub max_nodes: usize,
+    #[serde(default)]
+    pub forward_sds: bool,
+    #[serde(default)]
+    pub forward_sip: bool,
+    #[serde(default)]
+    pub forward_telegram: bool,
+    #[serde(default = "default_source_issi")]
+    pub sds_source_issi: u32,
+    #[serde(default)]
+    pub sds_dest_issi: u32,
+    #[serde(default)]
+    pub sds_dest_is_group: bool,
+    #[serde(default)]
+    pub sds_allowed_sources: Vec<String>,
+    #[serde(default = "default_meshcom_prefix")]
+    pub sip_title_prefix: String,
+    #[serde(default)]
+    pub sip_allowed_sources: Vec<String>,
+    #[serde(default = "default_meshcom_prefix")]
+    pub telegram_prefix: String,
+    #[serde(default)]
+    pub telegram_allowed_sources: Vec<String>,
+
+    #[serde(flatten)]
+    pub extra: HashMap<String, Value>,
+}
+
+impl Default for CfgMeshcomDto {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            bind_addr: default_bind_addr(),
+            bind_port: default_udp_port(),
+            tx_host: default_tx_host(),
+            tx_port: default_udp_port(),
+            allow_broadcast: true,
+            max_messages: default_max_messages(),
+            max_nodes: default_max_nodes(),
+            forward_sds: false,
+            forward_sip: false,
+            forward_telegram: false,
+            sds_source_issi: default_source_issi(),
+            sds_dest_issi: 0,
+            sds_dest_is_group: false,
+            sds_allowed_sources: Vec::new(),
+            sip_title_prefix: default_meshcom_prefix(),
+            sip_allowed_sources: Vec::new(),
+            telegram_prefix: default_meshcom_prefix(),
+            telegram_allowed_sources: Vec::new(),
+            extra: HashMap::new(),
+        }
+    }
+}
+
+fn default_true() -> bool {
+    true
+}
+
+fn default_bind_addr() -> String {
+    "0.0.0.0".to_string()
+}
+
+fn default_tx_host() -> String {
+    "255.255.255.255".to_string()
+}
+
+fn default_udp_port() -> u16 {
+    1799
+}
+
+fn default_max_messages() -> usize {
+    500
+}
+
+fn default_max_nodes() -> usize {
+    1000
+}
+
+fn default_source_issi() -> u32 {
+    9999
+}
+
+fn default_meshcom_prefix() -> String {
+    "MeshCom".to_string()
+}
+
+pub fn apply_meshcom_patch(src: CfgMeshcomDto) -> Result<CfgMeshcom, String> {
+    if src.enabled {
+        if src.bind_addr.trim().is_empty() {
+            return Err("meshcom: bind_addr cannot be empty when enabled".to_string());
+        }
+        if src.tx_host.trim().is_empty() {
+            return Err("meshcom: tx_host cannot be empty when enabled".to_string());
+        }
+        if src.bind_port == 0 || src.tx_port == 0 {
+            return Err("meshcom: bind_port/tx_port must be non-zero".to_string());
+        }
+    }
+    if src.forward_sds {
+        if src.sds_source_issi == 0 || src.sds_source_issi > 16_777_215 {
+            return Err("meshcom: sds_source_issi must be 1..=16777215".to_string());
+        }
+        if src.sds_dest_issi > 16_777_215 {
+            return Err("meshcom: sds_dest_issi must be 0..=16777215".to_string());
+        }
+    }
+
+    Ok(CfgMeshcom {
+        enabled: src.enabled,
+        bind_addr: non_empty_or(src.bind_addr, "0.0.0.0"),
+        bind_port: nonzero_port_or(src.bind_port, default_udp_port()),
+        tx_host: non_empty_or(src.tx_host, "255.255.255.255"),
+        tx_port: nonzero_port_or(src.tx_port, default_udp_port()),
+        allow_broadcast: src.allow_broadcast,
+        max_messages: src.max_messages.clamp(10, 10_000),
+        max_nodes: src.max_nodes.clamp(10, 65_535),
+        forward_sds: src.forward_sds,
+        forward_sip: src.forward_sip,
+        forward_telegram: src.forward_telegram,
+        sds_source_issi: src.sds_source_issi.max(1),
+        sds_dest_issi: src.sds_dest_issi,
+        sds_dest_is_group: src.sds_dest_is_group,
+        sds_allowed_sources: normalize_source_list(src.sds_allowed_sources),
+        sip_title_prefix: non_empty_or(src.sip_title_prefix, "MeshCom"),
+        sip_allowed_sources: normalize_source_list(src.sip_allowed_sources),
+        telegram_prefix: non_empty_or(src.telegram_prefix, "MeshCom"),
+        telegram_allowed_sources: normalize_source_list(src.telegram_allowed_sources),
+    })
+}
+
+fn non_empty_or(value: String, fallback: &str) -> String {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        fallback.to_string()
+    } else {
+        trimmed.to_string()
+    }
+}
+
+fn nonzero_port_or(value: u16, fallback: u16) -> u16 {
+    if value == 0 { fallback } else { value }
+}
+
+fn normalize_source_list(values: Vec<String>) -> BTreeSet<String> {
+    values
+        .into_iter()
+        .flat_map(|value| {
+            value
+                .split(|c: char| c == ',' || c.is_whitespace())
+                .map(str::trim)
+                .filter(|part| !part.is_empty())
+                .map(|part| part.to_ascii_uppercase())
+                .collect::<Vec<_>>()
+        })
+        .collect()
+}

--- a/crates/tetra-config/src/bluestation/state.rs
+++ b/crates/tetra-config/src/bluestation/state.rs
@@ -248,6 +248,33 @@ pub struct GeoalarmRuntimeOverride {
     pub telegram_prefix: String,
 }
 
+/// Runtime override for MeshCom external UDP settings, edited from the dashboard.
+///
+/// Mirrors `[meshcom]`. When present, it takes precedence over the config file so UDP routing
+/// edits apply immediately; the dashboard also writes the values back to TOML for persistence.
+#[derive(Debug, Clone, Default)]
+pub struct MeshcomRuntimeOverride {
+    pub enabled: bool,
+    pub bind_addr: String,
+    pub bind_port: u16,
+    pub tx_host: String,
+    pub tx_port: u16,
+    pub allow_broadcast: bool,
+    pub max_messages: usize,
+    pub max_nodes: usize,
+    pub forward_sds: bool,
+    pub forward_sip: bool,
+    pub forward_telegram: bool,
+    pub sds_source_issi: u32,
+    pub sds_dest_issi: u32,
+    pub sds_dest_is_group: bool,
+    pub sds_allowed_sources: std::collections::BTreeSet<String>,
+    pub sip_title_prefix: String,
+    pub sip_allowed_sources: std::collections::BTreeSet<String>,
+    pub telegram_prefix: String,
+    pub telegram_allowed_sources: std::collections::BTreeSet<String>,
+}
+
 /// Runtime override for Snom XML NOTIFY settings, edited from the dashboard.
 ///
 /// Mirrors `[snom_notify]`. When present, it takes precedence over the config file so
@@ -399,6 +426,80 @@ impl Default for GeoalarmRuntimeStatus {
     }
 }
 
+#[derive(Debug, Clone)]
+pub struct MeshcomNodeStatus {
+    pub src: String,
+    pub last_seen: String,
+    pub last_type: String,
+    pub lat: Option<f64>,
+    pub lon: Option<f64>,
+    pub alt: Option<f64>,
+    pub batt: Option<f64>,
+    pub rssi: Option<i64>,
+    pub snr: Option<i64>,
+    pub firmware: Option<String>,
+    pub fw_sub: Option<String>,
+    pub hw_id: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct MeshcomMessageStatus {
+    pub ts: String,
+    pub direction: String,
+    pub msg_type: String,
+    pub src_type: Option<String>,
+    pub src: Option<String>,
+    pub dst: Option<String>,
+    pub msg: Option<String>,
+    pub msg_id: Option<String>,
+    pub paths: Vec<String>,
+    pub lat: Option<f64>,
+    pub lon: Option<f64>,
+    pub alt: Option<f64>,
+    pub batt: Option<f64>,
+    pub rssi: Option<i64>,
+    pub snr: Option<i64>,
+}
+
+#[derive(Debug, Clone)]
+pub struct MeshcomRuntimeStatus {
+    pub configured: bool,
+    pub enabled: bool,
+    pub bind: String,
+    pub tx: String,
+    pub rx_packets: u64,
+    pub tx_packets: u64,
+    pub last_rx: Option<String>,
+    pub last_tx: Option<String>,
+    pub last_error: Option<String>,
+    pub forward_sds: bool,
+    pub forward_sip: bool,
+    pub forward_telegram: bool,
+    pub nodes: Vec<MeshcomNodeStatus>,
+    pub messages: Vec<MeshcomMessageStatus>,
+}
+
+impl Default for MeshcomRuntimeStatus {
+    fn default() -> Self {
+        Self {
+            configured: false,
+            enabled: false,
+            bind: String::new(),
+            tx: String::new(),
+            rx_packets: 0,
+            tx_packets: 0,
+            last_rx: None,
+            last_tx: None,
+            last_error: None,
+            forward_sds: false,
+            forward_sip: false,
+            forward_telegram: false,
+            nodes: Vec::new(),
+            messages: Vec::new(),
+        }
+    }
+}
+
 /// Mutable, stack-editable state (mutex-protected).
 #[derive(Debug, Clone)]
 pub struct StackState {
@@ -427,6 +528,8 @@ pub struct StackState {
     pub dapnet_override: Option<DapnetRuntimeOverride>,
     /// Runtime override for GeoAlarm settings (dashboard editing). See GeoalarmRuntimeOverride.
     pub geoalarm_override: Option<GeoalarmRuntimeOverride>,
+    /// Runtime override for MeshCom settings (dashboard editing). See MeshcomRuntimeOverride.
+    pub meshcom_override: Option<MeshcomRuntimeOverride>,
     /// Runtime override for Snom XML NOTIFY settings. See SnomNotifyRuntimeOverride.
     pub snom_notify_override: Option<SnomNotifyRuntimeOverride>,
     /// Next TPG2200 ActionURL incident number. Initialised lazily from `[tpg2200_action]`.
@@ -437,6 +540,8 @@ pub struct StackState {
     pub dapnet_status: DapnetRuntimeStatus,
     /// Runtime GeoAlarm status for `/api/geoalarm`.
     pub geoalarm_status: GeoalarmRuntimeStatus,
+    /// Runtime MeshCom UDP bridge status for `/api/meshcom` and the Health tab.
+    pub meshcom_status: MeshcomRuntimeStatus,
     /// Live map "identity currently reachable on a traffic channel" → (DL timeslot, usage_marker),
     /// republished every tick by CMCE call control from the live call tables (so it is never
     /// stale). Keyed by GSSI for active group calls and by each participant ISSI for connected
@@ -554,11 +659,13 @@ impl Default for StackState {
             telegram_override: None,
             dapnet_override: None,
             geoalarm_override: None,
+            meshcom_override: None,
             snom_notify_override: None,
             tpg2200_action_next_incident: None,
             asterisk_status: AsteriskRuntimeStatus::default(),
             dapnet_status: DapnetRuntimeStatus::default(),
             geoalarm_status: GeoalarmRuntimeStatus::default(),
+            meshcom_status: MeshcomRuntimeStatus::default(),
             active_call_ts: std::collections::HashMap::new(),
             ee_monitoring_windows: std::collections::HashMap::new(),
         }

--- a/crates/tetra-entities/src/lib.rs
+++ b/crates/tetra-entities/src/lib.rs
@@ -23,6 +23,7 @@ pub mod net_geoalarm;
 pub mod net_snom;
 pub mod net_telegram;
 pub mod net_telemetry;
+pub mod net_meshcom;
 
 pub mod backlight;
 pub mod health;

--- a/crates/tetra-entities/src/lib.rs
+++ b/crates/tetra-entities/src/lib.rs
@@ -20,10 +20,10 @@ pub mod net_control;
 pub mod net_dapnet;
 pub mod net_dashboard;
 pub mod net_geoalarm;
+pub mod net_meshcom;
 pub mod net_snom;
 pub mod net_telegram;
 pub mod net_telemetry;
-pub mod net_meshcom;
 
 pub mod backlight;
 pub mod health;

--- a/crates/tetra-entities/src/net_dapnet/mod.rs
+++ b/crates/tetra-entities/src/net_dapnet/mod.rs
@@ -566,7 +566,7 @@ fn parse_rwth_message(line: &str) -> Result<DapnetMessage, String> {
         }
         _ => parts[2].to_string(),
     };
-    let callsign = extract_callsign(&text).unwrap_or_else(|| recipient.clone());
+    let callsign = extract_callsign(&text).unwrap_or_default();
     let id = format!("rwth:{msg_id:02X}:{}", stable_hash_hex(body));
     Ok(DapnetMessage {
         id,
@@ -620,6 +620,18 @@ fn strip_skyper_rubric_prefix(text: &str) -> Option<&str> {
     let (_, first) = chars.next()?;
     let (_, second) = chars.next()?;
     let (third_idx, third) = chars.next()?;
+    let after_third_idx = third_idx + third.len_utf8();
+
+    if first.is_ascii_digit() && third == ')' {
+        let rest = &text[after_third_idx..];
+        if rest
+            .chars()
+            .next()
+            .is_some_and(|c| c.is_ascii_alphanumeric() || matches!(c, '[' | '\\' | ']' | '{' | '|' | '}' | '~'))
+        {
+            return Some(rest);
+        }
+    }
 
     if !third.is_ascii_alphanumeric() {
         return None;
@@ -655,6 +667,9 @@ fn skyper_charset_to_unicode(text: &str) -> String {
 fn should_decode_rot1(raw: &str, decoded: &str) -> bool {
     if raw.is_empty() {
         return false;
+    }
+    if strip_skyper_rubric_prefix(decoded).is_some() {
+        return true;
     }
     let raw_spaces = raw.chars().filter(|&c| c == ' ').count();
     let encoded_spaces = raw.chars().filter(|&c| c == '!').count();
@@ -743,6 +758,13 @@ mod tests {
     }
 
     #[test]
+    fn parse_rwth_message_does_not_copy_recipient_into_callsign() {
+        let msg = parse_rwth_message("#02 6:1:E0:3:YYYYMMDDHHMMSS260626185400").unwrap();
+        assert_eq!(msg.recipient, "RIC 0000224 / func 3");
+        assert_eq!(msg.callsign, "");
+    }
+
+    #[test]
     fn dapnet_text_decodes_skyper_rot1_but_keeps_plain_text() {
         let darc_70mhz = ";#EBSD;!Cvoeftsbut.Esvdltbdif!efgjojfsu!jo!Gvopuf!Sfdiutsbinfo!g~s!81.NI{.Cfusjfc";
         let nordsee = "\\&Opsetff;!33/17/37!27;41!Ifmhpmboe!Cjoofoibgfo!679/1dn!NOX;vocflboou";
@@ -758,6 +780,12 @@ mod tests {
             decode_dapnet_text(nordsee),
             "Nordsee: 22.06.26 16:30 Helgoland Binnenhafen 568.0cm MNW:unbekannt"
         );
+        assert_eq!(decode_dapnet_text("1r*Gfjotubvc"), "Feinstaub");
+        assert_eq!(decode_dapnet_text("1R*Tbufmmjufo"), "Satelliten");
+        assert_eq!(decode_dapnet_text("1K*IBNOFU"), "HAMNET");
+        assert_eq!(decode_dapnet_text("1_*XY.Mplbm"), "WX-Lokal");
+        assert_eq!(decode_dapnet_text("1J*HPF!Opugvol"), "GOE Notfunk");
+        assert_eq!(decode_dapnet_text("1D*Hf{fjufo"), "Gezeiten");
         assert_eq!(
             decode_dapnet_text("5357.0 EA5FIV von DL4MFF um 1933z"),
             "5357.0 EA5FIV von DL4MFF um 1933z"

--- a/crates/tetra-entities/src/net_dashboard/html.rs
+++ b/crates/tetra-entities/src/net_dashboard/html.rs
@@ -2256,6 +2256,10 @@ tbody tr:hover td{background:color-mix(in srgb,var(--bg3) 70%, transparent);}
       <span class="nav-icon" data-icon="geoalarm"></span>
       <span class="nav-label" data-i18n="geoalarm">GeoAlarm</span>
     </div>
+    <div class="nav-item" onclick="showPage('meshcom',this)" id="nav-meshcom">
+      <span class="nav-icon">⌁</span>
+      <span class="nav-label" data-i18n="meshcom">MeshCom</span>
+    </div>
     <div class="nav-item" onclick="showPage('telegram',this)" id="nav-telegram">
       <span class="nav-icon" data-icon="telegram"></span>
       <span class="nav-label" data-i18n="telegram">Telegram</span>
@@ -3338,6 +3342,178 @@ tbody tr:hover td{background:color-mix(in srgb,var(--bg3) 70%, transparent);}
             <button class="btn btn-sm" onclick="geoPrevPage()">‹ Prev</button>
             <span class="sds-empty" id="geo-events-page">Page 1 / 1</span>
             <button class="btn btn-sm" onclick="geoNextPage()">Next ›</button>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- ── MESHCOM ── -->
+    <div class="page" id="page-meshcom">
+      <div class="card">
+        <div class="card-head">
+          <div class="card-title" data-i18n="meshcom_title">MeshCom</div>
+          <div class="card-actions">
+            <button class="btn btn-sm" onclick="loadMeshcom()" data-i18n="refresh">⟳ Refresh</button>
+            <button class="btn btn-primary" onclick="saveMeshcom()" data-i18n="save">Save</button>
+          </div>
+        </div>
+        <div class="card-body">
+          <div class="stat-grid" style="margin-bottom:14px">
+            <div class="stat-card">
+              <div class="stat-label">UDP RX</div>
+              <div class="stat-value" id="mesh-rx-count">0</div>
+              <div class="stat-sub" id="mesh-bind">—</div>
+            </div>
+            <div class="stat-card blue">
+              <div class="stat-label">UDP TX</div>
+              <div class="stat-value blue" id="mesh-tx-count">0</div>
+              <div class="stat-sub" id="mesh-tx">—</div>
+            </div>
+          </div>
+          <div class="info-grid" style="margin-bottom:14px">
+            <div class="info-row"><div class="info-key">Nodes</div><div class="info-val" id="mesh-node-count">—</div></div>
+            <div class="info-row"><div class="info-key">Last RX</div><div class="info-val" id="mesh-last-rx">—</div></div>
+            <div class="info-row"><div class="info-key">Last TX</div><div class="info-val" id="mesh-last-tx">—</div></div>
+            <div class="info-row"><div class="info-key">Last error</div><div class="info-val" id="mesh-last-error">—</div></div>
+          </div>
+
+          <label class="sw-row">
+            <span class="sw-text">Enable MeshCom UDP integration</span>
+            <span class="sw"><input type="checkbox" id="mesh-enabled"><i></i></span>
+          </label>
+          <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(190px,1fr));gap:10px;align-items:center;margin-top:14px">
+            <label style="color:var(--muted);font-size:13px">Bind address</label>
+            <input type="text" id="mesh-bind-addr" class="form-input" placeholder="0.0.0.0">
+            <label style="color:var(--muted);font-size:13px">Bind port</label>
+            <input type="number" id="mesh-bind-port" class="form-input" min="1" max="65535" placeholder="1799">
+            <label style="color:var(--muted);font-size:13px">Node TX host</label>
+            <input type="text" id="mesh-tx-host" class="form-input" placeholder="255.255.255.255">
+            <label style="color:var(--muted);font-size:13px">Node TX port</label>
+            <input type="number" id="mesh-tx-port" class="form-input" min="1" max="65535" placeholder="1799">
+            <label style="color:var(--muted);font-size:13px">Allow broadcast</label>
+            <label style="display:flex;align-items:center;gap:10px"><span class="sw"><input type="checkbox" id="mesh-broadcast"><i></i></span><span style="color:var(--muted);font-size:12px">required for 255.255.255.255</span></label>
+            <label style="color:var(--muted);font-size:13px">History limits</label>
+            <div style="display:grid;grid-template-columns:1fr 1fr;gap:8px">
+              <input type="number" id="mesh-max-messages" class="form-input" min="10" max="10000" placeholder="500">
+              <input type="number" id="mesh-max-nodes" class="form-input" min="10" max="65535" placeholder="1000">
+            </div>
+          </div>
+          <div class="help-text" style="margin-top:10px">On the MeshCom node, enable extUDP and point it to the FlowStation host, for example: --extudpip &lt;flowstation-ip&gt; and --extudp on.</div>
+          <div class="config-msg" id="mesh-msg"></div>
+        </div>
+      </div>
+
+      <div class="card">
+        <div class="card-head">
+          <div class="card-title">MeshCom Routing</div>
+        </div>
+        <div class="card-body">
+          <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(280px,1fr));gap:14px">
+            <div>
+              <label class="sw-row">
+                <span class="sw-text">Forward MeshCom → SDS</span>
+                <span class="sw"><input type="checkbox" id="mesh-forward-sds"><i></i></span>
+              </label>
+              <div style="display:grid;grid-template-columns:1fr 1fr;gap:8px;margin-top:10px">
+                <input type="number" id="mesh-sds-source" class="form-input" min="1" max="16777215" placeholder="Source ISSI">
+                <input type="number" id="mesh-sds-dest" class="form-input" min="0" max="16777215" placeholder="Destination ISSI/GSSI">
+              </div>
+              <label style="display:flex;align-items:center;gap:10px;margin-top:10px"><span class="sw"><input type="checkbox" id="mesh-sds-group"><i></i></span><span style="color:var(--muted);font-size:12px">Destination is group/GSSI</span></label>
+              <textarea id="mesh-sds-sources" class="form-input" rows="3" placeholder="Allowed MeshCom sources, empty = all" style="margin-top:10px"></textarea>
+            </div>
+            <div>
+              <label class="sw-row">
+                <span class="sw-text">Forward MeshCom → SIP/Snom</span>
+                <span class="sw"><input type="checkbox" id="mesh-forward-sip"><i></i></span>
+              </label>
+              <input type="text" id="mesh-sip-prefix" class="form-input" placeholder="Snom title prefix" style="margin-top:10px">
+              <textarea id="mesh-sip-sources" class="form-input" rows="3" placeholder="Allowed MeshCom sources, empty = all" style="margin-top:10px"></textarea>
+            </div>
+            <div>
+              <label class="sw-row">
+                <span class="sw-text">Forward MeshCom → Telegram</span>
+                <span class="sw"><input type="checkbox" id="mesh-forward-telegram"><i></i></span>
+              </label>
+              <input type="text" id="mesh-telegram-prefix" class="form-input" placeholder="Telegram prefix" style="margin-top:10px">
+              <textarea id="mesh-telegram-sources" class="form-input" rows="3" placeholder="Allowed MeshCom sources, empty = all" style="margin-top:10px"></textarea>
+            </div>
+          </div>
+          <div class="help-text" style="margin-top:10px">Source filters match MeshCom packet src values case-insensitively. Empty filters forward every MeshCom text message.</div>
+        </div>
+      </div>
+
+      <div class="card">
+        <div class="card-head">
+          <div class="card-title">Send MeshCom Message</div>
+          <div class="card-actions">
+            <button class="btn btn-primary" onclick="sendMeshcomMessage()">Send</button>
+          </div>
+        </div>
+        <div class="card-body">
+          <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(220px,1fr));gap:10px;align-items:center">
+            <label style="color:var(--muted);font-size:13px">Destination</label>
+            <input type="text" id="mesh-out-dst" class="form-input" placeholder="CALLSIGN, group or *">
+            <label style="color:var(--muted);font-size:13px;align-self:flex-start;padding-top:8px">Message</label>
+            <textarea id="mesh-out-msg" class="form-input" rows="3" maxlength="512" placeholder="Message text"></textarea>
+          </div>
+          <div class="config-msg" id="mesh-send-msg"></div>
+        </div>
+      </div>
+
+      <div class="card">
+        <div class="card-head">
+          <div class="card-title">MeshCom Nodes</div>
+          <div class="card-actions">
+            <input type="text" id="mesh-node-filter" class="form-input" style="width:240px" placeholder="Search node, HW-ID or firmware" oninput="meshNodePageIndex=0;renderMeshcomNodes()">
+          </div>
+        </div>
+        <div class="card-body">
+          <div class="table-wrap">
+            <table>
+              <thead><tr>
+                <th>Node</th>
+                <th>Last seen</th>
+                <th>Position</th>
+                <th>Battery</th>
+                <th>RF</th>
+                <th>Firmware</th>
+                <th>HW-ID</th>
+              </tr></thead>
+              <tbody id="mesh-nodes-tbody"></tbody>
+            </table>
+          </div>
+          <div class="log-controls">
+            <button class="btn btn-sm" onclick="meshNodePrevPage()">‹ Prev</button>
+            <span class="sds-empty" id="mesh-nodes-page">Page 1 / 1</span>
+            <button class="btn btn-sm" onclick="meshNodeNextPage()">Next ›</button>
+          </div>
+        </div>
+      </div>
+
+      <div class="card">
+        <div class="card-head">
+          <div class="card-title">MeshCom Messages</div>
+        </div>
+        <div class="card-body">
+          <div class="table-wrap">
+            <table>
+              <thead><tr>
+                <th data-i18n="th_time">Time</th>
+                <th data-i18n="th_dir">Dir</th>
+                <th data-i18n="th_type">Type</th>
+                <th>Source</th>
+                <th>Destination</th>
+                <th data-i18n="th_message">Message</th>
+                <th>Paths</th>
+                <th>Position / RF</th>
+              </tr></thead>
+              <tbody id="mesh-msgs-tbody"></tbody>
+            </table>
+          </div>
+          <div class="log-controls">
+            <button class="btn btn-sm" onclick="meshMsgPrevPage()">‹ Prev</button>
+            <span class="sds-empty" id="mesh-msgs-page">Page 1 / 1</span>
+            <button class="btn btn-sm" onclick="meshMsgNextPage()">Next ›</button>
           </div>
         </div>
       </div>
@@ -4638,6 +4814,7 @@ function showPage(name,el){
   if(name==='asterisk'){loadAsteriskStatus();loadSnomNotify();}
   if(name==='dapnet'){loadDapnet();loadDapnetLog();}
   if(name==='geoalarm'){loadGeoalarm();}
+  if(name==='meshcom'){loadMeshcom();}
   if(name==='config'){loadConfig();loadWhitelist();loadWx();}
   if(name==='telegram'){loadTelegram();}
   if(name==='system'){loadSystemInfo();loadConfigProfiles();loadLiveSds();loadBrightness();}
@@ -4958,7 +5135,7 @@ async function wifiCall(url, body){
 function escAttr(s){ return String(s).replace(/&/g,'&amp;').replace(/'/g,"&#39;").replace(/"/g,'&quot;'); }
 
 // ── State + WS ────────────────────────────────────────────────────────────
-let ws=null,state={ms:{},calls:{},emergencies:{},lastHeard:[],sdsLog:[],dapnetLog:[],geoalarmEvents:[],brewOnline:false,brewVer:0},sdsDest=0;
+let ws=null,state={ms:{},calls:{},emergencies:{},lastHeard:[],sdsLog:[],dapnetLog:[],geoalarmEvents:[],meshcomNodes:[],meshcomMessages:[],brewOnline:false,brewVer:0},sdsDest=0;
 
 // ── RadioID callsigns (indicativ) ──────────────────────────────────────────────
 // issi -> {cs:"CALLSIGN", fl:"🇷🇴"} (found; fl is the country flag emoji from the prefix, or "")
@@ -5808,7 +5985,7 @@ function _p2(n){return String(n).padStart(2,'0');}
 // live rows arriving over the WS; rows fetched from /api/sds-log already carry a server stamp.
 function nowStamp(){const d=new Date();return `${d.getFullYear()}-${_p2(d.getMonth()+1)}-${_p2(d.getDate())} ${_p2(d.getHours())}:${_p2(d.getMinutes())}:${_p2(d.getSeconds())}`;}
 const LOG_PAGE_SIZE=50;
-let sdsLogPageIndex=0,dapnetLogPageIndex=0,geoalarmPageIndex=0;
+let sdsLogPageIndex=0,dapnetLogPageIndex=0,geoalarmPageIndex=0,meshNodePageIndex=0,meshMsgPageIndex=0;
 function setLogPager(id,page,total){
   const el=document.getElementById(id);if(!el)return;
   if(!total){el.textContent='Page 0 / 0 · 0';return;}
@@ -6265,6 +6442,179 @@ async function saveGeoalarm(){
   }catch{setGeoMsg(t('conn_error'),false);}
 }
 function setGeoMsg(txt,ok){const el=document.getElementById('geo-msg');if(!el)return;el.textContent=txt;el.style.color=ok?'var(--accent)':'var(--danger)';if(txt)setTimeout(()=>{if(el.textContent===txt)el.textContent='';},5000);}
+
+function meshMapLink(lat,lon,label){
+  if(lat===null||lat===undefined||lon===null||lon===undefined)return '—';
+  const la=Number(lat),lo=Number(lon);
+  if(!Number.isFinite(la)||!Number.isFinite(lo))return '—';
+  const url=`https://maps.google.com/?q=${encodeURIComponent(la+','+lo)}`;
+  return `<a class="sds-map-link" href="${url}" target="_blank" rel="noopener noreferrer">${escHtml(label||`${la.toFixed(5)}, ${lo.toFixed(5)}`)}</a>`;
+}
+function meshRfText(row){
+  const parts=[];
+  if(row.rssi!==null&&row.rssi!==undefined)parts.push(`RSSI ${row.rssi}`);
+  if(row.snr!==null&&row.snr!==undefined)parts.push(`SNR ${row.snr}`);
+  return parts.join(' · ')||'—';
+}
+function meshBatteryText(v){
+  if(v===null||v===undefined||v==='')return '—';
+  const n=Number(v);
+  if(!Number.isFinite(n))return escHtml(v);
+  return `${n}%`;
+}
+function meshSourceListText(values){
+  return Array.isArray(values)?values.join('\n'):'';
+}
+function meshSourceListBody(id){
+  const raw=dapVal(id);
+  if(!raw)return [];
+  return raw.split(/[\s,]+/).map(v=>v.trim()).filter(Boolean);
+}
+function meshPaths(paths){
+  if(!Array.isArray(paths)||!paths.length)return '<span class="sds-empty">—</span>';
+  return paths.map(p=>`<span class="badge badge-blue" style="font-size:10px">${escHtml(p)}</span>`).join(' ');
+}
+function meshNodeFiltered(){
+  const q=(document.getElementById('mesh-node-filter')?.value||'').trim().toUpperCase();
+  const rows=(state.meshcomNodes||[]).slice().sort((a,b)=>String(b.last_seen||'').localeCompare(String(a.last_seen||'')));
+  if(!q)return rows;
+  return rows.filter(n=>
+    String(n.src||'').toUpperCase().includes(q) ||
+    String(n.hw_id||'').toUpperCase().includes(q) ||
+    String(n.firmware||'').toUpperCase().includes(q) ||
+    String(n.fw_sub||'').toUpperCase().includes(q)
+  );
+}
+function meshNodeRow(n){
+  const fw=[n.firmware,n.fw_sub].filter(Boolean).join(' / ')||'—';
+  return `<tr>
+    <td><span class="badge badge-blue" style="font-size:10px">${escHtml(n.src||'—')}</span><div class="sds-empty">${escHtml(n.last_type||'')}</div></td>
+    <td class="sds-time">${escHtml(n.last_seen||'—')}</td>
+    <td>${meshMapLink(n.lat,n.lon)}</td>
+    <td>${meshBatteryText(n.batt)}</td>
+    <td class="sds-time">${escHtml(meshRfText(n))}</td>
+    <td class="sds-time">${escHtml(fw)}</td>
+    <td class="sds-time">${escHtml(n.hw_id||'—')}</td>
+  </tr>`;
+}
+function renderMeshcomNodes(){
+  const tb=document.getElementById('mesh-nodes-tbody');if(!tb)return;
+  const rows=meshNodeFiltered();
+  meshNodePageIndex=clampLogPage(meshNodePageIndex,rows.length);
+  setLogPager('mesh-nodes-page',meshNodePageIndex,rows.length);
+  if(!rows.length){tb.innerHTML=`<tr><td colspan="7" class="sds-empty" style="text-align:center;padding:24px">No MeshCom nodes yet</td></tr>`;return;}
+  const start=meshNodePageIndex*LOG_PAGE_SIZE;
+  tb.innerHTML=rows.slice(start,start+LOG_PAGE_SIZE).map(meshNodeRow).join('');
+}
+function meshNodePrevPage(){meshNodePageIndex--;renderMeshcomNodes();}
+function meshNodeNextPage(){meshNodePageIndex++;renderMeshcomNodes();}
+function meshMsgRow(m){
+  const msgText=m.msg?escHtml(m.msg):(m.lat!==null&&m.lat!==undefined&&m.lon!==null&&m.lon!==undefined?'<span class="sds-empty">[position]</span>':'');
+  const posRf=[meshMapLink(m.lat,m.lon,'map'),meshRfText(m)].filter(x=>x&&x!=='—').join(' · ')||'—';
+  return `<tr>
+    <td class="sds-time">${escHtml(m.ts||'')}</td>
+    <td>${dirBadge(m.direction)}</td>
+    <td><span class="badge" style="font-size:10px">${escHtml(m.msg_type||'unknown')}</span></td>
+    <td>${escHtml(m.src||'—')}<div class="sds-empty">${escHtml(m.src_type||'')}</div></td>
+    <td>${escHtml(m.dst||'—')}</td>
+    <td class="sds-msg">${msgText}</td>
+    <td>${meshPaths(m.paths)}</td>
+    <td class="sds-time">${posRf}</td>
+  </tr>`;
+}
+function renderMeshcomMessages(){
+  const tb=document.getElementById('mesh-msgs-tbody');if(!tb)return;
+  const rows=state.meshcomMessages||[];
+  meshMsgPageIndex=clampLogPage(meshMsgPageIndex,rows.length);
+  setLogPager('mesh-msgs-page',meshMsgPageIndex,rows.length);
+  if(!rows.length){tb.innerHTML=`<tr><td colspan="8" class="sds-empty" style="text-align:center;padding:24px">No MeshCom packets yet</td></tr>`;return;}
+  const start=meshMsgPageIndex*LOG_PAGE_SIZE;
+  tb.innerHTML=rows.slice(start,start+LOG_PAGE_SIZE).map(meshMsgRow).join('');
+}
+function meshMsgPrevPage(){meshMsgPageIndex--;renderMeshcomMessages();}
+function meshMsgNextPage(){meshMsgPageIndex++;renderMeshcomMessages();}
+async function loadMeshcom(){
+  try{
+    const r=await fetch('/api/meshcom');
+    if(!r.ok){setMeshMsg(t('conn_error'),false);return;}
+    const d=await r.json(),rt=d.runtime||{};
+    dapCheck('mesh-enabled',d.enabled);
+    dapSet('mesh-bind-addr',d.bind_addr||'0.0.0.0');
+    dapSet('mesh-bind-port',d.bind_port||1799);
+    dapSet('mesh-tx-host',d.tx_host||'255.255.255.255');
+    dapSet('mesh-tx-port',d.tx_port||1799);
+    dapCheck('mesh-broadcast',d.allow_broadcast);
+    dapSet('mesh-max-messages',d.max_messages||500);
+    dapSet('mesh-max-nodes',d.max_nodes||1000);
+    dapCheck('mesh-forward-sds',d.forward_sds);
+    dapCheck('mesh-forward-sip',d.forward_sip);
+    dapCheck('mesh-forward-telegram',d.forward_telegram);
+    dapSet('mesh-sds-source',d.sds_source_issi||9999);
+    dapSet('mesh-sds-dest',d.sds_dest_issi||0);
+    dapCheck('mesh-sds-group',d.sds_dest_is_group);
+    dapSet('mesh-sds-sources',meshSourceListText(d.sds_allowed_sources));
+    dapSet('mesh-sip-prefix',d.sip_title_prefix||'MeshCom');
+    dapSet('mesh-sip-sources',meshSourceListText(d.sip_allowed_sources));
+    dapSet('mesh-telegram-prefix',d.telegram_prefix||'MeshCom');
+    dapSet('mesh-telegram-sources',meshSourceListText(d.telegram_allowed_sources));
+    dapSet('mesh-rx-count',rt.rx_packets??0);
+    dapSet('mesh-tx-count',rt.tx_packets??0);
+    dapSet('mesh-bind',rt.bind||`${d.bind_addr||'0.0.0.0'}:${d.bind_port||1799}`);
+    dapSet('mesh-tx',rt.tx||`${d.tx_host||'255.255.255.255'}:${d.tx_port||1799}`);
+    dapSet('mesh-node-count',rt.node_count??(d.nodes||[]).length);
+    dapSet('mesh-last-rx',rt.last_rx||'—');
+    dapSet('mesh-last-tx',rt.last_tx||'—');
+    dapSet('mesh-last-error',rt.last_error||'—');
+    state.meshcomNodes=d.nodes||[];
+    state.meshcomMessages=d.messages||[];
+    meshNodePageIndex=0;meshMsgPageIndex=0;
+    renderMeshcomNodes();
+    renderMeshcomMessages();
+    setMeshMsg('',true);
+  }catch{setMeshMsg(t('conn_error'),false);}
+}
+async function saveMeshcom(){
+  const body={
+    enabled:document.getElementById('mesh-enabled').checked,
+    bind_addr:dapVal('mesh-bind-addr')||'0.0.0.0',
+    bind_port:dapNum('mesh-bind-port',1799,1,65535),
+    tx_host:dapVal('mesh-tx-host')||'255.255.255.255',
+    tx_port:dapNum('mesh-tx-port',1799,1,65535),
+    allow_broadcast:document.getElementById('mesh-broadcast').checked,
+    max_messages:dapNum('mesh-max-messages',500,10,10000),
+    max_nodes:dapNum('mesh-max-nodes',1000,10,65535),
+    forward_sds:document.getElementById('mesh-forward-sds').checked,
+    forward_sip:document.getElementById('mesh-forward-sip').checked,
+    forward_telegram:document.getElementById('mesh-forward-telegram').checked,
+    sds_source_issi:dapNum('mesh-sds-source',9999,1,16777215),
+    sds_dest_issi:dapNum('mesh-sds-dest',0,0,16777215),
+    sds_dest_is_group:document.getElementById('mesh-sds-group').checked,
+    sds_allowed_sources:meshSourceListBody('mesh-sds-sources'),
+    sip_title_prefix:dapVal('mesh-sip-prefix')||'MeshCom',
+    sip_allowed_sources:meshSourceListBody('mesh-sip-sources'),
+    telegram_prefix:dapVal('mesh-telegram-prefix')||'MeshCom',
+    telegram_allowed_sources:meshSourceListBody('mesh-telegram-sources')
+  };
+  try{
+    const r=await fetch('/api/meshcom',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify(body)});
+    if(r.ok){setMeshMsg('✓ Saved',true);setTimeout(loadMeshcom,500);}
+    else setMeshMsg(t('save_fail')+': '+await r.text(),false);
+  }catch{setMeshMsg(t('conn_error'),false);}
+}
+async function sendMeshcomMessage(){
+  const body={dst:dapVal('mesh-out-dst'),msg:dapVal('mesh-out-msg')};
+  if(!body.dst){setMeshSendMsg('Destination is empty',false);return;}
+  if(!body.msg){setMeshSendMsg('Message text is empty',false);return;}
+  setMeshSendMsg('Sending…',true);
+  try{
+    const r=await fetch('/api/meshcom/send',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify(body)});
+    const d=await r.json();
+    if(d.ok){setMeshSendMsg('✓ Sent',true);document.getElementById('mesh-out-msg').value='';setTimeout(loadMeshcom,300);}
+    else setMeshSendMsg('✗ '+(d.error||'Send failed'),false);
+  }catch{setMeshSendMsg(t('conn_error'),false);}
+}
+function setMeshMsg(txt,ok){const el=document.getElementById('mesh-msg');if(!el)return;el.textContent=txt;el.style.color=ok?'var(--accent)':'var(--danger)';if(txt)setTimeout(()=>{if(el.textContent===txt)el.textContent='';},5000);}
+function setMeshSendMsg(txt,ok){const el=document.getElementById('mesh-send-msg');if(!el)return;el.textContent=txt;el.style.color=ok?'var(--accent)':'var(--danger)';if(txt)setTimeout(()=>{if(el.textContent===txt)el.textContent='';},5000);}
 function setDapMsg(txt,ok){const el=document.getElementById('dap-msg');if(!el)return;el.textContent=txt;el.style.color=ok?'var(--accent)':'var(--danger)';if(txt)setTimeout(()=>{if(el.textContent===txt)el.textContent='';},5000);}
 function setDapSendMsg(txt,ok){const el=document.getElementById('dap-send-msg');if(!el)return;el.textContent=txt;el.style.color=ok?'var(--accent)':'var(--danger)';if(txt)setTimeout(()=>{if(el.textContent===txt)el.textContent='';},5000);}
 
@@ -7502,7 +7852,7 @@ function renderHealthTab(h){
   });
 }
 
-let healthIntegrationState={asterisk:null,dapnet:null,geoalarm:null,lastLoad:0};
+let healthIntegrationState={asterisk:null,dapnet:null,geoalarm:null,meshcom:null,lastLoad:0};
 // title, iconKey (asterisk|dapnet|geoalarm), accent (blue|purple|''), level, detail, extra.
 function integrationHealthCard(title,iconKey,accent,level,detail,extra){
   const lvlCls = healthLevelClass(level);
@@ -7579,6 +7929,19 @@ function classifyGeoalarmHealth(data){
   const extra=notes.length?notes.join(' · '):('Center '+(rt.center||'—')+' · radius '+Number(rt.radius_m||data.radius_m||0).toFixed(0)+' m · routes '+paths.join(', '));
   return {level,detail,extra};
 }
+function classifyMeshcomHealth(data){
+  if(!data||!data.enabled)return {level:'ok',detail:'disabled',extra:'MeshCom UDP bridge is not active.'};
+  const rt=data.runtime||{};
+  const err=rt.last_error||'';
+  const level=err?'degraded':'ok';
+  const paths=[];
+  if(data.forward_sds||rt.forward_sds)paths.push('SDS');
+  if(data.forward_sip||rt.forward_sip)paths.push('SIP');
+  if(data.forward_telegram||rt.forward_telegram)paths.push('Telegram');
+  const detail=(rt.rx_packets??0)+' RX · '+(rt.tx_packets??0)+' TX · '+(rt.node_count??0)+' node(s)';
+  const extra=err?('Last error: '+err):('Bind '+(rt.bind||((data.bind_addr||'—')+':'+(data.bind_port||'—')))+' · TX '+(rt.tx||((data.tx_host||'—')+':'+(data.tx_port||'—')))+' · routes '+(paths.join(', ')||'none')+(rt.last_rx?' · last RX '+rt.last_rx:''));
+  return {level,detail,extra};
+}
 function renderHealthIntegrations(){
   const grid=document.getElementById('health-integrations-grid');
   if(!grid)return;
@@ -7601,18 +7964,26 @@ function renderHealthIntegrations(){
   } else {
     grid.appendChild(integrationHealthCard('GeoAlarm','geoalarm','purple','degraded','status unavailable','Open the GeoAlarm page or wait for the next refresh.'));
   }
+  if(healthIntegrationState.meshcom){
+    const m=classifyMeshcomHealth(healthIntegrationState.meshcom);
+    grid.appendChild(integrationHealthCard('MeshCom','dapnet','blue',m.level,m.detail,m.extra));
+  } else {
+    grid.appendChild(integrationHealthCard('MeshCom','dapnet','blue','degraded','status unavailable','Open the MeshCom page or wait for the next refresh.'));
+  }
 }
 async function loadHealthIntegrations(){
   healthIntegrationState.lastLoad=Date.now();
   try{
-    const [ast,dap,geo]=await Promise.all([
+    const [ast,dap,geo,mesh]=await Promise.all([
       fetch('/api/asterisk/status').then(r=>r.ok?r.json():null).catch(()=>null),
       fetch('/api/dapnet').then(r=>r.ok?r.json():null).catch(()=>null),
-      fetch('/api/geoalarm').then(r=>r.ok?r.json():null).catch(()=>null)
+      fetch('/api/geoalarm').then(r=>r.ok?r.json():null).catch(()=>null),
+      fetch('/api/meshcom').then(r=>r.ok?r.json():null).catch(()=>null)
     ]);
     healthIntegrationState.asterisk=ast;
     healthIntegrationState.dapnet=dap;
     healthIntegrationState.geoalarm=geo;
+    healthIntegrationState.meshcom=mesh;
   }catch{}
   renderHealthIntegrations();
 }

--- a/crates/tetra-entities/src/net_dashboard/html.rs
+++ b/crates/tetra-entities/src/net_dashboard/html.rs
@@ -6185,8 +6185,15 @@ function dapPaths(paths){
   if(!p.length)return '<span class="sds-empty">—</span>';
   return p.map(x=>`<span class="badge badge-blue" style="font-size:10px">${escHtml(x)}</span>`).join(' ');
 }
+function dapnetLogCallsign(e){
+  const callsign=String(e?.callsign||'').trim();
+  const recipient=String(e?.recipient||'').trim();
+  if(callsign&&recipient&&callsign===recipient&&/^RIC\s+\d+/i.test(callsign))return '';
+  return callsign;
+}
 function dapnetRow(e){
-  return `<tr><td class="sds-time">${escHtml(e.ts||'')}</td><td>${dirBadge(e.direction)}</td><td>${escHtml(e.callsign||'')}</td><td>${escHtml(e.recipient||'')}</td><td>${dapPaths(e.paths)}</td><td class="sds-msg">${escHtml(e.text||'')}</td></tr>`;
+  const callsign=dapnetLogCallsign(e);
+  return `<tr><td class="sds-time">${escHtml(e.ts||'')}</td><td>${dirBadge(e.direction)}</td><td>${callsign?escHtml(callsign):'<span class="sds-empty">—</span>'}</td><td>${escHtml(e.recipient||'')}</td><td>${dapPaths(e.paths)}</td><td class="sds-msg">${escHtml(e.text||'')}</td></tr>`;
 }
 function renderDapnetLog(){
   const tb=document.getElementById('dapnetlog-tbody');if(!tb)return;
@@ -6214,7 +6221,7 @@ function exportDapnetLog(){
     lines.push([
       e.ts||'',
       (e.direction||'').toUpperCase(),
-      e.callsign||'',
+      dapnetLogCallsign(e),
       e.recipient||'',
       (e.paths||[]).join(','),
       e.text||''
@@ -8019,7 +8026,6 @@ function classifyDapnetHealth(data){
   } else {
     notes.push('RWTH receive feed disabled');
   }
-  if(!paths.length)notes.push('no forwarding path enabled');
   if(notes.length)level='degraded';
   const status=rt.rwth_core_status||(data.rwth_core_enabled?'enabled':'disabled');
   const detail='RWTH '+status+' · '+(paths.length?paths.join(', '):'no forwarding');

--- a/crates/tetra-entities/src/net_dashboard/html.rs
+++ b/crates/tetra-entities/src/net_dashboard/html.rs
@@ -735,6 +735,19 @@ input[type="radio"]{accent-color:var(--accent);}
 /* Page sections */
 .page{display:none;}
 .page.active{display:block;}
+.maps-layout{display:grid;grid-template-columns:minmax(320px,1.6fr) minmax(260px,.8fr);gap:14px;align-items:stretch;}
+.maps-stage{min-height:560px;border:1px solid var(--border);border-radius:var(--r);overflow:hidden;background:var(--bg1);}
+.maps-stage iframe{display:block;width:100%;height:560px;border:0;filter:saturate(.9) contrast(.95);}
+.maps-list{max-height:560px;overflow:auto;border:1px solid var(--border);border-radius:var(--r);background:var(--bg1);}
+.maps-list-row{display:grid;grid-template-columns:auto 1fr;gap:10px;padding:11px 12px;border-bottom:1px solid var(--border);cursor:pointer;}
+.maps-list-row:last-child{border-bottom:0;}
+.maps-list-row:hover{background:var(--bg3);}
+.maps-list-type{font:800 10px var(--mono);text-transform:uppercase;color:var(--text3);padding-top:3px;}
+.maps-list-title{font-weight:800;color:var(--text);}
+.maps-list-meta{font:700 11px/1.5 var(--mono);color:var(--text3);}
+.maps-list-detail{font-size:12px;color:var(--text2);line-height:1.45;margin-top:4px;}
+.maps-empty{padding:28px;text-align:center;color:var(--text3);font:700 12px var(--mono);}
+@media(max-width:1100px){.maps-layout{grid-template-columns:1fr}.maps-stage,.maps-stage iframe{min-height:430px;height:430px}.maps-list{max-height:360px;}}
 
 /* ── Stat cards ── */
 .stat-grid{
@@ -2260,6 +2273,10 @@ tbody tr:hover td{background:color-mix(in srgb,var(--bg3) 70%, transparent);}
       <span class="nav-icon">⌁</span>
       <span class="nav-label" data-i18n="meshcom">MeshCom</span>
     </div>
+    <div class="nav-item" onclick="showPage('maps',this)" id="nav-maps">
+      <span class="nav-icon">⌖</span>
+      <span class="nav-label" data-i18n="maps">Maps</span>
+    </div>
     <div class="nav-item" onclick="showPage('telegram',this)" id="nav-telegram">
       <span class="nav-icon" data-icon="telegram"></span>
       <span class="nav-label" data-i18n="telegram">Telegram</span>
@@ -3633,6 +3650,36 @@ tbody tr:hover td{background:color-mix(in srgb,var(--bg3) 70%, transparent);}
       </div>
     </div>
 
+    <!-- ── MAPS ── -->
+    <div class="page" id="page-maps">
+      <div class="section-label" data-i18n-section="monitor">Monitor</div>
+      <div class="hero">
+        <span class="hero-dot is-idle" id="maps-hero-dot"></span>
+        <div class="hero-main">
+          <div class="hero-title" data-i18n="maps_title">Maps</div>
+          <div class="hero-sub" id="maps-hero-sub">OpenStreetMap positions</div>
+        </div>
+        <div class="hero-metrics">
+          <span class="pill pill-idle" id="maps-count">0 markers</span>
+        </div>
+      </div>
+      <div class="card">
+        <div class="card-head">
+          <div class="card-title" data-i18n="maps_title">Maps</div>
+          <div class="card-actions">
+            <button class="btn btn-sm" onclick="refreshMapsData()">⟳ <span data-i18n="refresh">Refresh</span></button>
+            <button class="btn btn-sm" onclick="openMapsOsm()">Open OSM</button>
+          </div>
+        </div>
+        <div class="card-body">
+          <div class="maps-layout">
+            <div class="maps-stage"><iframe id="maps-frame" title="OpenStreetMap map" loading="lazy"></iframe></div>
+            <div class="maps-list" id="maps-list"></div>
+          </div>
+        </div>
+      </div>
+    </div>
+
     <!-- ── TELEGRAM ALERTS ──
          Owner-facing push notifications via a Telegram bot. The owner pastes their
          @BotFather token, detects their chat ID with one click (getUpdates), picks
@@ -4195,7 +4242,7 @@ const LANGS={
   en:{
     bts_ip:'BTS IP',offline:'OFFLINE',online:'ONLINE',
     brew_online:'ONLINE',brew_offline:'OFFLINE',
-    stations:'Radios',calls:'Calls',lastheard:'Last Heard',log:'Log',rf:'RF',health:'Health',asterisk:'Asterisk SIP',dapnet:'DAPNET',echolink:'EchoLink',echolink_title:'EchoLink',meshcom:'MeshCom',meshcom_title:'MeshCom',geoalarm:'GeoAlarm',geoalarm_title:'GeoAlarm',config:'Config',
+    stations:'Radios',calls:'Calls',lastheard:'Last Heard',log:'Log',rf:'RF',health:'Health',asterisk:'Asterisk SIP',dapnet:'DAPNET',echolink:'EchoLink',echolink_title:'EchoLink',meshcom:'MeshCom',meshcom_title:'MeshCom',maps:'Maps',maps_title:'Maps',geoalarm:'GeoAlarm',geoalarm_title:'GeoAlarm',config:'Config',
     sdslog:'SDS Log',th_dir:'Dir',th_from:'From',th_to:'To',th_message:'Message',no_sds:'No SDS messages yet',sds_refresh:'Refresh',
     rf_freq:'Center freq',rf_rate:'Sample rate',rf_rms:'RMS',rf_peak:'Peak',rf_age:'Snapshot',
     rf_waiting:'waiting…',rf_live:'live',rf_stale:'stale',
@@ -4416,7 +4463,7 @@ const LANGS={
   de:{
     bts_ip:'BTS-IP',offline:'OFFLINE',online:'ONLINE',
     brew_online:'ONLINE',brew_offline:'OFFLINE',
-    stations:'Radios',calls:'Anrufe',lastheard:'Zuletzt Gehört',log:'Log',rf:'RF',health:'Health',asterisk:'Asterisk SIP',dapnet:'DAPNET',echolink:'EchoLink',echolink_title:'EchoLink',meshcom:'MeshCom',meshcom_title:'MeshCom',geoalarm:'GeoAlarm',geoalarm_title:'GeoAlarm',config:'Config',
+    stations:'Radios',calls:'Anrufe',lastheard:'Zuletzt Gehört',log:'Log',rf:'RF',health:'Health',asterisk:'Asterisk SIP',dapnet:'DAPNET',echolink:'EchoLink',echolink_title:'EchoLink',meshcom:'MeshCom',meshcom_title:'MeshCom',maps:'Karte',maps_title:'Karte',geoalarm:'GeoAlarm',geoalarm_title:'GeoAlarm',config:'Config',
     sdslog:'SDS-Log',th_dir:'Ri.',th_from:'Von',th_to:'An',th_message:'Nachricht',no_sds:'Noch keine SDS-Nachrichten',sds_refresh:'Aktualisieren',
     rf_freq:'Mittenfrequenz',rf_rate:'Abtastrate',rf_rms:'RMS',rf_peak:'Spitze',rf_age:'Aufnahme',
     rf_waiting:'wartet…',rf_live:'live',rf_stale:'veraltet',
@@ -4800,7 +4847,7 @@ function closeMobileSidebar(){
 }
 
 // ── Page navigation ───────────────────────────────────────────────────────
-const PAGE_TITLES={stations:'stations',calls:'calls',lastheard:'lastheard',log:'log',sdslog:'sdslog',rf:'rf',health:'health',asterisk:'asterisk',dapnet:'dapnet',echolink:'echolink',meshcom:'meshcom',geoalarm:'geoalarm',config:'config',system:'system'};
+const PAGE_TITLES={stations:'stations',calls:'calls',lastheard:'lastheard',log:'log',sdslog:'sdslog',rf:'rf',health:'health',asterisk:'asterisk',dapnet:'dapnet',echolink:'echolink',meshcom:'meshcom',maps:'maps',geoalarm:'geoalarm',config:'config',system:'system'};
 function showPage(name,el){
   document.querySelectorAll('.page').forEach(p=>p.classList.remove('active'));
   document.querySelectorAll('.nav-item').forEach(n=>n.classList.remove('active'));
@@ -4815,6 +4862,7 @@ function showPage(name,el){
   if(name==='dapnet'){loadDapnet();loadDapnetLog();}
   if(name==='geoalarm'){loadGeoalarm();}
   if(name==='meshcom'){loadMeshcom();}
+  if(name==='maps'){refreshMapsData();}
   if(name==='config'){loadConfig();loadWhitelist();loadWx();}
   if(name==='telegram'){loadTelegram();}
   if(name==='system'){loadSystemInfo();loadConfigProfiles();loadLiveSds();loadBrightness();}
@@ -5135,7 +5183,7 @@ async function wifiCall(url, body){
 function escAttr(s){ return String(s).replace(/&/g,'&amp;').replace(/'/g,"&#39;").replace(/"/g,'&quot;'); }
 
 // ── State + WS ────────────────────────────────────────────────────────────
-let ws=null,state={ms:{},calls:{},emergencies:{},lastHeard:[],sdsLog:[],dapnetLog:[],geoalarmEvents:[],meshcomNodes:[],meshcomMessages:[],brewOnline:false,brewVer:0},sdsDest=0;
+let ws=null,state={ms:{},calls:{},emergencies:{},lastHeard:[],sdsLog:[],dapnetLog:[],geoalarmEvents:[],geoalarmConfig:null,meshcomNodes:[],meshcomMessages:[],brewOnline:false,brewVer:0},sdsDest=0;
 
 // ── RadioID callsigns (indicativ) ──────────────────────────────────────────────
 // issi -> {cs:"CALLSIGN", fl:"🇷🇴"} (found; fl is the country flag emoji from the prefix, or "")
@@ -5377,7 +5425,7 @@ function handleMsg(msg){
       if(!state.sdsLog)state.sdsLog=[];
       state.sdsLog.unshift({ts:nowStamp(),direction:msg.direction,source_issi:msg.source_issi,dest_issi:msg.dest_issi,is_group:msg.is_group,protocol_id:msg.protocol_id,text:msg.text});
       if(state.sdsLog.length>500)state.sdsLog.pop();
-      renderSdsLog();refreshCallsigns();break;
+      renderSdsLog();renderMapsIfActive();refreshCallsigns();break;
     case 'dapnet_log':
       if(!state.dapnetLog)state.dapnetLog=[];
       state.dapnetLog.unshift({ts:nowStamp(),direction:msg.direction,id:msg.id,callsign:msg.callsign,recipient:msg.recipient,text:msg.text,priority:msg.priority,paths:msg.paths||[]});
@@ -6287,9 +6335,8 @@ async function sendDapnetMessage(){
 function meshMapLink(lat,lon,label){
   if(lat===null||lat===undefined||lon===null||lon===undefined)return '—';
   const la=Number(lat),lo=Number(lon);
-  if(!Number.isFinite(la)||!Number.isFinite(lo))return '—';
-  const url=`https://maps.google.com/?q=${encodeURIComponent(la+','+lo)}`;
-  return `<a class="sds-map-link" href="${url}" target="_blank" rel="noopener noreferrer">${escHtml(label||`${la.toFixed(5)}, ${lo.toFixed(5)}`)}</a>`;
+  if(!validMapLatLon(la,lo))return '—';
+  return `<a class="sds-map-link" href="javascript:void(0)" onclick="event.preventDefault();openMapsAt(${la},${lo})">${escHtml(label||`${la.toFixed(5)}, ${lo.toFixed(5)}`)}</a>`;
 }
 function meshRfText(row){
   const parts=[];
@@ -6308,6 +6355,84 @@ function meshSourceListBody(id){
 function meshPaths(paths){
   if(!Array.isArray(paths)||!paths.length)return '<span class="sds-empty">—</span>';
   return paths.map(p=>`<span class="badge badge-blue" style="font-size:10px">${escHtml(p)}</span>`).join(' ');
+}
+
+// ── Maps: TETRA LIP, MeshCom and GeoAlarm positions on OpenStreetMap ─────
+let mapsFocus=null,mapsCurrentBounds=null;
+function validMapLatLon(lat,lon){
+  const la=Number(lat),lo=Number(lon);
+  return Number.isFinite(la)&&Number.isFinite(lo)&&la>=-90&&la<=90&&lo>=-180&&lo<=180;
+}
+function mapsMarker(type,title,lat,lon,detail,ts){
+  const la=Number(lat),lo=Number(lon);
+  if(!validMapLatLon(la,lo)||(la===0&&lo===0))return null;
+  return {type,title:title||'Position',lat:la,lon:lo,detail:detail||'',ts:ts||''};
+}
+function mapsCollect(){
+  const rows=[];
+  const geo=state.geoalarmConfig||{};
+  const station=mapsMarker('station','FlowStation',geo.flowstation_lat,geo.flowstation_lon,'GeoAlarm station position','');
+  if(station)rows.push(station);
+  (state.sdsLog||[]).forEach(e=>{
+    const lip=lipPositionFromText(e.text);if(!lip)return;
+    const cs=callsigns[e.source_issi]?.cs;
+    rows.push(mapsMarker('tetra',`TETRA ${[e.source_issi,cs].filter(Boolean).join(' ')||'LIP'}`,lip.lat,lip.lon,
+      `SDS ${String(e.direction||'').toUpperCase()} ${e.source_issi||'—'} → ${e.dest_issi||'—'}`,e.ts));
+  });
+  (state.meshcomNodes||[]).forEach(n=>{
+    const details=[n.last_type,meshRfText(n),n.batt!=null?`Battery ${meshBatteryText(n.batt)}`:''].filter(v=>v&&v!=='—').join(' · ');
+    rows.push(mapsMarker('mesh',`MeshCom ${n.src||'—'}`,n.lat,n.lon,details,n.last_seen));
+  });
+  (state.meshcomMessages||[]).forEach(m=>{
+    rows.push(mapsMarker('mesh',`MeshCom ${m.src||'—'}`,m.lat,m.lon,m.msg||m.msg_type||'position',m.ts));
+  });
+  (state.geoalarmEvents||[]).forEach(e=>{
+    const detail=[e.inside_radius?'inside radius':'outside radius',Number.isFinite(Number(e.distance_m))?`${Number(e.distance_m).toFixed(0)} m`:'',Array.isArray(e.paths)?e.paths.join(', '):''].filter(Boolean).join(' · ');
+    rows.push(mapsMarker(e.alarmed?'alarm':'geo',`GeoAlarm ${e.device||'—'}`,e.lat,e.lon,detail,e.ts));
+  });
+  return rows.filter(Boolean).sort((a,b)=>String(b.ts||'').localeCompare(String(a.ts||'')));
+}
+function mapsBounds(markers){
+  if(mapsFocus)return {minLon:mapsFocus.lon-.01,minLat:mapsFocus.lat-.006,maxLon:mapsFocus.lon+.01,maxLat:mapsFocus.lat+.006};
+  if(!markers.length)return {minLon:5.5,minLat:47,maxLon:15.5,maxLat:55.5};
+  let minLat=90,maxLat=-90,minLon=180,maxLon=-180;
+  markers.forEach(m=>{minLat=Math.min(minLat,m.lat);maxLat=Math.max(maxLat,m.lat);minLon=Math.min(minLon,m.lon);maxLon=Math.max(maxLon,m.lon);});
+  const latPad=Math.max(.006,(maxLat-minLat)*.18),lonPad=Math.max(.01,(maxLon-minLon)*.18);
+  return {minLon:Math.max(-180,minLon-lonPad),minLat:Math.max(-85,minLat-latPad),maxLon:Math.min(180,maxLon+lonPad),maxLat:Math.min(85,maxLat+latPad)};
+}
+function mapsEmbedUrl(b){
+  return `https://www.openstreetmap.org/export/embed.html?bbox=${encodeURIComponent(`${b.minLon},${b.minLat},${b.maxLon},${b.maxLat}`)}&layer=mapnik`;
+}
+function renderMapsPage(){
+  const markers=mapsCollect(),bounds=mapsBounds(markers);
+  mapsCurrentBounds=bounds;
+  const frame=document.getElementById('maps-frame'),list=document.getElementById('maps-list');
+  const count=document.getElementById('maps-count'),sub=document.getElementById('maps-hero-sub'),dot=document.getElementById('maps-hero-dot');
+  if(frame){const url=mapsEmbedUrl(bounds);if(frame.getAttribute('src')!==url)frame.src=url;}
+  if(count){count.textContent=`${markers.length} marker${markers.length===1?'':'s'}`;count.className=`pill ${markers.length?'pill-ok':'pill-idle'}`;}
+  if(sub)sub.textContent=markers.length?'TETRA LIP · MeshCom · GeoAlarm · FlowStation':'No positions collected yet';
+  if(dot)dot.className=`hero-dot ${markers.length?'is-ok':'is-idle'}`;
+  if(list)list.innerHTML=markers.length?markers.map(m=>`<div class="maps-list-row" onclick="openMapsAt(${m.lat},${m.lon})">
+    <div class="maps-list-type">${escHtml(m.type)}</div><div><div class="maps-list-title">${escHtml(m.title)}</div>
+    <div class="maps-list-meta">${m.ts?escHtml(m.ts)+' · ':''}${m.lat.toFixed(6)}, ${m.lon.toFixed(6)}</div>
+    ${m.detail?`<div class="maps-list-detail">${escHtml(m.detail)}</div>`:''}</div></div>`).join(''):'<div class="maps-empty">No positions yet</div>';
+  mapsFocus=null;
+}
+function mapsActive(){return !!document.getElementById('page-maps')?.classList.contains('active');}
+function renderMapsIfActive(){if(mapsActive())renderMapsPage();}
+function openMapsAt(lat,lon){
+  if(!validMapLatLon(lat,lon))return;
+  mapsFocus={lat:Number(lat),lon:Number(lon)};
+  showPage('maps',document.getElementById('nav-maps'));
+}
+function openMapsOsm(){
+  const b=mapsCurrentBounds||mapsBounds([]);
+  const lat=(b.minLat+b.maxLat)/2,lon=(b.minLon+b.maxLon)/2;
+  window.open(`https://www.openstreetmap.org/#map=12/${encodeURIComponent(lat)}/${encodeURIComponent(lon)}`,'_blank','noopener,noreferrer');
+}
+function refreshMapsData(){
+  renderMapsPage();
+  Promise.allSettled([loadSdsLog(),loadMeshcom(),loadGeoalarm()]).then(renderMapsPage);
 }
 
 // ── GeoAlarm ──────────────────────────────────────────────────────────────
@@ -6398,8 +6523,10 @@ async function loadGeoalarm(){
       d.enabled?(geoErr?t('integ_error'):t('integ_enabled')):t('integ_disabled'),
       rt.center||`${d.flowstation_lat??0}, ${d.flowstation_lon??0}`);
     state.geoalarmEvents=d.events||[];
+    state.geoalarmConfig=d;
     geoalarmPageIndex=0;
     renderGeoalarmEvents();
+    renderMapsIfActive();
     setGeoMsg('',true);
   }catch{setGeoMsg(t('conn_error'),false);setIntegrationHero('geo',false,false,t('conn_error'),'');}
 }
@@ -6443,19 +6570,6 @@ async function saveGeoalarm(){
 }
 function setGeoMsg(txt,ok){const el=document.getElementById('geo-msg');if(!el)return;el.textContent=txt;el.style.color=ok?'var(--accent)':'var(--danger)';if(txt)setTimeout(()=>{if(el.textContent===txt)el.textContent='';},5000);}
 
-function meshMapLink(lat,lon,label){
-  if(lat===null||lat===undefined||lon===null||lon===undefined)return '—';
-  const la=Number(lat),lo=Number(lon);
-  if(!Number.isFinite(la)||!Number.isFinite(lo))return '—';
-  const url=`https://maps.google.com/?q=${encodeURIComponent(la+','+lo)}`;
-  return `<a class="sds-map-link" href="${url}" target="_blank" rel="noopener noreferrer">${escHtml(label||`${la.toFixed(5)}, ${lo.toFixed(5)}`)}</a>`;
-}
-function meshRfText(row){
-  const parts=[];
-  if(row.rssi!==null&&row.rssi!==undefined)parts.push(`RSSI ${row.rssi}`);
-  if(row.snr!==null&&row.snr!==undefined)parts.push(`SNR ${row.snr}`);
-  return parts.join(' · ')||'—';
-}
 function meshBatteryText(v){
   if(v===null||v===undefined||v==='')return '—';
   const n=Number(v);
@@ -6570,6 +6684,7 @@ async function loadMeshcom(){
     meshNodePageIndex=0;meshMsgPageIndex=0;
     renderMeshcomNodes();
     renderMeshcomMessages();
+    renderMapsIfActive();
     setMeshMsg('',true);
   }catch{setMeshMsg(t('conn_error'),false);}
 }

--- a/crates/tetra-entities/src/net_dashboard/meshcom.rs
+++ b/crates/tetra-entities/src/net_dashboard/meshcom.rs
@@ -15,10 +15,7 @@ fn string_set_toml(values: &std::collections::BTreeSet<String>) -> String {
 }
 
 /// Rewrite (or insert) the `[meshcom]` section in the TOML file. A `.meshcom.bak` backup is made.
-pub fn write_meshcom_to_toml(
-    config_path: &str,
-    ov: &MeshcomRuntimeOverride,
-) -> std::io::Result<()> {
+pub fn write_meshcom_to_toml(config_path: &str, ov: &MeshcomRuntimeOverride) -> std::io::Result<()> {
     let original = std::fs::read_to_string(config_path)?;
     let section = format!(
         "[meshcom]\n\

--- a/crates/tetra-entities/src/net_dashboard/meshcom.rs
+++ b/crates/tetra-entities/src/net_dashboard/meshcom.rs
@@ -1,0 +1,108 @@
+//! Dashboard-side persistence helpers for MeshCom UDP settings.
+
+use tetra_config::bluestation::MeshcomRuntimeOverride;
+
+fn toml_escape(s: &str) -> String {
+    s.replace('\\', "\\\\").replace('"', "\\\"")
+}
+
+fn string_set_toml(values: &std::collections::BTreeSet<String>) -> String {
+    values
+        .iter()
+        .map(|v| format!("\"{}\"", toml_escape(v)))
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+/// Rewrite (or insert) the `[meshcom]` section in the TOML file. A `.meshcom.bak` backup is made.
+pub fn write_meshcom_to_toml(
+    config_path: &str,
+    ov: &MeshcomRuntimeOverride,
+) -> std::io::Result<()> {
+    let original = std::fs::read_to_string(config_path)?;
+    let section = format!(
+        "[meshcom]\n\
+         enabled = {}\n\
+         bind_addr = \"{}\"\n\
+         bind_port = {}\n\
+         tx_host = \"{}\"\n\
+         tx_port = {}\n\
+         allow_broadcast = {}\n\
+         max_messages = {}\n\
+         max_nodes = {}\n\n\
+         forward_sds = {}\n\
+         forward_sip = {}\n\
+         forward_telegram = {}\n\n\
+         sds_source_issi = {}\n\
+         sds_dest_issi = {}\n\
+         sds_dest_is_group = {}\n\
+         sds_allowed_sources = [{}]\n\n\
+         sip_title_prefix = \"{}\"\n\
+         sip_allowed_sources = [{}]\n\n\
+         telegram_prefix = \"{}\"\n\
+         telegram_allowed_sources = [{}]",
+        ov.enabled,
+        toml_escape(&ov.bind_addr),
+        nonzero_u16(ov.bind_port, 1799),
+        toml_escape(&ov.tx_host),
+        nonzero_u16(ov.tx_port, 1799),
+        ov.allow_broadcast,
+        ov.max_messages.clamp(10, 10_000),
+        ov.max_nodes.clamp(10, 65_535),
+        ov.forward_sds,
+        ov.forward_sip,
+        ov.forward_telegram,
+        ov.sds_source_issi.max(1),
+        ov.sds_dest_issi,
+        ov.sds_dest_is_group,
+        string_set_toml(&ov.sds_allowed_sources),
+        toml_escape(&ov.sip_title_prefix),
+        string_set_toml(&ov.sip_allowed_sources),
+        toml_escape(&ov.telegram_prefix),
+        string_set_toml(&ov.telegram_allowed_sources),
+    );
+
+    let lines: Vec<&str> = original.lines().collect();
+    let mut out: Vec<String> = Vec::with_capacity(lines.len() + 12);
+    let mut i = 0;
+    let mut replaced = false;
+
+    while i < lines.len() {
+        let trimmed = lines[i].trim_start();
+        if trimmed.starts_with("[meshcom]") {
+            out.push(section.clone());
+            replaced = true;
+            i += 1;
+            while i < lines.len() {
+                let t = lines[i].trim_start();
+                if t.starts_with('[') && t.contains(']') {
+                    break;
+                }
+                i += 1;
+            }
+            continue;
+        }
+        out.push(lines[i].to_string());
+        i += 1;
+    }
+
+    if !replaced {
+        if !out.is_empty() && !out.last().map(|l| l.is_empty()).unwrap_or(true) {
+            out.push(String::new());
+        }
+        out.push(section);
+    }
+
+    let mut new_content = out.join("\n");
+    if original.ends_with('\n') {
+        new_content.push('\n');
+    }
+
+    let backup = format!("{config_path}.meshcom.bak");
+    let _ = std::fs::copy(config_path, &backup);
+    std::fs::write(config_path, new_content)
+}
+
+fn nonzero_u16(value: u16, fallback: u16) -> u16 {
+    if value == 0 { fallback } else { value }
+}

--- a/crates/tetra-entities/src/net_dashboard/mod.rs
+++ b/crates/tetra-entities/src/net_dashboard/mod.rs
@@ -3,6 +3,7 @@ pub mod dapnet;
 pub mod dual_carrier;
 pub mod geoalarm;
 pub mod html;
+pub mod meshcom;
 pub mod radioid;
 pub mod server;
 pub mod snom_notify;

--- a/crates/tetra-entities/src/net_dashboard/server.rs
+++ b/crates/tetra-entities/src/net_dashboard/server.rs
@@ -1,6 +1,6 @@
 use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::io::{BufRead, BufReader, Read, Write};
-use std::net::{TcpListener, TcpStream};
+use std::net::{TcpListener, TcpStream, UdpSocket};
 use std::sync::{Arc, Mutex, RwLock};
 use std::time::Instant;
 
@@ -1915,6 +1915,16 @@ fn handle_connection(
     } else if req_line.contains("POST /api/geoalarm") {
         let (inner, body_str) = read_post_body(stream);
         serve_geoalarm_post(inner, &shared_config, &config_path, &body_str);
+    } else if req_line.contains("POST /api/meshcom/send") {
+        let (inner, body_str) = read_post_body(stream);
+        serve_meshcom_send(inner, &shared_config, &body_str);
+    } else if req_line.contains("GET /api/meshcom") {
+        let mut s = stream;
+        drain_http_headers(&mut s);
+        serve_meshcom_get(s, &shared_config);
+    } else if req_line.contains("POST /api/meshcom") {
+        let (inner, body_str) = read_post_body(stream);
+        serve_meshcom_post(inner, &shared_config, &config_path, &body_str);
     } else if req_line.contains("GET /api/config") {
         let mut buf = BufReader::new(stream);
         loop {
@@ -4397,6 +4407,368 @@ fn serve_dapnet_post(stream: TcpStream, shared_config: &Option<tetra_config::blu
         ov.forward_telegram
     );
     http_response(stream, 200, "OK");
+}
+
+/// GET /api/meshcom — return effective MeshCom settings and runtime status as JSON.
+fn serve_meshcom_get(
+    stream: TcpStream,
+    shared_config: &Option<tetra_config::bluestation::SharedConfig>,
+) {
+    let (meshcom, runtime) = match shared_config {
+        Some(cfg) => (cfg.effective_meshcom(), cfg.state_read().meshcom_status.clone()),
+        None => (
+            tetra_config::bluestation::CfgMeshcom::default(),
+            tetra_config::bluestation::MeshcomRuntimeStatus::default(),
+        ),
+    };
+    let nodes = runtime
+        .nodes
+        .iter()
+        .map(|node| {
+            serde_json::json!({
+                "src": node.src.clone(),
+                "last_seen": node.last_seen.clone(),
+                "last_type": node.last_type.clone(),
+                "lat": node.lat,
+                "lon": node.lon,
+                "alt": node.alt,
+                "batt": node.batt,
+                "rssi": node.rssi,
+                "snr": node.snr,
+                "firmware": node.firmware.clone(),
+                "fw_sub": node.fw_sub.clone(),
+                "hw_id": node.hw_id.clone(),
+            })
+        })
+        .collect::<Vec<_>>();
+    let messages = runtime
+        .messages
+        .iter()
+        .map(|msg| {
+            serde_json::json!({
+                "ts": msg.ts.clone(),
+                "direction": msg.direction.clone(),
+                "msg_type": msg.msg_type.clone(),
+                "src_type": msg.src_type.clone(),
+                "src": msg.src.clone(),
+                "dst": msg.dst.clone(),
+                "msg": msg.msg.clone(),
+                "msg_id": msg.msg_id.clone(),
+                "paths": msg.paths.clone(),
+                "lat": msg.lat,
+                "lon": msg.lon,
+                "alt": msg.alt,
+                "batt": msg.batt,
+                "rssi": msg.rssi,
+                "snr": msg.snr,
+            })
+        })
+        .collect::<Vec<_>>();
+    let runtime_body = serde_json::json!({
+        "configured": runtime.configured,
+        "enabled": runtime.enabled,
+        "bind": runtime.bind,
+        "tx": runtime.tx,
+        "rx_packets": runtime.rx_packets,
+        "tx_packets": runtime.tx_packets,
+        "last_rx": runtime.last_rx,
+        "last_tx": runtime.last_tx,
+        "last_error": runtime.last_error,
+        "forward_sds": runtime.forward_sds,
+        "forward_sip": runtime.forward_sip,
+        "forward_telegram": runtime.forward_telegram,
+        "node_count": nodes.len(),
+    });
+    let body = serde_json::json!({
+        "enabled": meshcom.enabled,
+        "bind_addr": meshcom.bind_addr.clone(),
+        "bind_port": meshcom.bind_port,
+        "tx_host": meshcom.tx_host.clone(),
+        "tx_port": meshcom.tx_port,
+        "allow_broadcast": meshcom.allow_broadcast,
+        "max_messages": meshcom.max_messages,
+        "max_nodes": meshcom.max_nodes,
+        "forward_sds": meshcom.forward_sds,
+        "forward_sip": meshcom.forward_sip,
+        "forward_telegram": meshcom.forward_telegram,
+        "sds_source_issi": meshcom.sds_source_issi,
+        "sds_dest_issi": meshcom.sds_dest_issi,
+        "sds_dest_is_group": meshcom.sds_dest_is_group,
+        "sds_allowed_sources": meshcom_source_list_as_json(&meshcom.sds_allowed_sources),
+        "sip_title_prefix": meshcom.sip_title_prefix.clone(),
+        "sip_allowed_sources": meshcom_source_list_as_json(&meshcom.sip_allowed_sources),
+        "telegram_prefix": meshcom.telegram_prefix.clone(),
+        "telegram_allowed_sources": meshcom_source_list_as_json(&meshcom.telegram_allowed_sources),
+        "runtime": runtime_body,
+        "nodes": nodes,
+        "messages": messages,
+    });
+    http_json_response(stream, 200, &body.to_string());
+}
+
+/// POST /api/meshcom — update MeshCom UDP settings. Applies immediately through StackState
+/// override and rewrites `[meshcom]` in config.toml.
+fn serve_meshcom_post(
+    stream: TcpStream,
+    shared_config: &Option<tetra_config::bluestation::SharedConfig>,
+    config_path: &str,
+    body: &str,
+) {
+    use tetra_config::bluestation::{
+        CfgMeshcomDto, MeshcomRuntimeOverride, apply_meshcom_patch,
+    };
+
+    let json: serde_json::Value = match serde_json::from_str(body.trim()) {
+        Ok(v) => v,
+        Err(e) => {
+            http_response(stream, 400, &format!("Invalid JSON: {e}"));
+            return;
+        }
+    };
+    let Some(cfg) = shared_config else {
+        http_response(stream, 503, "Config not available");
+        return;
+    };
+
+    let cur = cfg.effective_meshcom();
+    let sds_allowed_sources = match meshcom_source_list_from_json(
+        &json,
+        "sds_allowed_sources",
+        &cur.sds_allowed_sources,
+    ) {
+        Ok(v) => v,
+        Err(err) => {
+            http_response(stream, 400, &err);
+            return;
+        }
+    };
+    let sip_allowed_sources = match meshcom_source_list_from_json(
+        &json,
+        "sip_allowed_sources",
+        &cur.sip_allowed_sources,
+    ) {
+        Ok(v) => v,
+        Err(err) => {
+            http_response(stream, 400, &err);
+            return;
+        }
+    };
+    let telegram_allowed_sources = match meshcom_source_list_from_json(
+        &json,
+        "telegram_allowed_sources",
+        &cur.telegram_allowed_sources,
+    ) {
+        Ok(v) => v,
+        Err(err) => {
+            http_response(stream, 400, &err);
+            return;
+        }
+    };
+    let dto = CfgMeshcomDto {
+        enabled: dapnet_as_bool(&json, "enabled", cur.enabled),
+        bind_addr: dapnet_as_string(&json, "bind_addr", &cur.bind_addr),
+        bind_port: dapnet_as_u16(&json, "bind_port", cur.bind_port),
+        tx_host: dapnet_as_string(&json, "tx_host", &cur.tx_host),
+        tx_port: dapnet_as_u16(&json, "tx_port", cur.tx_port),
+        allow_broadcast: dapnet_as_bool(&json, "allow_broadcast", cur.allow_broadcast),
+        max_messages: dapnet_as_usize(&json, "max_messages", cur.max_messages),
+        max_nodes: dapnet_as_usize(&json, "max_nodes", cur.max_nodes),
+        forward_sds: dapnet_as_bool(&json, "forward_sds", cur.forward_sds),
+        forward_sip: dapnet_as_bool(&json, "forward_sip", cur.forward_sip),
+        forward_telegram: dapnet_as_bool(&json, "forward_telegram", cur.forward_telegram),
+        sds_source_issi: dapnet_as_u32(&json, "sds_source_issi", cur.sds_source_issi),
+        sds_dest_issi: dapnet_as_u32(&json, "sds_dest_issi", cur.sds_dest_issi),
+        sds_dest_is_group: dapnet_as_bool(&json, "sds_dest_is_group", cur.sds_dest_is_group),
+        sds_allowed_sources,
+        sip_title_prefix: dapnet_as_string(&json, "sip_title_prefix", &cur.sip_title_prefix),
+        sip_allowed_sources,
+        telegram_prefix: dapnet_as_string(&json, "telegram_prefix", &cur.telegram_prefix),
+        telegram_allowed_sources,
+        extra: HashMap::new(),
+    };
+    let normalized = match apply_meshcom_patch(dto) {
+        Ok(cfg) => cfg,
+        Err(err) => {
+            http_response(stream, 400, &err);
+            return;
+        }
+    };
+    let text_fields = [
+        normalized.bind_addr.as_str(),
+        normalized.tx_host.as_str(),
+        normalized.sip_title_prefix.as_str(),
+        normalized.telegram_prefix.as_str(),
+    ];
+    if !text_fields
+        .iter()
+        .all(|v| dapnet_text_acceptable(v))
+        || !normalized
+            .sds_allowed_sources
+            .iter()
+            .chain(normalized.sip_allowed_sources.iter())
+            .chain(normalized.telegram_allowed_sources.iter())
+            .all(|v| dapnet_text_acceptable(v))
+    {
+        http_response(stream, 400, "Invalid MeshCom setting: control characters are not allowed");
+        return;
+    }
+
+    let ov = MeshcomRuntimeOverride {
+        enabled: normalized.enabled,
+        bind_addr: normalized.bind_addr,
+        bind_port: normalized.bind_port,
+        tx_host: normalized.tx_host,
+        tx_port: normalized.tx_port,
+        allow_broadcast: normalized.allow_broadcast,
+        max_messages: normalized.max_messages,
+        max_nodes: normalized.max_nodes,
+        forward_sds: normalized.forward_sds,
+        forward_sip: normalized.forward_sip,
+        forward_telegram: normalized.forward_telegram,
+        sds_source_issi: normalized.sds_source_issi,
+        sds_dest_issi: normalized.sds_dest_issi,
+        sds_dest_is_group: normalized.sds_dest_is_group,
+        sds_allowed_sources: normalized.sds_allowed_sources,
+        sip_title_prefix: normalized.sip_title_prefix,
+        sip_allowed_sources: normalized.sip_allowed_sources,
+        telegram_prefix: normalized.telegram_prefix,
+        telegram_allowed_sources: normalized.telegram_allowed_sources,
+    };
+
+    {
+        let mut state = cfg.state_write();
+        state.meshcom_override = Some(ov.clone());
+    }
+
+    if let Err(e) = crate::net_dashboard::meshcom::write_meshcom_to_toml(config_path, &ov) {
+        tracing::warn!("Dashboard: MeshCom applied at runtime but failed to persist to TOML: {}", e);
+        http_response(stream, 200, "Applied at runtime; failed to write config file (check permissions)");
+        return;
+    }
+
+    tracing::info!(
+        "Dashboard: MeshCom updated (enabled={} bind={}:{} tx={}:{})",
+        ov.enabled,
+        ov.bind_addr,
+        ov.bind_port,
+        ov.tx_host,
+        ov.tx_port
+    );
+    http_response(stream, 200, "OK");
+}
+
+/// POST /api/meshcom/send — send one MeshCom text message through the configured UDP target.
+fn serve_meshcom_send(
+    stream: TcpStream,
+    shared_config: &Option<tetra_config::bluestation::SharedConfig>,
+    body: &str,
+) {
+    let json: serde_json::Value = match serde_json::from_str(body.trim()) {
+        Ok(v) => v,
+        Err(e) => {
+            http_json_response(
+                stream,
+                400,
+                &serde_json::json!({"ok": false, "error": format!("Invalid JSON: {e}")}).to_string(),
+            );
+            return;
+        }
+    };
+    let Some(cfg) = shared_config else {
+        http_json_response(stream, 503, &serde_json::json!({"ok": false, "error": "Config not available"}).to_string());
+        return;
+    };
+    let meshcom = cfg.effective_meshcom();
+    if !meshcom.enabled {
+        http_json_response(stream, 400, &serde_json::json!({"ok": false, "error": "MeshCom is disabled"}).to_string());
+        return;
+    }
+    let dst = json
+        .get("dst")
+        .and_then(|v| v.as_str())
+        .map(str::trim)
+        .unwrap_or("");
+    let msg = json
+        .get("msg")
+        .and_then(|v| v.as_str())
+        .map(str::trim)
+        .unwrap_or("");
+    if dst.is_empty() || msg.is_empty() {
+        http_json_response(stream, 400, &serde_json::json!({"ok": false, "error": "dst and msg are required"}).to_string());
+        return;
+    }
+    if !dapnet_text_acceptable(dst) || !dapnet_text_acceptable(msg) {
+        http_json_response(stream, 400, &serde_json::json!({"ok": false, "error": "control characters are not allowed"}).to_string());
+        return;
+    }
+
+    let wire = serde_json::json!({
+        "type": "msg",
+        "dst": dst,
+        "msg": msg.chars().take(512).collect::<String>(),
+    })
+    .to_string();
+    let target = format!("{}:{}", meshcom.tx_host, meshcom.tx_port);
+    let result = UdpSocket::bind("0.0.0.0:0")
+        .and_then(|socket| {
+            socket.set_broadcast(meshcom.allow_broadcast)?;
+            socket.send_to(wire.as_bytes(), &target)
+        });
+    match result {
+        Ok(bytes) => {
+            let ts = chrono::Local::now().format("%Y-%m-%d %H:%M:%S").to_string();
+            {
+                let mut state = cfg.state_write();
+                state.meshcom_status.configured = true;
+                state.meshcom_status.enabled = meshcom.enabled;
+                state.meshcom_status.bind = format!("{}:{}", meshcom.bind_addr, meshcom.bind_port);
+                state.meshcom_status.tx = target.clone();
+                state.meshcom_status.tx_packets = state.meshcom_status.tx_packets.saturating_add(1);
+                state.meshcom_status.last_tx = Some(ts.clone());
+                state.meshcom_status.last_error = None;
+                state.meshcom_status.forward_sds = meshcom.forward_sds;
+                state.meshcom_status.forward_sip = meshcom.forward_sip;
+                state.meshcom_status.forward_telegram = meshcom.forward_telegram;
+                state.meshcom_status.messages.insert(
+                    0,
+                    tetra_config::bluestation::MeshcomMessageStatus {
+                        ts,
+                        direction: "tx".to_string(),
+                        msg_type: "msg".to_string(),
+                        src_type: Some("flowstation".to_string()),
+                        src: Some("FlowStation".to_string()),
+                        dst: Some(dst.to_string()),
+                        msg: Some(msg.chars().take(512).collect::<String>()),
+                        msg_id: None,
+                        paths: vec!["udp".to_string()],
+                        lat: None,
+                        lon: None,
+                        alt: None,
+                        batt: None,
+                        rssi: None,
+                        snr: None,
+                    },
+                );
+                while state.meshcom_status.messages.len() > meshcom.max_messages {
+                    state.meshcom_status.messages.pop();
+                }
+            }
+            tracing::info!("MeshCom: sent {} bytes to {} dst={}", bytes, target, dst);
+            http_json_response(stream, 200, &serde_json::json!({"ok": true, "bytes": bytes}).to_string());
+        }
+        Err(err) => {
+            {
+                let mut state = cfg.state_write();
+                state.meshcom_status.last_error = Some(format!("UDP send failed: {err}"));
+            }
+            tracing::warn!("MeshCom: UDP send to {} failed: {}", target, err);
+            http_json_response(
+                stream,
+                500,
+                &serde_json::json!({"ok": false, "error": format!("UDP send failed: {err}")}).to_string(),
+            );
+        }
+    }
 }
 
 /// GET /api/geoalarm — return effective GeoAlarm settings and runtime status as JSON.

--- a/crates/tetra-entities/src/net_dashboard/server.rs
+++ b/crates/tetra-entities/src/net_dashboard/server.rs
@@ -2546,11 +2546,7 @@ fn serve_bts_info(mut stream: TcpStream, shared_config: &Option<tetra_config::bl
 /// GET /api/dualcarrier — current Dual-Carrier ON/OFF state for the first-page toggle.
 /// Reads the switch + configured secondary carrier from the TOML (so the number is shown even while
 /// off), plus the running effective state and the main carrier.
-fn serve_dual_carrier_get(
-    mut stream: TcpStream,
-    shared_config: &Option<tetra_config::bluestation::SharedConfig>,
-    config_path: &str,
-) {
+fn serve_dual_carrier_get(mut stream: TcpStream, shared_config: &Option<tetra_config::bluestation::SharedConfig>, config_path: &str) {
     let st = crate::net_dashboard::dual_carrier::read_dual_carrier(config_path);
     let main_carrier = shared_config.as_ref().map(|c| c.config().cell.main_carrier);
     // What the running stack is actually doing right now (may lag the file until the restart lands).
@@ -2653,10 +2649,7 @@ fn serve_dual_carrier_post(
         if enabled { "ON" } else { "OFF" },
         secondary
     );
-    crate::service_control::schedule_service_action(
-        crate::service_control::ServiceAction::Restart,
-        std::time::Duration::from_secs(2),
-    );
+    crate::service_control::schedule_service_action(crate::service_control::ServiceAction::Restart, std::time::Duration::from_secs(2));
 
     http_response(
         stream,
@@ -3519,7 +3512,9 @@ fn read_http_body(stream: &mut TcpStream) -> Vec<u8> {
             break;
         }
     }
-    if content_length == 0 { return Vec::new(); }
+    if content_length == 0 {
+        return Vec::new();
+    }
     let mut body = vec![0u8; content_length.min(512 * 1024)];
     let _ = stream.read_exact(&mut body);
     body
@@ -4410,10 +4405,7 @@ fn serve_dapnet_post(stream: TcpStream, shared_config: &Option<tetra_config::blu
 }
 
 /// GET /api/meshcom — return effective MeshCom settings and runtime status as JSON.
-fn serve_meshcom_get(
-    stream: TcpStream,
-    shared_config: &Option<tetra_config::bluestation::SharedConfig>,
-) {
+fn serve_meshcom_get(stream: TcpStream, shared_config: &Option<tetra_config::bluestation::SharedConfig>) {
     let (meshcom, runtime) = match shared_config {
         Some(cfg) => (cfg.effective_meshcom(), cfg.state_read().meshcom_status.clone()),
         None => (
@@ -4508,15 +4500,8 @@ fn serve_meshcom_get(
 
 /// POST /api/meshcom — update MeshCom UDP settings. Applies immediately through StackState
 /// override and rewrites `[meshcom]` in config.toml.
-fn serve_meshcom_post(
-    stream: TcpStream,
-    shared_config: &Option<tetra_config::bluestation::SharedConfig>,
-    config_path: &str,
-    body: &str,
-) {
-    use tetra_config::bluestation::{
-        CfgMeshcomDto, MeshcomRuntimeOverride, apply_meshcom_patch,
-    };
+fn serve_meshcom_post(stream: TcpStream, shared_config: &Option<tetra_config::bluestation::SharedConfig>, config_path: &str, body: &str) {
+    use tetra_config::bluestation::{CfgMeshcomDto, MeshcomRuntimeOverride, apply_meshcom_patch};
 
     let json: serde_json::Value = match serde_json::from_str(body.trim()) {
         Ok(v) => v,
@@ -4531,33 +4516,21 @@ fn serve_meshcom_post(
     };
 
     let cur = cfg.effective_meshcom();
-    let sds_allowed_sources = match meshcom_source_list_from_json(
-        &json,
-        "sds_allowed_sources",
-        &cur.sds_allowed_sources,
-    ) {
+    let sds_allowed_sources = match meshcom_source_list_from_json(&json, "sds_allowed_sources", &cur.sds_allowed_sources) {
         Ok(v) => v,
         Err(err) => {
             http_response(stream, 400, &err);
             return;
         }
     };
-    let sip_allowed_sources = match meshcom_source_list_from_json(
-        &json,
-        "sip_allowed_sources",
-        &cur.sip_allowed_sources,
-    ) {
+    let sip_allowed_sources = match meshcom_source_list_from_json(&json, "sip_allowed_sources", &cur.sip_allowed_sources) {
         Ok(v) => v,
         Err(err) => {
             http_response(stream, 400, &err);
             return;
         }
     };
-    let telegram_allowed_sources = match meshcom_source_list_from_json(
-        &json,
-        "telegram_allowed_sources",
-        &cur.telegram_allowed_sources,
-    ) {
+    let telegram_allowed_sources = match meshcom_source_list_from_json(&json, "telegram_allowed_sources", &cur.telegram_allowed_sources) {
         Ok(v) => v,
         Err(err) => {
             http_response(stream, 400, &err);
@@ -4599,9 +4572,7 @@ fn serve_meshcom_post(
         normalized.sip_title_prefix.as_str(),
         normalized.telegram_prefix.as_str(),
     ];
-    if !text_fields
-        .iter()
-        .all(|v| dapnet_text_acceptable(v))
+    if !text_fields.iter().all(|v| dapnet_text_acceptable(v))
         || !normalized
             .sds_allowed_sources
             .iter()
@@ -4658,11 +4629,7 @@ fn serve_meshcom_post(
 }
 
 /// POST /api/meshcom/send — send one MeshCom text message through the configured UDP target.
-fn serve_meshcom_send(
-    stream: TcpStream,
-    shared_config: &Option<tetra_config::bluestation::SharedConfig>,
-    body: &str,
-) {
+fn serve_meshcom_send(stream: TcpStream, shared_config: &Option<tetra_config::bluestation::SharedConfig>, body: &str) {
     let json: serde_json::Value = match serde_json::from_str(body.trim()) {
         Ok(v) => v,
         Err(e) => {
@@ -4675,30 +4642,38 @@ fn serve_meshcom_send(
         }
     };
     let Some(cfg) = shared_config else {
-        http_json_response(stream, 503, &serde_json::json!({"ok": false, "error": "Config not available"}).to_string());
+        http_json_response(
+            stream,
+            503,
+            &serde_json::json!({"ok": false, "error": "Config not available"}).to_string(),
+        );
         return;
     };
     let meshcom = cfg.effective_meshcom();
     if !meshcom.enabled {
-        http_json_response(stream, 400, &serde_json::json!({"ok": false, "error": "MeshCom is disabled"}).to_string());
+        http_json_response(
+            stream,
+            400,
+            &serde_json::json!({"ok": false, "error": "MeshCom is disabled"}).to_string(),
+        );
         return;
     }
-    let dst = json
-        .get("dst")
-        .and_then(|v| v.as_str())
-        .map(str::trim)
-        .unwrap_or("");
-    let msg = json
-        .get("msg")
-        .and_then(|v| v.as_str())
-        .map(str::trim)
-        .unwrap_or("");
+    let dst = json.get("dst").and_then(|v| v.as_str()).map(str::trim).unwrap_or("");
+    let msg = json.get("msg").and_then(|v| v.as_str()).map(str::trim).unwrap_or("");
     if dst.is_empty() || msg.is_empty() {
-        http_json_response(stream, 400, &serde_json::json!({"ok": false, "error": "dst and msg are required"}).to_string());
+        http_json_response(
+            stream,
+            400,
+            &serde_json::json!({"ok": false, "error": "dst and msg are required"}).to_string(),
+        );
         return;
     }
     if !dapnet_text_acceptable(dst) || !dapnet_text_acceptable(msg) {
-        http_json_response(stream, 400, &serde_json::json!({"ok": false, "error": "control characters are not allowed"}).to_string());
+        http_json_response(
+            stream,
+            400,
+            &serde_json::json!({"ok": false, "error": "control characters are not allowed"}).to_string(),
+        );
         return;
     }
 
@@ -4709,11 +4684,10 @@ fn serve_meshcom_send(
     })
     .to_string();
     let target = format!("{}:{}", meshcom.tx_host, meshcom.tx_port);
-    let result = UdpSocket::bind("0.0.0.0:0")
-        .and_then(|socket| {
-            socket.set_broadcast(meshcom.allow_broadcast)?;
-            socket.send_to(wire.as_bytes(), &target)
-        });
+    let result = UdpSocket::bind("0.0.0.0:0").and_then(|socket| {
+        socket.set_broadcast(meshcom.allow_broadcast)?;
+        socket.send_to(wire.as_bytes(), &target)
+    });
     match result {
         Ok(bytes) => {
             let ts = chrono::Local::now().format("%Y-%m-%d %H:%M:%S").to_string();

--- a/crates/tetra-entities/src/net_meshcom/mod.rs
+++ b/crates/tetra-entities/src/net_meshcom/mod.rs
@@ -1,0 +1,495 @@
+//! MeshCom external UDP integration.
+//!
+//! MeshCom nodes can expose an external-client UDP interface that exchanges JSON packets,
+//! commonly on UDP/1799. FlowStation listens for received `msg`, `pos`, and `tele` packets
+//! and keeps a small runtime directory/log for the dashboard. Outbound text messages are sent
+//! by the dashboard API using the same documented JSON format.
+
+use std::collections::{BTreeSet, VecDeque};
+use std::net::UdpSocket;
+use std::thread;
+use std::time::Duration;
+
+use serde_json::Value;
+use tetra_config::bluestation::{
+    CfgMeshcom, MeshcomMessageStatus, MeshcomNodeStatus, MeshcomRuntimeStatus, SharedConfig,
+};
+
+use crate::net_control::commands::ControlCommand;
+use crate::net_snom::SnomNotifySink;
+use crate::net_telegram::TelegramAlertSink;
+use crate::tpg2200::build_sds_text_payload;
+
+type CmdSender = crossbeam_channel::Sender<ControlCommand>;
+
+const UDP_READ_TIMEOUT: Duration = Duration::from_secs(1);
+const DISABLED_SLEEP: Duration = Duration::from_secs(1);
+const ERROR_SLEEP: Duration = Duration::from_secs(5);
+
+pub fn spawn_meshcom_worker(
+    cfg: SharedConfig,
+    cmce_cmd_tx: Option<CmdSender>,
+    telegram_sink: Option<TelegramAlertSink>,
+    snom_sink: Option<SnomNotifySink>,
+) -> Option<thread::JoinHandle<()>> {
+    match thread::Builder::new()
+        .name("meshcom-worker".into())
+        .spawn(move || MeshcomWorker::new(cfg, cmce_cmd_tx, telegram_sink, snom_sink).run())
+    {
+        Ok(handle) => Some(handle),
+        Err(err) => {
+            tracing::warn!("MeshCom: failed to spawn worker thread: {}", err);
+            None
+        }
+    }
+}
+
+struct MeshcomWorker {
+    cfg: SharedConfig,
+    cmce_cmd_tx: Option<CmdSender>,
+    telegram_sink: Option<TelegramAlertSink>,
+    snom_sink: Option<SnomNotifySink>,
+    socket: Option<UdpSocket>,
+    bind_key: String,
+    rx_packets: u64,
+    nodes: Vec<MeshcomNodeStatus>,
+    messages: VecDeque<MeshcomMessageStatus>,
+    last_enabled: Option<bool>,
+}
+
+impl MeshcomWorker {
+    fn new(
+        cfg: SharedConfig,
+        cmce_cmd_tx: Option<CmdSender>,
+        telegram_sink: Option<TelegramAlertSink>,
+        snom_sink: Option<SnomNotifySink>,
+    ) -> Self {
+        Self {
+            cfg,
+            cmce_cmd_tx,
+            telegram_sink,
+            snom_sink,
+            socket: None,
+            bind_key: String::new(),
+            rx_packets: 0,
+            nodes: Vec::new(),
+            messages: VecDeque::new(),
+            last_enabled: None,
+        }
+    }
+
+    fn run(&mut self) {
+        loop {
+            let meshcom = self.cfg.effective_meshcom();
+            if !meshcom.enabled {
+                if self.last_enabled != Some(false) {
+                    tracing::info!("MeshCom UDP integration disabled");
+                    self.last_enabled = Some(false);
+                }
+                self.socket = None;
+                self.bind_key.clear();
+                self.publish_status(&meshcom, None, None);
+                thread::sleep(DISABLED_SLEEP);
+                continue;
+            }
+
+            if self.last_enabled != Some(true) {
+                tracing::info!(
+                    "MeshCom UDP integration enabled (bind={}:{} tx={}:{} forward_sds={} forward_sip={} forward_telegram={})",
+                    meshcom.bind_addr,
+                    meshcom.bind_port,
+                    meshcom.tx_host,
+                    meshcom.tx_port,
+                    meshcom.forward_sds,
+                    meshcom.forward_sip,
+                    meshcom.forward_telegram
+                );
+                self.last_enabled = Some(true);
+            }
+
+            if let Err(err) = self.ensure_socket(&meshcom) {
+                tracing::warn!("MeshCom: {}", err);
+                self.publish_status(&meshcom, None, Some(err));
+                thread::sleep(ERROR_SLEEP);
+                continue;
+            }
+
+            let mut buf = [0u8; 8192];
+            let Some(socket) = self.socket.as_ref() else {
+                thread::sleep(ERROR_SLEEP);
+                continue;
+            };
+            let recv = socket.recv_from(&mut buf);
+
+            match recv {
+                Ok((len, from)) => {
+                    let text = String::from_utf8_lossy(&buf[..len]).trim().to_string();
+                    match self.handle_packet(&meshcom, &text) {
+                        Ok(()) => {
+                            tracing::debug!("MeshCom: received {} bytes from {}", len, from);
+                            self.publish_status(&meshcom, Some(now_stamp()), None);
+                        }
+                        Err(err) => {
+                            tracing::warn!("MeshCom: dropping invalid UDP packet from {}: {}", from, err);
+                            self.publish_status(&meshcom, None, Some(err));
+                        }
+                    }
+                }
+                Err(err)
+                    if err.kind() == std::io::ErrorKind::WouldBlock
+                        || err.kind() == std::io::ErrorKind::TimedOut => {}
+                Err(err) => {
+                    let msg = format!("UDP receive failed: {err}");
+                    tracing::warn!("MeshCom: {}", msg);
+                    self.publish_status(&meshcom, None, Some(msg));
+                    self.socket = None;
+                    self.bind_key.clear();
+                    thread::sleep(ERROR_SLEEP);
+                }
+            }
+        }
+    }
+
+    fn ensure_socket(&mut self, meshcom: &CfgMeshcom) -> Result<(), String> {
+        let key = format!("{}:{}", meshcom.bind_addr.trim(), meshcom.bind_port);
+        if self.socket.is_some() && self.bind_key == key {
+            return Ok(());
+        }
+
+        self.socket = None;
+        let socket = UdpSocket::bind(&key).map_err(|e| format!("UDP bind {key} failed: {e}"))?;
+        socket
+            .set_read_timeout(Some(UDP_READ_TIMEOUT))
+            .map_err(|e| format!("UDP set_read_timeout failed: {e}"))?;
+        if let Err(err) = socket.set_broadcast(meshcom.allow_broadcast) {
+            tracing::warn!(
+                "MeshCom: failed to set UDP broadcast={} on {}: {}",
+                meshcom.allow_broadcast,
+                key,
+                err
+            );
+        }
+        self.bind_key = key;
+        self.socket = Some(socket);
+        self.publish_status(meshcom, None, None);
+        Ok(())
+    }
+
+    fn handle_packet(&mut self, meshcom: &CfgMeshcom, text: &str) -> Result<(), String> {
+        if text.is_empty() {
+            return Err("empty packet".to_string());
+        }
+        let value: Value = serde_json::from_str(text).map_err(|e| format!("invalid JSON: {e}"))?;
+        let msg_type = string_field(&value, "type").unwrap_or_else(|| "unknown".to_string());
+        let src = string_field(&value, "src");
+        let dst = string_field(&value, "dst");
+        let src_type = string_field(&value, "src_type");
+        let msg = string_field(&value, "msg").map(|s| truncate_chars(&s, 512));
+        let msg_id = string_field(&value, "msg_id");
+        let lat = signed_coord(f64_field(&value, "lat"), string_field(&value, "lat_dir").as_deref());
+        let lon = signed_coord(f64_field(&value, "long"), string_field(&value, "long_dir").as_deref());
+        let alt = f64_field(&value, "alt");
+        let batt = f64_field(&value, "batt");
+        let rssi = i64_field(&value, "rssi");
+        let snr = i64_field(&value, "snr");
+        let firmware = string_field(&value, "firmware");
+        let fw_sub = string_field(&value, "fw_sub");
+        let hw_id = string_field(&value, "hw_id");
+        let ts = now_stamp();
+        let paths = self.forward_message(
+            meshcom,
+            &msg_type,
+            src.as_deref(),
+            dst.as_deref(),
+            msg.as_deref(),
+            msg_id.as_deref(),
+        );
+
+        self.rx_packets = self.rx_packets.saturating_add(1);
+        let event = MeshcomMessageStatus {
+            ts: ts.clone(),
+            direction: "rx".to_string(),
+            msg_type: msg_type.clone(),
+            src_type,
+            src: src.clone(),
+            dst,
+            msg,
+            msg_id,
+            paths,
+            lat,
+            lon,
+            alt,
+            batt,
+            rssi,
+            snr,
+        };
+
+        if let Some(source) = src {
+            self.upsert_node(
+                meshcom,
+                MeshcomNodeStatus {
+                    src: source,
+                    last_seen: ts,
+                    last_type: msg_type,
+                    lat,
+                    lon,
+                    alt,
+                    batt,
+                    rssi,
+                    snr,
+                    firmware,
+                    fw_sub,
+                    hw_id,
+                },
+            );
+        }
+        self.messages.push_front(event);
+        while self.messages.len() > meshcom.max_messages {
+            self.messages.pop_back();
+        }
+        Ok(())
+    }
+
+    fn upsert_node(&mut self, meshcom: &CfgMeshcom, update: MeshcomNodeStatus) {
+        if let Some(node) = self.nodes.iter_mut().find(|node| node.src == update.src) {
+            node.last_seen = update.last_seen;
+            node.last_type = update.last_type;
+            if update.lat.is_some() {
+                node.lat = update.lat;
+            }
+            if update.lon.is_some() {
+                node.lon = update.lon;
+            }
+            if update.alt.is_some() {
+                node.alt = update.alt;
+            }
+            if update.batt.is_some() {
+                node.batt = update.batt;
+            }
+            if update.rssi.is_some() {
+                node.rssi = update.rssi;
+            }
+            if update.snr.is_some() {
+                node.snr = update.snr;
+            }
+            if update.firmware.is_some() {
+                node.firmware = update.firmware;
+            }
+            if update.fw_sub.is_some() {
+                node.fw_sub = update.fw_sub;
+            }
+            if update.hw_id.is_some() {
+                node.hw_id = update.hw_id;
+            }
+            return;
+        }
+        self.nodes.push(update);
+        while self.nodes.len() > meshcom.max_nodes {
+            self.nodes.remove(0);
+        }
+    }
+
+    fn forward_message(
+        &self,
+        meshcom: &CfgMeshcom,
+        msg_type: &str,
+        src: Option<&str>,
+        dst: Option<&str>,
+        msg: Option<&str>,
+        msg_id: Option<&str>,
+    ) -> Vec<String> {
+        let mut paths = Vec::new();
+        if !msg_type.eq_ignore_ascii_case("msg") {
+            return paths;
+        }
+        let Some(text) = msg.map(str::trim).filter(|s| !s.is_empty()) else {
+            return paths;
+        };
+        let src = src.map(str::trim).filter(|s| !s.is_empty()).unwrap_or("unknown");
+
+        if meshcom.forward_sds && source_allowed(&meshcom.sds_allowed_sources, src) {
+            match self.forward_sds(meshcom, src, text) {
+                Ok(()) => paths.push("sds".to_string()),
+                Err(err) => tracing::warn!("MeshCom: SDS forwarding failed src={}: {}", src, err),
+            }
+        }
+        if meshcom.forward_sip && source_allowed(&meshcom.sip_allowed_sources, src) {
+            match self.forward_sip(meshcom, src, dst, text, msg_id) {
+                Ok(()) => paths.push("sip".to_string()),
+                Err(err) => tracing::warn!("MeshCom: SIP notify forwarding failed src={}: {}", src, err),
+            }
+        }
+        if meshcom.forward_telegram && source_allowed(&meshcom.telegram_allowed_sources, src) {
+            match self.forward_telegram(meshcom, src, text) {
+                Ok(()) => paths.push("telegram".to_string()),
+                Err(err) => tracing::warn!("MeshCom: Telegram forwarding failed src={}: {}", src, err),
+            }
+        }
+
+        if paths.is_empty()
+            && (meshcom.forward_sds || meshcom.forward_sip || meshcom.forward_telegram)
+        {
+            tracing::info!(
+                "MeshCom: received message src={} dst={} with no successful forwarding target",
+                src,
+                dst.unwrap_or("-")
+            );
+        } else if !paths.is_empty() {
+            tracing::info!(
+                "MeshCom: forwarded message src={} dst={} paths={}",
+                src,
+                dst.unwrap_or("-"),
+                paths.join(",")
+            );
+        }
+        paths
+    }
+
+    fn forward_sds(&self, meshcom: &CfgMeshcom, src: &str, text: &str) -> Result<(), String> {
+        if meshcom.sds_dest_issi == 0 {
+            return Err("sds_dest_issi is 0".to_string());
+        }
+        let Some(tx) = &self.cmce_cmd_tx else {
+            return Err("CMCE control sender unavailable".to_string());
+        };
+        let body = format_plain_meshcom_message(src, text);
+        let (len_bits, payload) = build_sds_text_payload(&body);
+        tx.send(ControlCommand::SendSds {
+            handle: 0,
+            source_ssi: meshcom.sds_source_issi,
+            dest_ssi: meshcom.sds_dest_issi,
+            dest_is_group: meshcom.sds_dest_is_group,
+            len_bits,
+            payload,
+        })
+        .map_err(|e| format!("send to CMCE failed: {}", e))
+    }
+
+    fn forward_sip(
+        &self,
+        meshcom: &CfgMeshcom,
+        src: &str,
+        dst: Option<&str>,
+        text: &str,
+        msg_id: Option<&str>,
+    ) -> Result<(), String> {
+        let Some(sink) = &self.snom_sink else {
+            return Err("Snom notify sink unavailable".to_string());
+        };
+        sink.send_meshcom(
+            meshcom.sip_title_prefix.clone(),
+            src.to_string(),
+            dst.map(ToString::to_string),
+            text.to_string(),
+            msg_id.map(ToString::to_string),
+        );
+        Ok(())
+    }
+
+    fn forward_telegram(&self, meshcom: &CfgMeshcom, src: &str, text: &str) -> Result<(), String> {
+        let Some(sink) = &self.telegram_sink else {
+            return Err("Telegram alert sink unavailable".to_string());
+        };
+        sink.send_meshcom(
+            meshcom.telegram_prefix.clone(),
+            src.to_string(),
+            text.to_string(),
+        );
+        Ok(())
+    }
+
+    fn publish_status(
+        &self,
+        meshcom: &CfgMeshcom,
+        last_rx: Option<String>,
+        last_error: Option<String>,
+    ) {
+        let mut state = self.cfg.state_write();
+        let previous_tx_packets = state.meshcom_status.tx_packets;
+        let previous_last_tx = state.meshcom_status.last_tx.clone();
+        let previous_last_rx = state.meshcom_status.last_rx.clone();
+        let mut messages: Vec<MeshcomMessageStatus> = self.messages.iter().cloned().collect();
+        for msg in state
+            .meshcom_status
+            .messages
+            .iter()
+            .filter(|msg| msg.direction == "tx")
+        {
+            if messages.len() >= meshcom.max_messages {
+                break;
+            }
+            messages.push(msg.clone());
+        }
+        state.meshcom_status = MeshcomRuntimeStatus {
+            configured: true,
+            enabled: meshcom.enabled,
+            bind: format!("{}:{}", meshcom.bind_addr, meshcom.bind_port),
+            tx: format!("{}:{}", meshcom.tx_host, meshcom.tx_port),
+            rx_packets: self.rx_packets,
+            tx_packets: previous_tx_packets,
+            last_rx: last_rx.or(previous_last_rx),
+            last_tx: previous_last_tx,
+            last_error,
+            forward_sds: meshcom.forward_sds,
+            forward_sip: meshcom.forward_sip,
+            forward_telegram: meshcom.forward_telegram,
+            nodes: self.nodes.clone(),
+            messages,
+        };
+    }
+}
+
+fn now_stamp() -> String {
+    chrono::Local::now().format("%Y-%m-%d %H:%M:%S").to_string()
+}
+
+fn string_field(value: &Value, key: &str) -> Option<String> {
+    value
+        .get(key)
+        .and_then(|v| v.as_str())
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(ToString::to_string)
+}
+
+fn f64_field(value: &Value, key: &str) -> Option<f64> {
+    value.get(key).and_then(|v| {
+        v.as_f64()
+            .or_else(|| v.as_str().and_then(|s| s.trim().parse::<f64>().ok()))
+    })
+}
+
+fn i64_field(value: &Value, key: &str) -> Option<i64> {
+    value.get(key).and_then(|v| {
+        v.as_i64()
+            .or_else(|| v.as_u64().and_then(|n| i64::try_from(n).ok()))
+            .or_else(|| v.as_str().and_then(|s| s.trim().parse::<i64>().ok()))
+    })
+}
+
+fn signed_coord(value: Option<f64>, dir: Option<&str>) -> Option<f64> {
+    let mut value = value?;
+    if matches!(dir.map(|d| d.trim().to_ascii_uppercase()), Some(d) if d == "S" || d == "W") {
+        value = -value.abs();
+    }
+    Some(value)
+}
+
+fn truncate_chars(text: &str, max_chars: usize) -> String {
+    if text.chars().count() <= max_chars {
+        return text.to_string();
+    }
+    text.chars().take(max_chars).collect()
+}
+
+fn source_allowed(allowed: &BTreeSet<String>, src: &str) -> bool {
+    if allowed.is_empty() {
+        return true;
+    }
+    let src = src.trim().to_ascii_uppercase();
+    allowed.contains(&src)
+}
+
+fn format_plain_meshcom_message(src: &str, text: &str) -> String {
+    format!("MeshCom: {} - {}", src.trim(), text.trim())
+}

--- a/crates/tetra-entities/src/net_meshcom/mod.rs
+++ b/crates/tetra-entities/src/net_meshcom/mod.rs
@@ -11,11 +11,10 @@ use std::thread;
 use std::time::Duration;
 
 use serde_json::Value;
-use tetra_config::bluestation::{
-    CfgMeshcom, MeshcomMessageStatus, MeshcomNodeStatus, MeshcomRuntimeStatus, SharedConfig,
-};
+use tetra_config::bluestation::{CfgMeshcom, MeshcomMessageStatus, MeshcomNodeStatus, MeshcomRuntimeStatus, SharedConfig};
 
 use crate::net_control::commands::ControlCommand;
+use crate::net_geoalarm::GeoAlarmSink;
 use crate::net_snom::SnomNotifySink;
 use crate::net_telegram::TelegramAlertSink;
 use crate::tpg2200::build_sds_text_payload;
@@ -31,10 +30,11 @@ pub fn spawn_meshcom_worker(
     cmce_cmd_tx: Option<CmdSender>,
     telegram_sink: Option<TelegramAlertSink>,
     snom_sink: Option<SnomNotifySink>,
+    geoalarm_sink: Option<GeoAlarmSink>,
 ) -> Option<thread::JoinHandle<()>> {
     match thread::Builder::new()
         .name("meshcom-worker".into())
-        .spawn(move || MeshcomWorker::new(cfg, cmce_cmd_tx, telegram_sink, snom_sink).run())
+        .spawn(move || MeshcomWorker::new(cfg, cmce_cmd_tx, telegram_sink, snom_sink, geoalarm_sink).run())
     {
         Ok(handle) => Some(handle),
         Err(err) => {
@@ -49,6 +49,7 @@ struct MeshcomWorker {
     cmce_cmd_tx: Option<CmdSender>,
     telegram_sink: Option<TelegramAlertSink>,
     snom_sink: Option<SnomNotifySink>,
+    geoalarm_sink: Option<GeoAlarmSink>,
     socket: Option<UdpSocket>,
     bind_key: String,
     rx_packets: u64,
@@ -63,12 +64,14 @@ impl MeshcomWorker {
         cmce_cmd_tx: Option<CmdSender>,
         telegram_sink: Option<TelegramAlertSink>,
         snom_sink: Option<SnomNotifySink>,
+        geoalarm_sink: Option<GeoAlarmSink>,
     ) -> Self {
         Self {
             cfg,
             cmce_cmd_tx,
             telegram_sink,
             snom_sink,
+            geoalarm_sink,
             socket: None,
             bind_key: String::new(),
             rx_packets: 0,
@@ -135,9 +138,7 @@ impl MeshcomWorker {
                         }
                     }
                 }
-                Err(err)
-                    if err.kind() == std::io::ErrorKind::WouldBlock
-                        || err.kind() == std::io::ErrorKind::TimedOut => {}
+                Err(err) if err.kind() == std::io::ErrorKind::WouldBlock || err.kind() == std::io::ErrorKind::TimedOut => {}
                 Err(err) => {
                     let msg = format!("UDP receive failed: {err}");
                     tracing::warn!("MeshCom: {}", msg);
@@ -204,6 +205,10 @@ impl MeshcomWorker {
             msg.as_deref(),
             msg_id.as_deref(),
         );
+
+        if let (Some(sink), Some(source), Some(lat), Some(lon)) = (&self.geoalarm_sink, src.as_ref(), lat, lon) {
+            sink.send_meshcom_position(source.clone(), lat, lon);
+        }
 
         self.rx_packets = self.rx_packets.saturating_add(1);
         let event = MeshcomMessageStatus {
@@ -326,9 +331,7 @@ impl MeshcomWorker {
             }
         }
 
-        if paths.is_empty()
-            && (meshcom.forward_sds || meshcom.forward_sip || meshcom.forward_telegram)
-        {
+        if paths.is_empty() && (meshcom.forward_sds || meshcom.forward_sip || meshcom.forward_telegram) {
             tracing::info!(
                 "MeshCom: received message src={} dst={} with no successful forwarding target",
                 src,
@@ -365,14 +368,7 @@ impl MeshcomWorker {
         .map_err(|e| format!("send to CMCE failed: {}", e))
     }
 
-    fn forward_sip(
-        &self,
-        meshcom: &CfgMeshcom,
-        src: &str,
-        dst: Option<&str>,
-        text: &str,
-        msg_id: Option<&str>,
-    ) -> Result<(), String> {
+    fn forward_sip(&self, meshcom: &CfgMeshcom, src: &str, dst: Option<&str>, text: &str, msg_id: Option<&str>) -> Result<(), String> {
         let Some(sink) = &self.snom_sink else {
             return Err("Snom notify sink unavailable".to_string());
         };
@@ -390,31 +386,17 @@ impl MeshcomWorker {
         let Some(sink) = &self.telegram_sink else {
             return Err("Telegram alert sink unavailable".to_string());
         };
-        sink.send_meshcom(
-            meshcom.telegram_prefix.clone(),
-            src.to_string(),
-            text.to_string(),
-        );
+        sink.send_meshcom(meshcom.telegram_prefix.clone(), src.to_string(), text.to_string());
         Ok(())
     }
 
-    fn publish_status(
-        &self,
-        meshcom: &CfgMeshcom,
-        last_rx: Option<String>,
-        last_error: Option<String>,
-    ) {
+    fn publish_status(&self, meshcom: &CfgMeshcom, last_rx: Option<String>, last_error: Option<String>) {
         let mut state = self.cfg.state_write();
         let previous_tx_packets = state.meshcom_status.tx_packets;
         let previous_last_tx = state.meshcom_status.last_tx.clone();
         let previous_last_rx = state.meshcom_status.last_rx.clone();
         let mut messages: Vec<MeshcomMessageStatus> = self.messages.iter().cloned().collect();
-        for msg in state
-            .meshcom_status
-            .messages
-            .iter()
-            .filter(|msg| msg.direction == "tx")
-        {
+        for msg in state.meshcom_status.messages.iter().filter(|msg| msg.direction == "tx") {
             if messages.len() >= meshcom.max_messages {
                 break;
             }
@@ -453,10 +435,9 @@ fn string_field(value: &Value, key: &str) -> Option<String> {
 }
 
 fn f64_field(value: &Value, key: &str) -> Option<f64> {
-    value.get(key).and_then(|v| {
-        v.as_f64()
-            .or_else(|| v.as_str().and_then(|s| s.trim().parse::<f64>().ok()))
-    })
+    value
+        .get(key)
+        .and_then(|v| v.as_f64().or_else(|| v.as_str().and_then(|s| s.trim().parse::<f64>().ok())))
 }
 
 fn i64_field(value: &Value, key: &str) -> Option<i64> {

--- a/crates/tetra-entities/tests/common/default_stack.rs
+++ b/crates/tetra-entities/tests/common/default_stack.rs
@@ -1,7 +1,6 @@
 use tetra_config::bluestation::{
-    CfgAsterisk, CfgCellInfo, CfgDapnet, CfgEmergency, CfgGeoalarm, CfgHealth, CfgNetInfo, CfgPhyIo, CfgRecovery, CfgSecurity,
-    CfgMeshcom, CfgSnomNotify, CfgTpg2200Action, CfgWxService, PhyBackend,
-    StackConfig, StackMode,
+    CfgAsterisk, CfgCellInfo, CfgDapnet, CfgEmergency, CfgGeoalarm, CfgHealth, CfgMeshcom, CfgNetInfo, CfgPhyIo, CfgRecovery, CfgSecurity,
+    CfgSnomNotify, CfgTpg2200Action, CfgWxService, PhyBackend, StackConfig, StackMode,
 };
 use tetra_core::{freqs::FreqInfo, ranges::SortedDisjointSsiRanges};
 

--- a/crates/tetra-entities/tests/common/default_stack.rs
+++ b/crates/tetra-entities/tests/common/default_stack.rs
@@ -1,6 +1,7 @@
 use tetra_config::bluestation::{
     CfgAsterisk, CfgCellInfo, CfgDapnet, CfgEmergency, CfgGeoalarm, CfgHealth, CfgNetInfo, CfgPhyIo, CfgRecovery, CfgSecurity,
-    CfgSnomNotify, CfgTpg2200Action, CfgWxService, PhyBackend, StackConfig, StackMode,
+    CfgMeshcom, CfgSnomNotify, CfgTpg2200Action, CfgWxService, PhyBackend,
+    StackConfig, StackMode,
 };
 use tetra_core::{freqs::FreqInfo, ranges::SortedDisjointSsiRanges};
 
@@ -24,6 +25,7 @@ pub fn default_test_config_bs() -> StackConfig {
         asterisk: CfgAsterisk::default(),
         dapnet: CfgDapnet::default(),
         geoalarm: CfgGeoalarm::default(),
+        meshcom: CfgMeshcom::default(),
         tpg2200_action: CfgTpg2200Action::default(),
         snom_notify: CfgSnomNotify::default(),
         dashboard: None,

--- a/example_config/config.toml
+++ b/example_config/config.toml
@@ -495,6 +495,41 @@ voice_service = true
 
 ###############################################################################
 
+# OPTIONAL: MeshCom external UDP bridge
+#
+# FlowStation can listen for MeshCom extUDP JSON packets (msg/pos/tele) and send
+# text messages back to a MeshCom node. On the node side, point extUDP to the
+# FlowStation host and enable it, for example:
+#   --extudpip <flowstation-ip>
+#   --extudp on
+#
+# [meshcom]
+# enabled = false
+# bind_addr = "0.0.0.0"
+# bind_port = 1799
+# tx_host = "255.255.255.255"
+# tx_port = 1799
+# allow_broadcast = true
+# max_messages = 500
+# max_nodes = 1000
+#
+# forward_sds = false
+# forward_sip = false                  # sends SnomIPPhoneText via the existing [snom_notify] AMI setup
+# forward_telegram = false
+#
+# sds_source_issi = 9999
+# sds_dest_issi = 0                    # 0 = not configured
+# sds_dest_is_group = false
+# sds_allowed_sources = []             # empty = every MeshCom source; examples: ["DJ2TH", "OE1ABC-12"]
+#
+# sip_title_prefix = "MeshCom"
+# sip_allowed_sources = []             # empty = every MeshCom source
+#
+# telegram_prefix = "MeshCom"
+# telegram_allowed_sources = []        # empty = every MeshCom source
+
+###############################################################################
+
 # OPTIONAL: Emergency-state handling (FlowStation)
 #
 # A radio signals emergency with a U-STATUS PDU (pre_coded_status = Emergency, status 0,


### PR DESCRIPTION
## Summary

- add the MeshCom extUDP worker and configuration
- forward MeshCom messages to SDS, Snom/SIP notifications, and Telegram
- expose MeshCom runtime status, nodes, messages, send controls, and persistence in the dashboard
- add an OpenStreetMap dashboard view combining TETRA LIP, MeshCom, GeoAlarm, and configured FlowStation positions
- route MeshCom position packets into GeoAlarm
- fix DAPNET callsign attribution and short Skyper rubric decoding
- keep DAPNET health healthy when no forwarding path is configured
- hide historic RIC placeholders from the DAPNET callsign column and exports
- update the example configuration and documentation

## Validation

- `DOCS_RS=1 cargo check -p tetra-entities --lib`
- `DOCS_RS=1 cargo check -p bluestation-bs --no-default-features`
- `cargo test -p tetra-config` — 29 tests passed
- `DOCS_RS=1 cargo test -p tetra-entities net_dapnet --lib` — 8 tests passed
- `rustfmt --edition 2021 --check crates/tetra-entities/src/net_dapnet/mod.rs`
- embedded dashboard JavaScript syntax and required DOM IDs validated

## Remaining verification

A hardware/runtime test with a real MeshCom extUDP node, live DAPNET RWTH feed, and SoapySDR installation is still recommended.