### PR TITLE
SS-DGNA framing fix + dashboard security hardening

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1867,6 +1867,7 @@ dependencies = [
  "chrono",
  "chrono-tz",
  "crossbeam-channel",
+ "libc",
  "md5",
  "num",
  "num-complex",

--- a/bins/bluestation-bs/src/main.rs
+++ b/bins/bluestation-bs/src/main.rs
@@ -38,6 +38,13 @@ use tetra_entities::{
     umac::umac_bs::UmacBs,
 };
 
+/// True if the dashboard bind address resolves to a loopback interface only.
+/// Used to decide whether to warn about an unauthenticated, off-host-reachable dashboard.
+/// A non-parseable / hostname bind is treated as non-loopback (warn rather than stay silent).
+fn bind_is_loopback(bind: &str) -> bool {
+    bind.parse::<std::net::IpAddr>().map(|ip| ip.is_loopback()).unwrap_or(false)
+}
+
 /// Result of loading config — either primary or fallback.
 enum ConfigLoadResult {
     Primary(StackConfig),
@@ -433,6 +440,17 @@ fn main() {
             if let (Some(user), Some(pass)) = (dash_cfg.username.clone(), dash_cfg.password.clone()) {
                 tracing::info!("Dashboard: HTTP Basic Auth enabled (user: {})", user);
                 dashboard.set_auth(Some((user, pass)));
+            } else if !bind_is_loopback(&dash_cfg.bind) {
+                // No credentials AND a non-loopback bind: the dashboard is reachable from the
+                // network with no login. The request handler still hard-gates every mutating
+                // endpoint to localhost in this state, but read-only views are exposed, so warn
+                // loudly. Set both username and password to require login, or bind to 127.0.0.1.
+                tracing::warn!(
+                    "Dashboard is UNAUTHENTICATED and bound to {} (reachable off-host). \
+                     Set [dashboard] username+password, or bind to 127.0.0.1. \
+                     Until then, mutating requests are restricted to localhost.",
+                    dash_cfg.bind
+                );
             }
 
             // Optional anonymous read-only public overview (FH-FEAT-033). Inert unless auth is set;

--- a/crates/tetra-config/src/bluestation/sec_dashboard.rs
+++ b/crates/tetra-config/src/bluestation/sec_dashboard.rs
@@ -7,7 +7,9 @@ use toml::Value;
 pub struct CfgDashboard {
     /// Port to listen on (default: 8080)
     pub port: u16,
-    /// Bind address (default: 0.0.0.0)
+    /// Bind address (default: 127.0.0.1 — loopback only).
+    /// Off-host access is opt-in: set this to an interface address (or 0.0.0.0) explicitly, and
+    /// set username/password so the dashboard is not left open on the LAN.
     pub bind: String,
     /// Optional explicit path to the FlowStation git source directory used for OTA updates.
     /// When unset, the dashboard auto-detects by:
@@ -37,7 +39,7 @@ impl Default for CfgDashboard {
     fn default() -> Self {
         Self {
             port: 8080,
-            bind: "0.0.0.0".to_string(),
+            bind: "127.0.0.1".to_string(),
             source_dir: None,
             username: None,
             password: None,
@@ -71,7 +73,10 @@ fn default_port() -> u16 {
     8080
 }
 fn default_bind() -> String {
-    "0.0.0.0".to_string()
+    // Loopback by default: a config that enables [dashboard] without an explicit bind stays
+    // localhost-only. An operator who wants LAN access sets `bind` (and credentials) deliberately.
+    // Configs that already set `bind` keep their value.
+    "127.0.0.1".to_string()
 }
 
 pub fn apply_dashboard_patch(src: CfgDashboardDto) -> Result<CfgDashboard, String> {

--- a/crates/tetra-entities/Cargo.toml
+++ b/crates/tetra-entities/Cargo.toml
@@ -42,5 +42,9 @@ chrono-tz = { workspace = true }
 # both uses run on their own short-lived threads.
 reqwest = { version = "0.12", default-features = false, features = ["blocking", "rustls-tls", "json"] }
 
+# Unix-only: geteuid() for the OTA source-tree ownership check (dashboard build path).
+[target.'cfg(unix)'.dependencies]
+libc = "0.2"
+
 [lints]
 workspace = true

--- a/crates/tetra-entities/src/cmce/subentities/ss_bs.rs
+++ b/crates/tetra-entities/src/cmce/subentities/ss_bs.rs
@@ -80,7 +80,7 @@ impl SsBsSubentity {
         };
 
         let pdu = DFacility {
-            facility: Some(DFacilitySsBody { routeing: 0, ss_pdu }),
+            facility: Some(DFacilitySsBody { ss_pdu }),
         };
 
         let mut sdu = BitBuffer::new_autoexpand(32);

--- a/crates/tetra-entities/src/net_dashboard/html.rs
+++ b/crates/tetra-entities/src/net_dashboard/html.rs
@@ -4752,20 +4752,28 @@ async function wifiLoadSaved(){
       el.innerHTML = `<div class="wifi-list-empty">${t('wifi_no_saved')||'No saved networks.'}</div>`;
       return;
     }
-    el.innerHTML = wifiState.saved.map(p => `
-      <div class="wifi-row ${p.active?'active':''}">
-        <div class="wifi-row-main">
-          <div class="wifi-row-ssid">
-            ${escHtml(p.name)}
-            ${p.active ? `<span class="wifi-tag active">${t('wifi_connected')||'CONNECTED'}</span>` : ''}
-          </div>
-        </div>
-        <div class="wifi-row-actions">
-          ${p.active ? '' : `<button class="btn btn-sm" onclick="wifiConnectSaved('${escAttr(p.uuid)}')">${t('wifi_connect')||'Connect'}</button>`}
-          <button class="btn btn-sm btn-danger" onclick="wifiForget('${escAttr(p.uuid)}','${escAttr(p.name)}')">${t('wifi_forget')||'Forget'}</button>
-        </div>
-      </div>
-    `).join('');
+    // Build rows with the DOM so the profile name/uuid never enter an inline handler string: a saved
+    // SSID/name is raw 802.11 data set by whoever broadcast the AP, and an inline onclick would let it
+    // break out of the attribute and run as script. textContent + closures keep it inert.
+    el.innerHTML = '';
+    wifiState.saved.forEach(p => {
+      const row=document.createElement('div');
+      row.className='wifi-row'+(p.active?' active':'');
+      const main=document.createElement('div');main.className='wifi-row-main';
+      const ssid=document.createElement('div');ssid.className='wifi-row-ssid';
+      ssid.appendChild(document.createTextNode(p.name||''));
+      if(p.active){const tag=document.createElement('span');tag.className='wifi-tag active';tag.textContent=' '+(t('wifi_connected')||'CONNECTED');ssid.appendChild(tag);}
+      main.appendChild(ssid);row.appendChild(main);
+      const actions=document.createElement('div');actions.className='wifi-row-actions';
+      if(!p.active){
+        const b=document.createElement('button');b.className='btn btn-sm';b.textContent=t('wifi_connect')||'Connect';
+        b.onclick=()=>wifiConnectSaved(p.uuid);actions.appendChild(b);
+      }
+      const forget=document.createElement('button');forget.className='btn btn-sm btn-danger';forget.textContent=t('wifi_forget')||'Forget';
+      forget.onclick=()=>wifiForget(p.uuid,p.name);actions.appendChild(forget);
+      row.appendChild(actions);
+      el.appendChild(row);
+    });
   }catch(e){
     el.innerHTML = `<div class="wifi-list-empty" style="color:var(--danger)">${escHtml(String(e))}</div>`;
   }
@@ -4784,38 +4792,42 @@ async function wifiScan(){
       el.innerHTML = `<div class="wifi-list-empty">${t('wifi_no_networks')||'No networks in range.'}</div>`;
       return;
     }
-    el.innerHTML = wifiState.scan.map(n => {
-      const bars = wifiSignalBars(n.signal);
+    // Build rows with the DOM. A scanned SSID is raw 802.11 data from whoever is broadcasting in
+    // range, so it must never enter an inline handler string — textContent + onclick closures keep it
+    // inert. wifiSignalBars() is static, trusted markup, so it stays as innerHTML on its own cell.
+    el.innerHTML = '';
+    wifiState.scan.forEach(n => {
       const isOpen = !n.security || n.security === '--';
       const secCls = isOpen ? 'sec open' : 'sec';
       const secLabel = isOpen ? (t('wifi_open')||'OPEN') : n.security;
-      const tags = [];
-      if(n.active) tags.push(`<span class="wifi-tag active">${t('wifi_connected')||'CONNECTED'}</span>`);
-      else if(n.saved) tags.push(`<span class="wifi-tag saved">${t('wifi_saved_tag')||'SAVED'}</span>`);
-      // Action button differs by state: if connected, no action; if saved,
-      // quick reconnect; otherwise prompt for password.
-      let actionBtn = '';
+      const row=document.createElement('div');
+      row.className='wifi-row'+(n.active?' active':'');
+
+      const sig=document.createElement('div');sig.className='wifi-row-signal';sig.innerHTML=wifiSignalBars(n.signal);row.appendChild(sig);
+
+      const main=document.createElement('div');main.className='wifi-row-main';
+      const ssid=document.createElement('div');ssid.className='wifi-row-ssid';
+      ssid.appendChild(document.createTextNode(n.ssid||''));
+      if(n.active){const tag=document.createElement('span');tag.className='wifi-tag active';tag.textContent=' '+(t('wifi_connected')||'CONNECTED');ssid.appendChild(tag);}
+      else if(n.saved){const tag=document.createElement('span');tag.className='wifi-tag saved';tag.textContent=' '+(t('wifi_saved_tag')||'SAVED');ssid.appendChild(tag);}
+      main.appendChild(ssid);
+      const meta=document.createElement('div');meta.className='wifi-row-meta';
+      const sg=document.createElement('span');sg.textContent=n.signal+'%';meta.appendChild(sg);
+      const sec=document.createElement('span');sec.className=secCls;sec.textContent=secLabel;meta.appendChild(sec);
+      main.appendChild(meta);
+      row.appendChild(main);
+
+      // Action button differs by state: connected = none; saved = quick reconnect; else prompt for password.
+      const actions=document.createElement('div');actions.className='wifi-row-actions';
       if(!n.active){
-        if(n.saved){
-          actionBtn = `<button class="btn btn-sm" onclick="wifiConnectBySsid('${escAttr(n.ssid)}')">${t('wifi_connect')||'Connect'}</button>`;
-        } else {
-          actionBtn = `<button class="btn btn-sm btn-primary" onclick="wifiShowPasswordModal('${escAttr(n.ssid)}',${isOpen?'true':'false'})">${t('wifi_connect')||'Connect'}</button>`;
-        }
+        const b=document.createElement('button');
+        if(n.saved){b.className='btn btn-sm';b.textContent=t('wifi_connect')||'Connect';b.onclick=()=>wifiConnectBySsid(n.ssid);}
+        else{b.className='btn btn-sm btn-primary';b.textContent=t('wifi_connect')||'Connect';b.onclick=()=>wifiShowPasswordModal(n.ssid,isOpen);}
+        actions.appendChild(b);
       }
-      return `
-        <div class="wifi-row ${n.active?'active':''}">
-          <div class="wifi-row-signal">${bars}</div>
-          <div class="wifi-row-main">
-            <div class="wifi-row-ssid">${escHtml(n.ssid)} ${tags.join(' ')}</div>
-            <div class="wifi-row-meta">
-              <span>${n.signal}%</span>
-              <span class="${secCls}">${escHtml(secLabel)}</span>
-            </div>
-          </div>
-          <div class="wifi-row-actions">${actionBtn}</div>
-        </div>
-      `;
-    }).join('');
+      row.appendChild(actions);
+      el.appendChild(row);
+    });
   }catch(e){
     el.innerHTML = `<div class="wifi-list-empty" style="color:var(--danger)">${escHtml(String(e))}</div>`;
   }
@@ -5015,7 +5027,9 @@ function renderEmergencyBanner(){
     // callsigns[issi] is an object {cs, fl} (see idCell/tsIssiText), not a string.
     const c=callsigns[e.issi];
     const fl=(c&&c.fl)?c.fl+' ':'';
-    const who=(c&&c.cs)?(e.issi+' · '+fl+c.cs):(''+e.issi);
+    // Escape the callsign before it goes into innerHTML below, mirroring idCell. The issi is numeric
+    // and fl is a flag emoji derived from the prefix, so only the callsign needs escaping.
+    const who=(c&&c.cs)?(e.issi+' · '+fl+escHtml(c.cs)):(''+e.issi);
     return `<span style="display:inline-flex;align-items:center;gap:6px;background:rgba(255,255,255,0.18);border-radius:4px;padding:2px 8px"><code style="color:#fff">${who}</code><button onclick="clearEmergency(${e.issi})" style="padding:1px 7px;background:#fff;color:var(--danger);border:none;border-radius:3px;font-weight:600;cursor:pointer;font-size:11px">${t('emg_clear')}</button></span>`;
   }).join('');
 }
@@ -5256,6 +5270,10 @@ function rssiPct(v){if(v==null)return 0;return Math.max(0,Math.min(100,(v+60)/50
 // usable=info, marginal=warn, weak/none=danger/idle.
 function rssiGaugeClass(v){if(v==null)return'is-idle';if(v>-20)return'';if(v>-30)return'is-info';if(v>-40)return'is-warn';return'is-danger';}
 function escHtml(s){return String(s).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;');}
+// Attribute-safe escape: like escHtml but also encodes the quote characters, so a value placed inside
+// a double- or single-quoted HTML attribute (e.g. title="...") cannot close the attribute and inject
+// an event handler. Use this for attribute values; escHtml is only safe in element text.
+function escHtmlAttr(s){return escHtml(s).replace(/"/g,'&quot;').replace(/'/g,'&#39;');}
 function renderAll(){renderStations();renderCalls();renderLastHeard();updateTsBlocksCarrier();}
 
 // ── TS Visualizer ─────────────────────────────────────────────────────────
@@ -7689,7 +7707,7 @@ function handleSysHealth(msg){
                : 2;
     const valColor = sensorColor(s.kind, s.value);
     return `<div class="sys-sensor-tile">
-      <div class="sys-sensor-label" title="${escHtml(s.name)}">${escHtml(s.name)}</div>
+      <div class="sys-sensor-label" title="${escHtmlAttr(s.name)}">${escHtml(s.name)}</div>
       <div class="sys-sensor-value" style="color:${valColor}">${s.value.toFixed(dp)} <span class="sys-sensor-unit">${unit}</span></div>
     </div>`;
   }).join('');

--- a/crates/tetra-entities/src/net_dashboard/radioid.rs
+++ b/crates/tetra-entities/src/net_dashboard/radioid.rs
@@ -18,6 +18,11 @@ const RPTR_API_URL_PREFIX: &str = "https://radioid.net/api/dmr/repeater/?id=";
 /// Politeness delay between successive API calls (each ID is fetched only once, ever).
 const FETCH_THROTTLE: Duration = Duration::from_millis(1100);
 const HTTP_TIMEOUT: Duration = Duration::from_secs(8);
+/// Cap on IDs queued/in-flight at once. The worker drains ~1/sec, so a client rotating distinct
+/// IDs could otherwise grow `pending` and the fetch channel without bound. Once this many are
+/// outstanding, new unseen IDs are dropped (returned as Pending, retried on a later request) instead
+/// of queued — they simply stay unresolved until the backlog clears.
+const MAX_PENDING: usize = 1024;
 
 /// Result of a callsign lookup.
 pub enum Lookup {
@@ -62,7 +67,10 @@ impl RadioIdCache {
             pending: HashSet::new(),
             path,
         }));
-        let (tx, rx) = crossbeam_channel::unbounded::<u32>();
+        // Bounded so a flood of distinct IDs can't grow the channel without bound; the matching
+        // `pending` cap keeps the set bounded too. The capacity matches MAX_PENDING so the set cap is
+        // what actually gates new work.
+        let (tx, rx) = crossbeam_channel::bounded::<u32>(MAX_PENDING);
         let worker_inner = Arc::clone(&inner);
         std::thread::Builder::new()
             .name("radioid-fetch".into())
@@ -81,8 +89,18 @@ impl RadioIdCache {
                 Entry::NotFound => Lookup::NotFound,
             };
         }
+        // Drop new work once the backlog is full, so a client rotating distinct IDs can't grow the
+        // pending set / fetch channel without bound. The ID stays unresolved and is retried on a
+        // later request once the worker has drained some of the backlog.
+        if inner.pending.len() >= MAX_PENDING {
+            return Lookup::Pending;
+        }
         if inner.pending.insert(issi) {
-            let _ = self.tx.send(issi);
+            // try_send (not send) so a momentarily-full bounded channel never blocks the request
+            // thread; on failure we back the ID out of `pending` so it can be re-queued later.
+            if self.tx.try_send(issi).is_err() {
+                inner.pending.remove(&issi);
+            }
         }
         Lookup::Pending
     }

--- a/crates/tetra-entities/src/net_dashboard/server.rs
+++ b/crates/tetra-entities/src/net_dashboard/server.rs
@@ -22,6 +22,14 @@ type CmdSender = crossbeam_channel::Sender<ControlCommand>;
 type WsBroadcastTx = crossbeam_channel::Sender<String>;
 type WsClients = Arc<Mutex<Vec<WsBroadcastTx>>>;
 
+/// Per-client outbound queue depth. A client that stops reading its socket fills this; once full,
+/// broadcast() drops the connection (its sender errors and is pruned) rather than buffering without
+/// bound. Sized for a burst of telemetry while a browser is briefly busy.
+const WS_CLIENT_QUEUE: usize = 256;
+/// Hard cap on concurrent WS clients, so many idle/non-draining connections can't grow memory and
+/// thread count without bound. New upgrades past this are refused.
+const WS_MAX_CLIENTS: usize = 64;
+
 // ---------------------------------------------------------------------------
 // OTA update state — shared between the HTTP handler and the update thread.
 // ---------------------------------------------------------------------------
@@ -258,6 +266,44 @@ fn resolve_source_dir(override_dir: Option<&str>) -> Result<std::path::PathBuf, 
     ))
 }
 
+/// Reject an OTA source tree that is not safe to build from. `cargo build` runs any `build.rs` /
+/// proc-macro in the tree as the service identity (often root), so before building we require the
+/// tree to be owned by us (the running euid) or by root, and to be neither group- nor world-writable
+/// (`mode & 0o022 == 0`). A tree another user can write into could plant a build script that runs as
+/// us — so a directory failing this check (whether auto-detected or supplied via the dashboard
+/// `source_dir`) is refused rather than compiled. Unix-only; returns `Ok(())` on platforms without
+/// the metadata.
+#[cfg(unix)]
+fn source_tree_is_trusted(dir: &std::path::Path) -> Result<(), String> {
+    use std::os::unix::fs::MetadataExt;
+
+    let meta = std::fs::metadata(dir).map_err(|e| format!("cannot stat source tree {}: {e}", dir.display()))?;
+    // SAFETY: geteuid() is always successful and has no preconditions.
+    let euid = unsafe { libc::geteuid() };
+    let owner = meta.uid();
+    if owner != euid && owner != 0 {
+        return Err(format!(
+            "source tree {} is owned by uid {} (we run as uid {}); refusing to build from a tree we don't own",
+            dir.display(),
+            owner,
+            euid
+        ));
+    }
+    if meta.mode() & 0o022 != 0 {
+        return Err(format!(
+            "source tree {} is group/world-writable (mode {:o}); refusing to build from a tree others can modify",
+            dir.display(),
+            meta.mode() & 0o7777
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(not(unix))]
+fn source_tree_is_trusted(_dir: &std::path::Path) -> Result<(), String> {
+    Ok(())
+}
+
 /// Spawn an already-configured command, streaming its stdout+stderr into the update log line by
 /// line (so a long `cargo build` shows live progress instead of looking hung — FH-BUG-035), and
 /// return the collected stdout on success. On spawn/exit failure it logs an error, marks the update
@@ -394,6 +440,16 @@ fn run_update(update: SharedUpdateState, config_path: String, source_dir_overrid
     };
 
     log!(update, "Source dir: {}", src_dir.display());
+
+    // Refuse to build from a tree we don't own or that others can write into. `cargo build` runs any
+    // build.rs / proc-macro in this tree as the service identity (often root), so an attacker-writable
+    // or attacker-owned tree would mean arbitrary code execution. This applies equally to an
+    // auto-detected clone and a dashboard-supplied source_dir.
+    if let Err(e) = source_tree_is_trusted(&src_dir) {
+        log!(update, "ERROR: {}", e);
+        update.lock().unwrap().finish(false);
+        return;
+    }
 
     /// Run a command, streaming stdout+stderr into the log; return collected stdout or None.
     fn run_cmd_output(update: &SharedUpdateState, program: &str, args: &[&str], dir: &std::path::Path) -> Option<String> {
@@ -1099,7 +1155,10 @@ impl DashboardServer {
 
     fn broadcast(&self, msg: &str) {
         let mut clients = self.clients.lock().unwrap();
-        clients.retain(|tx| tx.send(msg.to_owned()).is_ok());
+        // try_send, not send: a client whose bounded queue is full (it stopped reading its socket) is
+        // dropped here instead of letting an unbounded backlog grow. A closed receiver also errors and
+        // is pruned, same as before.
+        clients.retain(|tx| tx.try_send(msg.to_owned()).is_ok());
     }
 }
 
@@ -1363,6 +1422,11 @@ fn handle_connection(
 ) {
     let _ = stream.set_read_timeout(Some(std::time::Duration::from_millis(500)));
 
+    // Capture the peer's loopback status before the stream is moved into any handler. When the
+    // dashboard runs with no auth, mutating requests (POST, WS upgrade) are restricted to localhost
+    // (the gate below). A failed peer lookup is treated as non-loopback (fail closed).
+    let peer_is_loopback = stream.peer_addr().map(|a| a.ip().is_loopback()).unwrap_or(false);
+
     // ── Read the first 4KB of headers into a buffer, peek first for routing ──
     // We need to both route on the request line AND read the Authorization header,
     // so we collect all headers before dispatching.
@@ -1456,11 +1520,11 @@ fn handle_connection(
             let ok = timing_safe_eq(user.as_bytes(), expected_user.as_bytes()) && timing_safe_eq(pass.as_bytes(), expected_pass.as_bytes());
 
             if ok {
-                let token = if let Ok(mut store) = sessions.lock() {
-                    store.create()
-                } else {
-                    String::new()
-                };
+                // Recover from a poisoned lock instead of issuing an empty cookie: an empty token
+                // would "log in" the browser yet store no session, so every later request would fail
+                // the gate (logged in, but bounced). Poisoning only happens after a panic elsewhere;
+                // the session store itself stays usable.
+                let token = sessions.lock().unwrap_or_else(|e| e.into_inner()).create();
                 tracing::info!("Dashboard: login OK (user: {})", user);
                 serve_login_success(buf.into_inner(), &token);
             } else {
@@ -1528,6 +1592,28 @@ fn handle_connection(
             } else {
                 http_response(inner, 401, "Unauthorized — please log in");
             }
+            return;
+        }
+    }
+
+    // No-auth hard gate: when no credentials are configured the dashboard is open, so any mutating
+    // request (a POST, or the WebSocket upgrade that drives restart/shutdown/dgna/sds/kick) must come
+    // from localhost. Read-only GETs are still served so a LAN overview keeps working. This is
+    // independent of the cookie gate above (which is inert without auth) and closes the "open
+    // dashboard on the LAN can change config / restart the BS" path even if the operator binds wide.
+    if auth.is_none() && !peer_is_loopback {
+        let is_ws_upgrade = req_line.starts_with("GET ")
+            && header_str
+                .lines()
+                .any(|l| l.to_ascii_lowercase().starts_with("upgrade:") && l.to_ascii_lowercase().contains("websocket"));
+        let is_mutating = req_line.starts_with("POST ") || is_ws_upgrade;
+        if is_mutating {
+            drain_http_headers(&mut stream);
+            tracing::warn!(
+                "Dashboard: rejected unauthenticated off-host {} (mutations are localhost-only without auth)",
+                req_line
+            );
+            http_response(stream, 403, "Forbidden — set dashboard credentials for off-host control");
             return;
         }
     }
@@ -1769,14 +1855,9 @@ fn handle_connection(
         let mut body = vec![0u8; content_length.min(512 * 1024)];
         let _ = buf.read_exact(&mut body);
         let body_str = String::from_utf8_lossy(&body);
-        // Write backup of current config before overwriting
-        let backup_path = format!("{}.bak", config_path);
-        if let Err(e) = std::fs::copy(&config_path, &backup_path) {
-            tracing::warn!("Dashboard: failed to write config backup: {}", e);
-        }
-        match std::fs::write(&config_path, body_str.as_ref()) {
-            Ok(_) => http_response(buf.into_inner(), 200, "OK"),
-            Err(e) => http_response(buf.into_inner(), 500, &e.to_string()),
+        match write_config_validated(&config_path, body_str.as_ref()) {
+            Ok(()) => http_response(buf.into_inner(), 200, "OK"),
+            Err((code, msg)) => http_response(buf.into_inner(), code, &msg),
         }
     } else if req_line.contains("GET /api/btsinfo") {
         let mut buf = BufReader::new(stream);
@@ -2192,10 +2273,17 @@ fn handle_ws(
         }
     };
 
-    // Register this connection for broadcasts
-    let (broadcast_tx, broadcast_rx) = crossbeam_channel::unbounded::<String>();
+    // Register this connection for broadcasts. The queue is bounded (a non-draining client is dropped
+    // in broadcast() rather than buffered without bound), and total clients are capped so many idle
+    // connections can't grow memory/threads without bound.
+    let (broadcast_tx, broadcast_rx) = crossbeam_channel::bounded::<String>(WS_CLIENT_QUEUE);
     {
         let mut c = clients.lock().unwrap();
+        if c.len() >= WS_MAX_CLIENTS {
+            tracing::warn!("Dashboard: WS client cap ({}) reached, refusing new connection", WS_MAX_CLIENTS);
+            let _ = ws.close(None);
+            return;
+        }
         c.push(broadcast_tx);
     }
 
@@ -3416,10 +3504,37 @@ fn serve_html(mut stream: TcpStream) {
     let _ = stream.write_all(body);
 }
 
+/// Persist a posted config.toml after a dry-run parse + validate.
+///
+/// Writing garbage here is what would brick the base station: the service restarts to apply config,
+/// the new file fails to parse, and (with no valid `.fallback`) startup aborts under systemd
+/// `Restart=` into a crash-loop. So parse + `validate()` exactly like `serve_dual_carrier_post`
+/// before touching disk — a bad body is rejected and the running config is left untouched. On
+/// success the previous config is backed up to `<path>.bak` and the new one written.
+///
+/// Returns `Ok(())` on success, or `Err((http_code, message))` for the caller to relay.
+fn write_config_validated(config_path: &str, body: &str) -> Result<(), (u16, String)> {
+    match tetra_config::bluestation::parsing::from_toml_str(body) {
+        Ok(cfg) => {
+            if let Err(e) = cfg.validate() {
+                return Err((400, format!("config is invalid: {e}")));
+            }
+        }
+        Err(e) => return Err((400, format!("config does not parse: {e}"))),
+    }
+    // Back up the current config before overwriting (best-effort; a missing source is not fatal).
+    let backup_path = format!("{}.bak", config_path);
+    if let Err(e) = std::fs::copy(config_path, &backup_path) {
+        tracing::warn!("Dashboard: failed to write config backup: {}", e);
+    }
+    std::fs::write(config_path, body).map_err(|e| (500, e.to_string()))
+}
+
 fn serve_config_get(mut stream: TcpStream, config_path: &str) {
     match std::fs::read_to_string(config_path) {
         Ok(content) => {
-            let body = content.as_bytes();
+            let masked = mask_config_secrets(&content);
+            let body = masked.as_bytes();
             let header = format!(
                 "HTTP/1.1 200 OK\r\nContent-Type: text/plain; charset=utf-8\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
                 body.len()
@@ -3428,6 +3543,59 @@ fn serve_config_get(mut stream: TcpStream, config_path: &str) {
             let _ = stream.write_all(body);
         }
         Err(e) => http_response(stream, 500, &e.to_string()),
+    }
+}
+
+/// Mask the secret values in a raw config.toml before it is sent to the browser.
+///
+/// The config holds plaintext credentials (Telegram bot token, DAPNET password / RWTH core authkey,
+/// Asterisk AMI password). The per-field endpoints already mask these; the raw `/api/config` read
+/// must do the same so the cleartext never leaves the host. We mask line-by-line, keying on the TOML
+/// key name, and replace only the quoted value — comments and structure are preserved so the file
+/// still reads naturally in the editor.
+fn mask_config_secrets(content: &str) -> String {
+    use crate::net_dashboard::dapnet::mask_secret;
+    use crate::net_dashboard::telegram::mask_token;
+
+    // key -> masker. `bot_token` keeps the "id:tail" shape; the rest use the generic head…tail mask.
+    fn mask_for_key(key: &str, value: &str) -> Option<String> {
+        match key {
+            "bot_token" => Some(mask_token(value)),
+            "password" | "rwth_core_authkey" | "ami_password" => Some(mask_secret(value)),
+            _ => None,
+        }
+    }
+
+    let mut out = String::with_capacity(content.len());
+    for line in content.lines() {
+        out.push_str(&mask_toml_secret_line(line, mask_for_key));
+        out.push('\n');
+    }
+    out
+}
+
+/// Mask the value of a single TOML `key = "value"` line when `key` is a known secret. Leaves
+/// comments (lines whose first non-space char is `#`) and non-secret/non-matching lines untouched.
+fn mask_toml_secret_line(line: &str, mask_for_key: fn(&str, &str) -> Option<String>) -> String {
+    let trimmed = line.trim_start();
+    if trimmed.starts_with('#') {
+        return line.to_string();
+    }
+    let Some(eq) = line.find('=') else {
+        return line.to_string();
+    };
+    let key = line[..eq].trim();
+    // Only touch a bare quoted-string assignment. The value must be a `"..."` literal.
+    let rhs = line[eq + 1..].trim();
+    let Some(inner) = rhs.strip_prefix('"').and_then(|s| s.strip_suffix('"')) else {
+        return line.to_string();
+    };
+    match mask_for_key(key, inner) {
+        Some(masked) => {
+            let indent_len = line.len() - line.trim_start().len();
+            format!("{}{} = \"{}\"", &line[..indent_len], key, masked)
+        }
+        None => line.to_string(),
     }
 }
 
@@ -4952,8 +5120,84 @@ fn serve_dapnet_send(
 
 #[cfg(test)]
 mod tests {
-    use super::{DashboardServer, binary_built_from};
+    use super::{DashboardServer, binary_built_from, mask_config_secrets, write_config_validated};
     use crate::net_telemetry::TelemetryEvent;
+
+    /// A minimal config.toml that parses + validates (mirrors tetra-config's own minimal fixture).
+    const MINIMAL_CONFIG: &str = r#"
+config_version = "0.6"
+stack_mode = "Bs"
+
+[phy_io]
+backend = "None"
+
+[net_info]
+mcc = 901
+mnc = 9999
+
+[cell_info]
+main_carrier = 1584
+freq_band = 4
+freq_offset = 0
+duplex_spacing = 4
+reverse_operation = false
+location_area = 1
+"#;
+
+    /// A bad config body posted to /api/config must be rejected (400) and must NOT touch the file on
+    /// disk — otherwise the next restart fails to parse it and the base station crash-loops.
+    #[test]
+    fn bad_config_post_is_rejected_and_file_untouched() {
+        let dir = std::env::temp_dir();
+        let path = dir.join(format!("fs_a2_config_{}.toml", std::process::id()));
+        let path_str = path.to_str().unwrap();
+        std::fs::write(&path, MINIMAL_CONFIG).expect("seed config");
+
+        // Garbage that does not parse as TOML.
+        let res = write_config_validated(path_str, "this is not = valid toml [[[");
+        match res {
+            Err((400, _)) => {}
+            other => panic!("expected 400 rejection, got {other:?}"),
+        }
+        // The on-disk config is exactly what we seeded — nothing was written, no .bak made.
+        let after = std::fs::read_to_string(&path).expect("read back");
+        assert_eq!(after, MINIMAL_CONFIG, "running config must be untouched after a rejected write");
+        assert!(
+            !std::path::Path::new(&format!("{path_str}.bak")).exists(),
+            "no backup should be written on rejection"
+        );
+
+        // A valid body is accepted and persisted.
+        let good = format!("{}\n# touched\n", MINIMAL_CONFIG);
+        write_config_validated(path_str, &good).expect("valid config accepted");
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), good, "valid config is written");
+
+        let _ = std::fs::remove_file(&path);
+        let _ = std::fs::remove_file(format!("{path_str}.bak"));
+    }
+
+    /// Raw config reads must mask plaintext secrets line-by-line, leaving structure/comments intact.
+    #[test]
+    fn config_get_masks_secrets() {
+        let raw = "\
+[telegram_alerts]
+bot_token = \"123456:ABCdefGHIjklMNOpqrsWXYZ\"
+# password = \"commented-should-stay\"
+
+[dapnet]
+password = \"supersecretpw\"
+rwth_core_authkey = \"another-secret-key\"
+enabled = true
+";
+        let masked = mask_config_secrets(raw);
+        assert!(!masked.contains("123456:ABCdefGHIjklMNOpqrsWXYZ"), "bot_token cleartext leaked");
+        assert!(!masked.contains("supersecretpw"), "dapnet password cleartext leaked");
+        assert!(!masked.contains("another-secret-key"), "authkey cleartext leaked");
+        // Structure / non-secret values / comments survive untouched.
+        assert!(masked.contains("[telegram_alerts]"));
+        assert!(masked.contains("enabled = true"));
+        assert!(masked.contains("# password = \"commented-should-stay\""), "comments untouched");
+    }
 
     /// FH-BUG (brew shown as v0): the transport reports version 0 ("unknown") on every (re)connect
     /// and v1 is learned lazily from a v1 group call. A confirmed v1 must never be downgraded by a

--- a/crates/tetra-pdus/src/cmce/pdus/d_facility.rs
+++ b/crates/tetra-pdus/src/cmce/pdus/d_facility.rs
@@ -30,6 +30,12 @@ use tetra_core::{BitBuffer, expect_pdu_type, pdu_parse_error::PduParseErr};
 /// Empty-body back-compat: a non-DGNA / legacy D-FACILITY carries no SS PDU and is just a single
 /// trailing O-bit = 0 (`facility = None`). On parse the two are distinguished by the 4-bit Number of
 /// SS PDUs: a populated container has it >= 1, an empty body cannot supply those 4 bits.
+///
+/// This split is a value heuristic, not an explicit presence/length discriminator — EN 300 392-9
+/// V1.7.1 Table 4 carries none. We support exactly two body shapes: an empty body (a single O-bit =
+/// 0) and a Table-4 container holding one SS-DGNA PDU. Any other SS body (a non-DGNA SS PDU) is
+/// rejected downstream by `SsType` (only 22 = DGNA is accepted), so the heuristic never has to
+/// disambiguate an SS body we don't implement.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DFacility {
     /// The SS-DGNA SS-PDU container, or `None` for a legacy empty body.

--- a/crates/tetra-pdus/src/cmce/pdus/d_facility.rs
+++ b/crates/tetra-pdus/src/cmce/pdus/d_facility.rs
@@ -12,26 +12,24 @@ use tetra_core::{BitBuffer, expect_pdu_type, pdu_parse_error::PduParseErr};
 /// SS-protocol-defined body. For SS-DGNA we carry the EN 300 392-9 V1.7.1
 /// SS-PDU container (Table 4) directly in the body:
 ///
+/// Wire layout (matches the normative worked example, EN 300 392-2 V2.4.1 Annex E Table E.4):
+///
 /// ```text
 ///   PDU type           5b  = 10000 (16)          [EN 300 392-2 Table 114]
-///   --- SS body (EN 300 392-9 Table 4) ---
-///   Routeing           2b  = 00 (same SwMI; v1 fixed)
+///   --- SS body (EN 300 392-9 V1.7.1 Table 4, DOWNLINK form) ---
 ///   Number of SS PDUs  4b  = 0001 (v1)
-///   Length indicator  11b  = bit-length of the SS PDU
-///   SS PDU contents    Nb  = the SS-DGNA PDU
+///   Length indicator  11b  = bit-length of the SS PDU (incl. its terminating O-bit)
+///   SS PDU contents    Nb  = the SS-DGNA PDU, ending in its own O-bit = 0
+///   O-bit              1b  = 0  (terminates the D-FACILITY PDU)
 /// ```
 ///
-/// Empty-body back-compat: a non-DGNA / legacy D-FACILITY carries no SS PDU.
-/// EN 300 392-9 does not mandate an O-bit/M-bit trailer on the FACILITY SS
-/// body, so we keep the original stub convention — a single trailing O-bit = 0
-/// — only for the empty case (`facility = None`). When a real SS PDU is present
-/// we follow Table 4 exactly (no trailing M-bit). On parse the two are
-/// distinguished by the Number-of-SS-PDUs field: a populated container has
-/// Number of SS PDUs >= 1, whereas the empty body has at most the single O-bit.
+/// Downlink carries NEITHER Routeing nor MNI — EN 300 392-9 Table 4 states the D-FACILITY shall
+/// have neither (those exist only on the uplink U-FACILITY). Emitting a Routeing field shifts every
+/// following field and the terminal mis-frames the whole PDU.
 ///
-/// Note: EN 300 392-9 Table 4 also defines a 24-bit MNI that is only present
-/// when Routeing = 11. v1 always uses Routeing = 00, so the MNI is never
-/// emitted; non-zero Routeing on the wire is rejected rather than guessed.
+/// Empty-body back-compat: a non-DGNA / legacy D-FACILITY carries no SS PDU and is just a single
+/// trailing O-bit = 0 (`facility = None`). On parse the two are distinguished by the 4-bit Number of
+/// SS PDUs: a populated container has it >= 1, an empty body cannot supply those 4 bits.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DFacility {
     /// The SS-DGNA SS-PDU container, or `None` for a legacy empty body.
@@ -42,8 +40,6 @@ pub struct DFacility {
 /// v1 carries exactly one SS PDU and uses Routeing = 00 (same SwMI).
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DFacilitySsBody {
-    /// Routeing, 2 bits. 00 = same SwMI (the only value supported in v1).
-    pub routeing: u8,
     /// The single SS-DGNA PDU (Number of SS PDUs = 1).
     pub ss_pdu: SsDgnaPdu,
 }
@@ -54,18 +50,13 @@ impl DFacility {
         let pdu_type = buffer.read_field(5, "pdu_type")?;
         expect_pdu_type!(pdu_type, CmcePduTypeDl::DFacility)?;
 
-        // Distinguish a populated SS-PDU container from a legacy empty body.
-        // The container starts with Routeing (2b) + Number of SS PDUs (4b);
-        // a real container always carries at least one SS PDU. An empty body
-        // has at most the single trailing O-bit, so it cannot supply 6 header
-        // bits with a non-zero Number of SS PDUs.
-        let has_container = match buffer.peek_bits(6) {
-            Some(header) => (header & 0b1111) >= 1,
-            None => false,
-        };
+        // Distinguish a populated SS-PDU container from an empty body. A downlink D-FACILITY has no
+        // Routeing, so a container starts with the 4-bit Number of SS PDUs (>= 1); an empty body is
+        // just a single trailing O-bit and cannot supply 4 header bits.
+        let has_container = matches!(buffer.peek_bits(4), Some(n) if n >= 1);
 
         if !has_container {
-            // Legacy empty-body convention: trailing O-bit must be 0.
+            // Empty-body convention: a single trailing O-bit = 0.
             let obit = delimiters::read_obit(buffer)?;
             if obit {
                 return Err(PduParseErr::InvalidTrailingMbitValue);
@@ -73,14 +64,6 @@ impl DFacility {
             return Ok(DFacility { facility: None });
         }
 
-        let routeing = buffer.read_field(2, "routeing")? as u8;
-        if routeing != 0 {
-            // Routeing 11 would introduce a 24-bit MNI; not handled in v1.
-            return Err(PduParseErr::InvalidValue {
-                field: "routeing",
-                value: routeing as u64,
-            });
-        }
         let number_of_ss_pdus = buffer.read_field(4, "number_of_ss_pdus")?;
         if number_of_ss_pdus != 1 {
             return Err(PduParseErr::InvalidValue {
@@ -100,8 +83,14 @@ impl DFacility {
             });
         }
 
+        // O-bit terminating the D-FACILITY PDU (Annex E Table E.4).
+        let obit = delimiters::read_obit(buffer)?;
+        if obit {
+            return Err(PduParseErr::InvalidTrailingMbitValue);
+        }
+
         Ok(DFacility {
-            facility: Some(DFacilitySsBody { routeing, ss_pdu }),
+            facility: Some(DFacilitySsBody { ss_pdu }),
         })
     }
 
@@ -116,12 +105,13 @@ impl DFacility {
             return Ok(());
         };
 
-        // SS body (EN 300 392-9 Table 4).
-        buffer.write_bits(body.routeing as u64, 2);
+        // A downlink D-FACILITY carries NEITHER Routeing nor MNI -- those exist only on the uplink
+        // U-FACILITY (EN 300 392-9 V1.7.1 Table 4 downlink rule). Go straight to the Number of SS PDUs.
         buffer.write_bits(1, 4); // Number of SS PDUs = 1.
 
-        // Serialize the SS PDU into a scratch buffer first so we can write its
-        // exact bit length as the 11-bit Length indicator.
+        // Serialize the SS PDU into a scratch buffer first so we can write its exact bit length as the
+        // 11-bit Length indicator. The SS PDU already ends with its own terminating O-bit, which the
+        // Length indicator counts (EN 300 392-2 V2.4.1 Annex E Table E.4).
         let mut scratch = BitBuffer::new_autoexpand(32);
         body.ss_pdu.to_bitbuf(&mut scratch)?;
         let ss_pdu_bits = scratch.get_pos();
@@ -135,6 +125,9 @@ impl DFacility {
         scratch.seek(0);
         buffer.copy_bits(&mut scratch, ss_pdu_bits);
 
+        // O-bit terminating the D-FACILITY PDU itself (Annex E Table E.4).
+        delimiters::write_obit(buffer, 0);
+
         Ok(())
     }
 }
@@ -143,7 +136,7 @@ impl fmt::Display for DFacility {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match &self.facility {
             None => write!(f, "DFacility {{ }}"),
-            Some(body) => write!(f, "DFacility {{ routeing: {} ss_pdu: {} }}", body.routeing, body.ss_pdu),
+            Some(body) => write!(f, "DFacility {{ ss_pdu: {} }}", body.ss_pdu),
         }
     }
 }
@@ -165,6 +158,42 @@ mod tests {
         let parsed = DFacility::from_bitbuf(&mut buf).expect("parse");
         assert_eq!(parsed, pdu);
         assert!(parsed.facility.is_none());
+    }
+
+    /// The exact on-air D-FACILITY for an SS-DGNA ASSIGN of GSSI 91 (attach permanently, class of
+    /// usage 4, no mnemonic, ack requested) must match the normative worked example in
+    /// EN 300 392-2 V2.4.1 Annex E Table E.4 — bit for bit. This is the pattern a real terminal
+    /// accepts (no Routeing, with both terminating O-bits).
+    #[test]
+    fn d_facility_assign_matches_annex_e_table_e4() {
+        let pdu = DFacility {
+            facility: Some(DFacilitySsBody {
+                ss_pdu: SsDgnaPdu::Assign(Assign {
+                    groups: vec![GroupAssignment {
+                        group_ssi: 91,
+                        group_extension: None,
+                        attachment_mode: GroupIdentityAttachmentMode::AttachedPermanently,
+                        class_of_usage: Some(4),
+                        mnemonic: None,
+                        security_related_information: None,
+                        additional_group_information: None,
+                        vgssi: None,
+                    }],
+                    ack_requested: true,
+                }),
+            }),
+        };
+        let mut buf = BitBuffer::new_autoexpand(96);
+        pdu.to_bitbuf(&mut buf).expect("serialize");
+        let total = buf.get_pos();
+        buf.seek(0);
+        let bits: String = (0..total)
+            .map(|_| if buf.read_bits(1).unwrap() == 1 { '1' } else { '0' })
+            .collect();
+        assert_eq!(
+            bits,
+            "1000000010000011011101011000111000010000000000000000010110110000111000000100"
+        );
     }
 
     /// A D-FACILITY wrapping an ASSIGN: the container parses, carries exactly
@@ -193,7 +222,6 @@ mod tests {
 
         let pdu = DFacility {
             facility: Some(DFacilitySsBody {
-                routeing: 0,
                 ss_pdu: SsDgnaPdu::Assign(assign.clone()),
             }),
         };
@@ -201,11 +229,10 @@ mod tests {
         let mut buf = BitBuffer::new_autoexpand(64);
         pdu.to_bitbuf(&mut buf).expect("serialize");
 
-        // Decode the framing fields by hand to assert their exact values.
+        // Decode the framing fields by hand to assert their exact values. Downlink has no Routeing.
         buf.seek(0);
         assert_eq!(buf.read_bits(5).unwrap(), 16, "PDU type = D-FACILITY (16)");
-        assert_eq!(buf.read_bits(2).unwrap(), 0, "Routeing = 00");
-        assert_eq!(buf.read_bits(4).unwrap(), 1, "Number of SS PDUs = 1");
+        assert_eq!(buf.read_bits(4).unwrap(), 1, "Number of SS PDUs = 1 (no Routeing on downlink)");
         assert_eq!(
             buf.read_bits(11).unwrap() as usize,
             inner_bits,

--- a/crates/tetra-pdus/src/cmce/pdus/u_facility.rs
+++ b/crates/tetra-pdus/src/cmce/pdus/u_facility.rs
@@ -18,12 +18,25 @@ use tetra_core::{BitBuffer, expect_pdu_type, pdu_parse_error::PduParseErr};
 ///   Number of SS PDUs  4b  = 0001 (v1)
 ///   Length indicator  11b  = bit-length of the SS PDU
 ///   SS PDU contents    Nb  = the SS-DGNA PDU
+///   O-bit              1b  = 0  (terminates the U-FACILITY PDU)
 /// ```
 ///
 /// Empty-body back-compat works exactly as in D-FACILITY: a legacy / non-DGNA
 /// U-FACILITY carries no SS PDU and keeps the original single trailing
-/// O-bit = 0 convention; a populated container follows Table 4 with no trailing
-/// M-bit. The two are distinguished on parse by the Number-of-SS-PDUs field.
+/// O-bit = 0 convention; a populated container follows Table 4. The two are
+/// distinguished on parse by the Number-of-SS-PDUs field.
+///
+/// The container is terminated by an O-bit = 0, symmetric with D-FACILITY (Annex
+/// E Table E.4). We always emit it. On parse we stay tolerant: a real MS's
+/// ASSIGN-ACK / DEASSIGN-ACK framing of this trailing bit is not yet confirmed
+/// on-air, so the bit is consumed only when present and a peer that omits it is
+/// still accepted.
+///
+/// The empty-vs-container split is a value heuristic, not an explicit
+/// presence/length discriminator — EN 300 392-9 V1.7.1 Table 4 carries none. We
+/// support exactly two body shapes: an empty body (a single O-bit = 0) and a
+/// Table-4 container holding one SS-DGNA PDU. Any other SS body is rejected
+/// downstream by `SsType` (only 22 = DGNA is accepted).
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct UFacility {
     /// The SS-DGNA SS-PDU container, or `None` for a legacy empty body.
@@ -87,6 +100,12 @@ impl UFacility {
             });
         }
 
+        // O-bit terminating the U-FACILITY PDU (symmetric with D-FACILITY; EN 300 392-2 V2.4.1 Annex E
+        // Table E.4). We emit it on the write side, but stay tolerant on parse: a real MS's ASSIGN-ACK
+        // / DEASSIGN-ACK framing of this trailing bit is not yet confirmed on-air, so consume it only
+        // if a bit remains and do NOT reject a peer that omits it. A spurious set bit is ignored.
+        let _ = buffer.peek_bits(1).map(|_| delimiters::read_obit(buffer));
+
         Ok(UFacility {
             facility: Some(UFacilitySsBody { routeing, ss_pdu }),
         })
@@ -121,6 +140,11 @@ impl UFacility {
         buffer.write_bits(ss_pdu_bits as u64, 11);
         scratch.seek(0);
         buffer.copy_bits(&mut scratch, ss_pdu_bits);
+
+        // O-bit terminating the U-FACILITY PDU itself, symmetric with D-FACILITY (EN 300 392-2 V2.4.1
+        // Annex E Table E.4). The Length indicator above counts only the inner SS PDU, so this bit
+        // sits after the copied body.
+        delimiters::write_obit(buffer, 0);
 
         Ok(())
     }
@@ -190,5 +214,76 @@ mod tests {
         buf.seek(0);
         let parsed = UFacility::from_bitbuf(&mut buf).expect("parse");
         assert_eq!(parsed, pdu);
+    }
+
+    /// The container is terminated by an O-bit = 0, symmetric with D-FACILITY (Annex E Table E.4):
+    /// the serialized form is exactly one bit longer than the framing + inner SS PDU, and that bit is
+    /// 0. The PDU still round-trips.
+    #[test]
+    fn u_facility_emits_terminating_obit() {
+        let ack = AssignAck {
+            acks: vec![GroupAssignmentAck {
+                group_ssi: 91,
+                group_extension: None,
+                result_of_assignment: ResultOfAssignment::Accepted,
+                result_of_attachment: ResultOfAttachment::Attached,
+            }],
+        };
+
+        let mut inner = BitBuffer::new_autoexpand(32);
+        ack.to_bitbuf(&mut inner).expect("serialize inner");
+        let inner_bits = inner.get_pos();
+
+        let pdu = UFacility {
+            facility: Some(UFacilitySsBody {
+                routeing: 0,
+                ss_pdu: SsDgnaPdu::AssignAck(ack),
+            }),
+        };
+
+        let mut buf = BitBuffer::new_autoexpand(64);
+        pdu.to_bitbuf(&mut buf).expect("serialize");
+        // 5 (PDU type) + 2 (routeing) + 4 (num SS PDUs) + 11 (length) + inner + 1 (terminating O-bit).
+        let framed = 5 + 2 + 4 + 11 + inner_bits;
+        assert_eq!(buf.get_pos(), framed + 1, "one trailing O-bit beyond the framed body");
+        let bits = buf.to_bitstr();
+        assert_eq!(&bits[framed..], "0", "terminating O-bit is 0");
+
+        buf.seek(0);
+        assert_eq!(UFacility::from_bitbuf(&mut buf).expect("parse"), pdu);
+    }
+
+    /// Parse is tolerant of a peer that omits the trailing O-bit (the legacy 67-bit short form): the
+    /// container without the terminating bit still parses to the same value. This keeps the BS able
+    /// to read a real radio's ASSIGN-ACK whichever form it sends.
+    #[test]
+    fn u_facility_parses_without_trailing_obit() {
+        let ack = AssignAck {
+            acks: vec![GroupAssignmentAck {
+                group_ssi: 91,
+                group_extension: None,
+                result_of_assignment: ResultOfAssignment::Accepted,
+                result_of_attachment: ResultOfAttachment::Attached,
+            }],
+        };
+        let pdu = UFacility {
+            facility: Some(UFacilitySsBody {
+                routeing: 0,
+                ss_pdu: SsDgnaPdu::AssignAck(ack),
+            }),
+        };
+
+        // Serialize, then drop the final O-bit to reconstruct the short form.
+        let mut full = BitBuffer::new_autoexpand(64);
+        pdu.to_bitbuf(&mut full).expect("serialize");
+        let bits = full.to_bitstr();
+        let short = &bits[..bits.len() - 1];
+
+        let mut buf = BitBuffer::new_autoexpand(64);
+        for ch in short.chars() {
+            buf.write_bit(if ch == '1' { 1 } else { 0 });
+        }
+        buf.seek(0);
+        assert_eq!(UFacility::from_bitbuf(&mut buf).expect("parse"), pdu);
     }
 }

--- a/crates/tetra-pdus/src/cmce/ss_dgna/enums/results.rs
+++ b/crates/tetra-pdus/src/cmce/ss_dgna/enums/results.rs
@@ -213,19 +213,6 @@ impl GroupIdentityAttachmentMode {
             GroupIdentityAttachmentMode::NotAttachedMayNotRequest => 5,
         }
     }
-
-    /// True for the attachment modes (0..3) that EN 300 392-2 cl.16.10.6 pairs
-    /// with a Class of usage field in the Group assignment IE (Table 45). The
-    /// "not attached" modes (4, 5) carry no class of usage.
-    pub fn carries_class_of_usage(self) -> bool {
-        matches!(
-            self,
-            GroupIdentityAttachmentMode::AttachedPermanently
-                | GroupIdentityAttachmentMode::AttachRequestedNextItsiAttach
-                | GroupIdentityAttachmentMode::AttachNotAllowedNextItsiAttach
-                | GroupIdentityAttachmentMode::AttachRequestedNextLocationUpdate
-        )
-    }
 }
 
 impl From<GroupIdentityAttachmentMode> for u64 {

--- a/crates/tetra-pdus/src/cmce/ss_dgna/fields/group_assignment.rs
+++ b/crates/tetra-pdus/src/cmce/ss_dgna/fields/group_assignment.rs
@@ -141,6 +141,14 @@ impl GroupAssignment {
 
         // Type-2 elements, each preceded by its P-bit, in Table 45 order.
         typed::write_type2_generic(obit, buf, self.class_of_usage.map(|v| v as u64), 3);
+        // FIXME(C2): the mnemonic group name is framed here as P-bit + 6-bit octet count + N octets,
+        // the same opaque shape as the security / additional-group fields. A display name is really a
+        // TETRA text string (coding-scheme byte + length, like net_brew's SS-TPI mnemonic), so the
+        // octet-count framing is likely wrong and, since the mnemonic precedes the remaining type-2
+        // elements, a populated one would shift every following P-bit. This is latent: the only
+        // constructor (ss_bs.rs) hard-codes mnemonic = None, so it is never emitted on-air. Before any
+        // path populates it, give the mnemonic its own writer using the TETRA text format and verify
+        // the exact widths against TS 100 392-12-22 V1.5.1 Table 45.
         Self::write_type2_octets(obit, buf, &self.mnemonic)?;
         Self::write_type2_octets(obit, buf, &self.security_related_information)?;
         Self::write_type2_octets(obit, buf, &self.additional_group_information)?;

--- a/crates/tetra-pdus/src/cmce/ss_dgna/mod.rs
+++ b/crates/tetra-pdus/src/cmce/ss_dgna/mod.rs
@@ -12,3 +12,28 @@ pub mod enums;
 pub mod fields;
 pub mod pdus;
 pub mod ss_dgna_pdu;
+
+use tetra_core::typed_pdu_fields::delimiters;
+use tetra_core::{BitBuffer, pdu_parse_error::PduParseErr};
+
+/// Write the terminating O-bit that closes an SS-DGNA PDU.
+///
+/// All four SS-DGNA PDUs we encode (ASSIGN / ASSIGN ACK / DEASSIGN /
+/// DEASSIGN ACK) are made up only of type-1 elements, but EN 300 392-2 annex E
+/// still requires a final O-bit = 0 ("no type 2/3/4 elements follow") as the
+/// last bit of any such PDU. See the worked example in EN 300 392-2 annex E
+/// table E.4 (D-FACILITY with SS-DGNA ASSIGN), which terminates the ASSIGN PDU
+/// with this O-bit before the D-FACILITY's own trailing O-bit.
+fn write_terminating_obit(buf: &mut BitBuffer) {
+    delimiters::write_obit(buf, 0);
+}
+
+/// Read and require the terminating O-bit of an SS-DGNA PDU (see
+/// [`write_terminating_obit`]). We never define type-2/3/4 elements, so the
+/// only valid value is 0; a 1 would announce optional elements we do not parse.
+fn read_terminating_obit(buf: &mut BitBuffer) -> Result<(), PduParseErr> {
+    if delimiters::read_obit(buf)? {
+        return Err(PduParseErr::InvalidTrailingMbitValue);
+    }
+    Ok(())
+}

--- a/crates/tetra-pdus/src/cmce/ss_dgna/pdus/assign.rs
+++ b/crates/tetra-pdus/src/cmce/ss_dgna/pdus/assign.rs
@@ -41,6 +41,15 @@ impl Assign {
         expect_pdu_type!(pdu_type, SsDgnaPduType::Assign)?;
 
         let number_of_groups = buf.read_field(5, "number_of_groups")? as usize;
+        // An ASSIGN must carry at least one group (Table 18). 0 has no meaning and the encoder rejects
+        // it, so reject it on decode too — otherwise a parsed 0-group ASSIGN could never be
+        // re-serialized (decode-then-forward would fail).
+        if number_of_groups == 0 {
+            return Err(PduParseErr::InvalidValue {
+                field: "number_of_groups",
+                value: 0,
+            });
+        }
         let mut groups = Vec::with_capacity(number_of_groups);
         for _ in 0..number_of_groups {
             groups.push(GroupAssignment::from_bitbuf(buf)?);
@@ -150,6 +159,25 @@ mod tests {
             "0",                        // SS PDU terminating O-bit
         );
         assert_eq!(buf.to_bitstr(), expected);
+    }
+
+    /// A 0-group ASSIGN must be rejected on decode (the encoder already rejects it). Build the header
+    /// by hand with Number of groups = 0 and assert the parse fails with InvalidValue.
+    #[test]
+    fn assign_rejects_zero_groups() {
+        let mut buf = BitBuffer::new_autoexpand(8);
+        buf.write_bits(SsType::Dgna.into_raw(), 6);
+        buf.write_bits(SsDgnaPduType::Assign.into_raw(), 5);
+        buf.write_bits(0, 5); // Number of groups = 0.
+        buf.write_bits(0, 1); // ack_requested (unreached, but keep the buffer non-empty).
+        buf.seek(0);
+        match Assign::from_bitbuf(&mut buf) {
+            Err(PduParseErr::InvalidValue { field, value }) => {
+                assert_eq!(field, "number_of_groups");
+                assert_eq!(value, 0);
+            }
+            other => panic!("expected InvalidValue for 0 groups, got {other:?}"),
+        }
     }
 
     /// Type-2 framing: mnemonic present vs absent must produce the right O/P

--- a/crates/tetra-pdus/src/cmce/ss_dgna/pdus/assign.rs
+++ b/crates/tetra-pdus/src/cmce/ss_dgna/pdus/assign.rs
@@ -5,6 +5,7 @@ use tetra_core::{BitBuffer, expect_pdu_type, pdu_parse_error::PduParseErr};
 use crate::cmce::ss_dgna::enums::ss_dgna_pdu_type::SsDgnaPduType;
 use crate::cmce::ss_dgna::enums::ss_type::SsType;
 use crate::cmce::ss_dgna::fields::group_assignment::GroupAssignment;
+use crate::cmce::ss_dgna::{read_terminating_obit, write_terminating_obit};
 
 /// ASSIGN PDU, TS 100 392-12-22 V1.5.1 Table 18 (downlink, carried in
 /// D-FACILITY).
@@ -20,6 +21,8 @@ use crate::cmce::ss_dgna::fields::group_assignment::GroupAssignment;
 ///   Number of groups           5b  = groups.len() (1..31)
 ///   Group assignment IE       var  repeated, Number of groups times  [Table 45]
 ///   Acknowledgement requested  1b  once, at the end
+///   O-bit                      1b  = 0, terminates the SS PDU (EN 300 392-2
+///                                   annex E; see table E.4)
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Assign {
@@ -44,6 +47,7 @@ impl Assign {
         }
 
         let ack_requested = buf.read_field(1, "ack_requested")? == 1;
+        read_terminating_obit(buf)?;
 
         Ok(Assign { groups, ack_requested })
     }
@@ -63,6 +67,7 @@ impl Assign {
             group.to_bitbuf(buf)?;
         }
         buf.write_bits(self.ack_requested as u64, 1);
+        write_terminating_obit(buf);
         Ok(())
     }
 }
@@ -111,7 +116,8 @@ mod tests {
     /// (00001), then the single Group assignment IE and the trailing ack bit.
     ///
     /// IE: Group SSI = 1 (24b), ext present = 0, attachment mode = 000, O-bit = 0.
-    /// Trailing "Acknowledgement requested" = 1.
+    /// Trailing "Acknowledgement requested" = 1, then the SS PDU terminating
+    /// O-bit = 0 (EN 300 392-2 annex E table E.4).
     #[test]
     fn assign_exact_bits() {
         let pdu = Assign {
@@ -141,6 +147,7 @@ mod tests {
             "000",                      // Group identity attachment mode = 000
             "0",                        // O-bit (no type-2 optionals)
             "1",                        // Acknowledgement requested = 1
+            "0",                        // SS PDU terminating O-bit
         );
         assert_eq!(buf.to_bitstr(), expected);
     }

--- a/crates/tetra-pdus/src/cmce/ss_dgna/pdus/assign_ack.rs
+++ b/crates/tetra-pdus/src/cmce/ss_dgna/pdus/assign_ack.rs
@@ -5,6 +5,7 @@ use tetra_core::{BitBuffer, expect_pdu_type, pdu_parse_error::PduParseErr};
 use crate::cmce::ss_dgna::enums::ss_dgna_pdu_type::SsDgnaPduType;
 use crate::cmce::ss_dgna::enums::ss_type::SsType;
 use crate::cmce::ss_dgna::fields::group_assignment_ack::GroupAssignmentAck;
+use crate::cmce::ss_dgna::{read_terminating_obit, write_terminating_obit};
 
 /// ASSIGN ACK PDU, TS 100 392-12-22 V1.5.1 Table 19 (uplink, carried in
 /// U-FACILITY).
@@ -18,6 +19,8 @@ use crate::cmce::ss_dgna::fields::group_assignment_ack::GroupAssignmentAck;
 ///   SS-DGNA PDU type          5b  = 01000 (ASSIGN ACK)    [TS Table 74]
 ///   Number of groups          5b  = acks.len()
 ///   Group assignment Ack IE  var  repeated, Number of groups times  [Table 46]
+///   O-bit                     1b  = 0, terminates the SS PDU (EN 300 392-2
+///                                  annex E; see table E.4)
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct AssignAck {
@@ -38,6 +41,7 @@ impl AssignAck {
         for _ in 0..number_of_groups {
             acks.push(GroupAssignmentAck::from_bitbuf(buf)?);
         }
+        read_terminating_obit(buf)?;
 
         Ok(AssignAck { acks })
     }
@@ -56,6 +60,7 @@ impl AssignAck {
         for ack in &self.acks {
             ack.to_bitbuf(buf)?;
         }
+        write_terminating_obit(buf);
         Ok(())
     }
 }

--- a/crates/tetra-pdus/src/cmce/ss_dgna/pdus/deassign.rs
+++ b/crates/tetra-pdus/src/cmce/ss_dgna/pdus/deassign.rs
@@ -5,6 +5,7 @@ use tetra_core::{BitBuffer, expect_pdu_type, pdu_parse_error::PduParseErr};
 use crate::cmce::ss_dgna::enums::ss_dgna_pdu_type::SsDgnaPduType;
 use crate::cmce::ss_dgna::enums::ss_type::SsType;
 use crate::cmce::ss_dgna::fields::group_deassignment::GroupDeassignment;
+use crate::cmce::ss_dgna::{read_terminating_obit, write_terminating_obit};
 
 /// DEASSIGN PDU, TS 100 392-12-22 V1.5.1 Table 20 (downlink, carried in
 /// D-FACILITY).
@@ -20,6 +21,8 @@ use crate::cmce::ss_dgna::fields::group_deassignment::GroupDeassignment;
 ///   Number of groups in deassign request    5b  = groups.len() (00000 = ALL)
 ///   Group deassignment IE                  var  repeated, that many times  [Table 47]
 ///   Acknowledgement requested               1b  once, at the end
+///   O-bit                                   1b  = 0, terminates the SS PDU
+///                                                (EN 300 392-2 annex E; see table E.4)
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Deassign {
@@ -44,6 +47,7 @@ impl Deassign {
         }
 
         let ack_requested = buf.read_field(1, "ack_requested")? == 1;
+        read_terminating_obit(buf)?;
 
         Ok(Deassign { groups, ack_requested })
     }
@@ -63,6 +67,7 @@ impl Deassign {
             group.to_bitbuf(buf)?;
         }
         buf.write_bits(self.ack_requested as u64, 1);
+        write_terminating_obit(buf);
         Ok(())
     }
 }
@@ -104,8 +109,8 @@ mod tests {
 
         let mut buf = BitBuffer::new_autoexpand(32);
         pdu.to_bitbuf(&mut buf).expect("serialize");
-        // SS type 6 + PDU type 5 + number of groups 5 + ack 1 = 17 bits.
-        assert_eq!(buf.get_pos(), 17);
+        // SS type 6 + PDU type 5 + number of groups 5 + ack 1 + terminating O-bit 1 = 18 bits.
+        assert_eq!(buf.get_pos(), 18);
         buf.seek(0);
         let parsed = Deassign::from_bitbuf(&mut buf).expect("parse");
         assert_eq!(parsed, pdu);

--- a/crates/tetra-pdus/src/cmce/ss_dgna/pdus/deassign_ack.rs
+++ b/crates/tetra-pdus/src/cmce/ss_dgna/pdus/deassign_ack.rs
@@ -5,6 +5,7 @@ use tetra_core::{BitBuffer, expect_pdu_type, pdu_parse_error::PduParseErr};
 use crate::cmce::ss_dgna::enums::ss_dgna_pdu_type::SsDgnaPduType;
 use crate::cmce::ss_dgna::enums::ss_type::SsType;
 use crate::cmce::ss_dgna::fields::group_deassignment_ack::GroupDeassignmentAck;
+use crate::cmce::ss_dgna::{read_terminating_obit, write_terminating_obit};
 
 /// DEASSIGN ACK PDU, TS 100 392-12-22 V1.5.1 Table 21 (uplink, carried in
 /// U-FACILITY).
@@ -19,6 +20,8 @@ use crate::cmce::ss_dgna::fields::group_deassignment_ack::GroupDeassignmentAck;
 ///   Number of groups in deassign ack 5b = acks.len()
 ///   Group deassignment Ack IE     var  repeated, that many times  [Table 48]
 ///   Acknowledgement complete       1b  once, at the end
+///   O-bit                          1b  = 0, terminates the SS PDU (EN 300 392-2
+///                                       annex E; see table E.4)
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DeassignAck {
@@ -42,6 +45,7 @@ impl DeassignAck {
         }
 
         let ack_complete = buf.read_field(1, "ack_complete")? == 1;
+        read_terminating_obit(buf)?;
 
         Ok(DeassignAck { acks, ack_complete })
     }
@@ -61,6 +65,7 @@ impl DeassignAck {
             ack.to_bitbuf(buf)?;
         }
         buf.write_bits(self.ack_complete as u64, 1);
+        write_terminating_obit(buf);
         Ok(())
     }
 }


### PR DESCRIPTION
Follow-up to #23 (already merged at the initial SS-DGNA commit) — these three commits never made it onto main: the D-FACILITY framing fix that actually makes terminals accept the DGNA, plus the dashboard security hardening and a few protocol robustness fixes.

## SS-DGNA — make the radio accept it (critical)
On a real Motorola the ASSIGN was L2-ACKed but ignored. Two framing errors, both confirmed against the normative worked example in EN 300 392-2 V2.4.1 Annex E Table E.4:
- A downlink D-FACILITY must carry NO Routeing field (it shifted every following field, so the radio read Number of SS PDUs = 0).
- Each SS-DGNA PDU and the D-FACILITY must end with a terminating O-bit.
The on-air ASSIGN now matches Table E.4 bit for bit (oracle test).

## Dashboard security hardening
- Default bind `127.0.0.1`; with no credentials set, off-host mutating requests (POST + WebSocket) are rejected — mutations are localhost-only without auth, even if bound wide. Loud warning when bound off-host without auth.
- `POST /api/config` now parses + `validate()`s before writing, so a bad config can't be persisted and crash-loop the BS on restart.
- Refuse to run the OTA `cargo build` from a source tree not owned by the service user (or root) or that is group/world-writable — closes a `build.rs` RCE path.
- `GET /api/config` masks secrets instead of streaming tokens/passwords in clear.
- Proper escaping of WiFi SSIDs / callsigns (DOM closures, not inline handlers) to stop XSS from on-air / scanned names.
- Bounded RadioID fetch queue and per-client WebSocket channel; WS client cap. Recover a poisoned session lock instead of issuing an empty cookie.

## Protocol robustness
U-FACILITY emits the symmetric terminating O-bit (parser stays tolerant); ASSIGN rejects zero groups; dead helper removed; latent mnemonic framing flagged for correction before it's ever emitted.

`cargo test --workspace --all-targets`: 396 passed, 0 failed.
