### PR TITLE
Fix for Brew to CMCE

### DIFF
--- a/crates/tetra-entities/src/cmce/cmce_bs.rs
+++ b/crates/tetra-entities/src/cmce/cmce_bs.rs
@@ -4,6 +4,7 @@ use crate::{MessageQueue, TetraEntityTrait};
 use tetra_config::bluestation::SharedConfig;
 use tetra_core::tetra_entities::TetraEntity;
 use tetra_core::{Sap, TdmaTime, unimplemented_log};
+use tetra_saps::control::brew::BrewSubscriberAction;
 use tetra_saps::{SapMsg, SapMsgInner};
 
 use super::components::pc_bs::{ControlRoute, LcmcRoute, PcBs};
@@ -236,7 +237,7 @@ impl TetraEntityTrait for CmceBs {
     }
 
     fn rx_prim(&mut self, queue: &mut MessageQueue, message: SapMsg) {
-        tracing::debug!("rx_prim: {:?}", message);
+        tracing::trace!("rx_prim: {:?}", message);
         // tracing::debug!(ts=%message.dltime, "rx_prim: {:?}", message);
 
         match message.sap {
@@ -253,9 +254,24 @@ impl TetraEntityTrait for CmceBs {
                     self.cc.rx_call_control(queue, message);
                 }
                 ControlRoute::CcSubscriberUpdate => {
+                    let source = message.src;
                     let SapMsgInner::MmSubscriberUpdate(update) = message.msg else {
                         unreachable!();
                     };
+                    if source == TetraEntity::Brew {
+                        if !crate::net_brew::is_brew_external_subscriber_allowed(&self.config, update.issi) {
+                            tracing::trace!(
+                                "CMCE: ignoring Brew subscriber update issi={} action={:?}",
+                                update.issi,
+                                update.action
+                            );
+                            return;
+                        }
+                        if update.action == BrewSubscriberAction::Register && update.groups.is_empty() {
+                            tracing::trace!("CMCE: ignoring Brew presence-only register issi={}", update.issi);
+                            return;
+                        }
+                    }
                     self.cc.handle_subscriber_update(queue, update);
                 }
                 ControlRoute::SdsRc => {

--- a/crates/tetra-entities/src/cmce/subentities/cc_bs/pdu.rs
+++ b/crates/tetra-entities/src/cmce/subentities/cc_bs/pdu.rs
@@ -418,8 +418,10 @@ impl CcBsSubentity {
                         self.dec_group_listener(gssi);
                         self.drop_group_calls_if_unlistened(queue, gssi);
                     }
+                    tracing::debug!("CMCE: subscriber deregister issi={}", issi);
+                } else {
+                    tracing::trace!("CMCE: subscriber deregister ignored unknown issi={}", issi);
                 }
-                tracing::info!("CMCE: subscriber deregister issi={}", issi);
             }
             BrewSubscriberAction::Affiliate => {
                 let mut new_groups = Vec::new();

--- a/crates/tetra-entities/src/net_brew/components/brew_routable.rs
+++ b/crates/tetra-entities/src/net_brew/components/brew_routable.rs
@@ -73,6 +73,16 @@ pub fn is_brew_inbound_allowed(config: &SharedConfig, ssi: u32) -> bool {
     is_active(config) && !config.config().cell.local_ssi_ranges.contains(ssi)
 }
 
+/// Determine whether Brew-originated external subscriber state may be mirrored into CMCE.
+///
+/// Subscriber events for a local-only SSI are looped-back state, not external listeners.
+/// Filtering them at the Brew boundary avoids needless CMCE queue traffic and prevents local
+/// subscribers from being represented a second time as network subscribers.
+#[inline]
+pub fn is_brew_external_subscriber_allowed(config: &SharedConfig, issi: u32) -> bool {
+    is_active(config) && !config.config().cell.local_ssi_ranges.contains(issi)
+}
+
 /// Determine if a given ISSI should be sent to the Brew server.
 /// On TetraPack, subscriber ISSIs must be 7 digits (1_000_000..=9_999_999).
 /// Special service ISSIs (e.g. 600 echo, short numbers) are always forwarded to Brew —
@@ -88,5 +98,54 @@ pub fn is_brew_issi_routable(config: &SharedConfig, issi: u32) -> bool {
         (issi >= 1_000_000 && issi <= 9_999_999) || issi < 1_000_000 || is_pbx_gateway_issi(config, issi)
     } else {
         true
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tetra_config::bluestation::{SharedConfig, parsing::from_toml_str};
+
+    fn shared_config(extra_cell: &str) -> SharedConfig {
+        let toml = format!(
+            r#"
+config_version = "0.6"
+stack_mode = "Bs"
+
+[phy_io]
+backend = "None"
+
+[net_info]
+mcc = 901
+mnc = 9999
+
+[cell_info]
+main_carrier = 1584
+freq_band = 4
+freq_offset = 0
+duplex_spacing = 4
+reverse_operation = false
+location_area = 1
+{}
+
+[brew]
+host = "example.invalid"
+port = 443
+tls = true
+username = 0
+password = ""
+"#,
+            extra_cell
+        );
+        SharedConfig::from_parts(from_toml_str(&toml).expect("test config parses"), None)
+    }
+
+    #[test]
+    fn external_subscriber_state_respects_local_ssi_ranges() {
+        let cfg = shared_config("local_ssi_ranges = [[999, 999], [9998, 9999]]");
+
+        assert!(!is_brew_external_subscriber_allowed(&cfg, 999));
+        assert!(!is_brew_external_subscriber_allowed(&cfg, 9999));
+        assert!(is_brew_external_subscriber_allowed(&cfg, 2632585));
     }
 }

--- a/crates/tetra-entities/src/net_brew/entity.rs
+++ b/crates/tetra-entities/src/net_brew/entity.rs
@@ -281,7 +281,7 @@ impl BrewEntity {
                     tracing::debug!("BrewEntity: SDS report uuid={} status={}", uuid, status);
                 }
                 BrewEvent::SubscriberEvent { msg_type, issi, groups } => {
-                    tracing::debug!("BrewEntity: subscriber event type={} issi={} groups={:?}", msg_type, issi, groups);
+                    tracing::trace!("BrewEntity: subscriber event type={} issi={} groups={:?}", msg_type, issi, groups);
                     // External subscriber (e.g. SvxLink gateway) affiliated/deaffiliated on Brew server.
                     // Notify CMCE so it updates group_listeners — without this, has_listener()
                     // returns false for GSSIs where only external subscribers are present,
@@ -289,46 +289,28 @@ impl BrewEntity {
                     match msg_type {
                         crate::net_brew::protocol::BREW_SUBSCRIBER_AFFILIATE => {
                             if !groups.is_empty() {
-                                tracing::info!("BrewEntity: external subscriber issi={} → AFFILIATE groups={:?}", issi, groups);
-                                queue.push_back(SapMsg {
-                                    sap: tetra_core::Sap::Control,
-                                    src: TetraEntity::Brew,
-                                    dest: TetraEntity::Cmce,
-                                    msg: SapMsgInner::MmSubscriberUpdate(MmSubscriberUpdate {
-                                        issi,
-                                        groups: groups.clone(),
-                                        action: BrewSubscriberAction::Affiliate,
-                                    }),
-                                });
+                                self.queue_external_subscriber_update(
+                                    queue,
+                                    issi,
+                                    groups.clone(),
+                                    BrewSubscriberAction::Affiliate,
+                                    "AFFILIATE",
+                                );
                             }
                         }
                         crate::net_brew::protocol::BREW_SUBSCRIBER_DEAFFILIATE => {
                             if !groups.is_empty() {
-                                tracing::info!("BrewEntity: external subscriber issi={} → DEAFFILIATE groups={:?}", issi, groups);
-                                queue.push_back(SapMsg {
-                                    sap: tetra_core::Sap::Control,
-                                    src: TetraEntity::Brew,
-                                    dest: TetraEntity::Cmce,
-                                    msg: SapMsgInner::MmSubscriberUpdate(MmSubscriberUpdate {
-                                        issi,
-                                        groups: groups.clone(),
-                                        action: BrewSubscriberAction::Deaffiliate,
-                                    }),
-                                });
+                                self.queue_external_subscriber_update(
+                                    queue,
+                                    issi,
+                                    groups.clone(),
+                                    BrewSubscriberAction::Deaffiliate,
+                                    "DEAFFILIATE",
+                                );
                             }
                         }
                         crate::net_brew::protocol::BREW_SUBSCRIBER_DEREGISTER => {
-                            tracing::info!("BrewEntity: external subscriber issi={} → DEREGISTER", issi);
-                            queue.push_back(SapMsg {
-                                sap: tetra_core::Sap::Control,
-                                src: TetraEntity::Brew,
-                                dest: TetraEntity::Cmce,
-                                msg: SapMsgInner::MmSubscriberUpdate(MmSubscriberUpdate {
-                                    issi,
-                                    groups: Vec::new(),
-                                    action: BrewSubscriberAction::Deregister,
-                                }),
-                            });
+                            self.queue_external_subscriber_update(queue, issi, Vec::new(), BrewSubscriberAction::Deregister, "DEREGISTER");
                         }
                         _ => {}
                     }
@@ -484,6 +466,37 @@ impl BrewEntity {
                 }
             }
         }
+    }
+
+    fn queue_external_subscriber_update(
+        &self,
+        queue: &mut MessageQueue,
+        issi: u32,
+        groups: Vec<u32>,
+        action: BrewSubscriberAction,
+        action_label: &str,
+    ) {
+        if !super::is_brew_external_subscriber_allowed(&self.config, issi) {
+            tracing::trace!(
+                "BrewEntity: external subscriber issi={} → {} ignored (local SSI range)",
+                issi,
+                action_label
+            );
+            return;
+        }
+
+        tracing::trace!(
+            "BrewEntity: external subscriber issi={} → {} groups={:?}",
+            issi,
+            action_label,
+            groups
+        );
+        queue.push_back(SapMsg {
+            sap: tetra_core::Sap::Control,
+            src: TetraEntity::Brew,
+            dest: TetraEntity::Cmce,
+            msg: SapMsgInner::MmSubscriberUpdate(MmSubscriberUpdate { issi, groups, action }),
+        });
     }
 
     /// Handle RSSI update from MM. Forwards to Brew server if feature_rssi_export is enabled,

--- a/crates/tetra-entities/src/net_brew/mod.rs
+++ b/crates/tetra-entities/src/net_brew/mod.rs
@@ -12,6 +12,7 @@ pub mod worker;
 pub use components::brew_routable::feature_sds_enabled;
 /// Convenience re-export of commonly externally used functions
 pub use components::brew_routable::is_active;
+pub use components::brew_routable::is_brew_external_subscriber_allowed;
 pub use components::brew_routable::is_brew_gssi_routable;
 pub use components::brew_routable::is_brew_inbound_allowed;
 pub use components::brew_routable::is_brew_issi_routable;


### PR DESCRIPTION
## Summary

- filter Brew subscriber events for `local_ssi_ranges` before they enter the CMCE queue
- add a defensive CMCE guard for local SSI updates and presence-only Brew registrations
- reduce high-frequency subscriber logging and make unknown deregistrations cheap no-ops
- keep valid external affiliation/deaffiliation state, voice calls, and SDS routing unchanged

## Validation

- `DOCS_RS=1 cargo test -p tetra-entities --lib` — 188 passed, 5 ignored
- `DOCS_RS=1 cargo check -p bluestation-bs --no-default-features`
- targeted regression test for local/external SSI filtering
- `rustfmt --edition 2024 --check` on all changed Rust files
- `git diff --check`