### PR TITLE
asterisk: wildcard routing + inbound setup timeout (for beta)

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,22 +231,102 @@ After installation, confirm both TETRA ACELP -> PCM decoding and PCM -> TETRA
 ACELP encoding work before enabling the bridge (follow the codec project's
 README for the exact verification commands).
 
-### Asterisk packages and modules
+### Asterisk packages, source build, and modules
 
-Install Asterisk when using the SIP bridge or Snom display notifications:
+Asterisk is required for the SIP/RTP bridge and for Snom XML display
+notifications via AMI `PJSIPNotify`.
+
+On Debian GNU/Linux 13, build Asterisk from source. The distribution package may
+not provide the module set FlowStation needs, especially `res_pjsip_notify.so`.
+The commands below use Asterisk 22 LTS/current; use a pinned tarball if you need
+reproducible builds.
+
+Install build dependencies:
+
+```bash
+sudo apt update
+sudo apt install -y \
+  build-essential pkg-config wget tar git subversion \
+  autoconf automake libtool bison flex \
+  libedit-dev libjansson-dev libxml2-dev libsqlite3-dev uuid-dev \
+  libssl-dev libsrtp2-dev libspeexdsp-dev libgsm1-dev libopus-dev \
+  libcurl4-openssl-dev libnewt-dev libncurses-dev
+```
+
+Download and build Asterisk:
+
+```bash
+cd /usr/src
+sudo wget -O asterisk-22-current.tar.gz \
+  https://downloads.asterisk.org/pub/telephony/asterisk/asterisk-22-current.tar.gz
+sudo tar xzf asterisk-22-current.tar.gz
+cd asterisk-22*/
+
+sudo ./configure --with-jansson-bundled --with-pjproject-bundled
+sudo make menuselect.makeopts
+sudo menuselect/menuselect \
+  --enable chan_pjsip \
+  --enable res_pjsip \
+  --enable res_pjsip_session \
+  --enable res_pjsip_pubsub \
+  --enable res_pjsip_notify \
+  --enable res_pjsip_outbound_registration \
+  --enable res_pjsip_registrar \
+  --enable res_pjsip_authenticator_digest \
+  --enable res_pjsip_endpoint_identifier_user \
+  --enable res_pjsip_endpoint_identifier_ip \
+  --enable res_rtp_asterisk \
+  --enable codec_ulaw \
+  --enable app_dial \
+  --enable app_playback \
+  --enable app_stack \
+  --enable pbx_config \
+  menuselect.makeopts
+
+sudo make -j"$(nproc)"
+sudo make install
+```
+
+For a first-time install, install sample configs and the systemd service. Do not
+run `make samples` on a production Asterisk host without backing up
+`/etc/asterisk` first, because it can overwrite local config files.
+
+```bash
+sudo make samples
+sudo make config
+sudo ldconfig
+sudo systemctl enable --now asterisk
+```
+
+If you prefer running Asterisk as the dedicated `asterisk` user, create it and set
+ownership before starting the service:
+
+```bash
+sudo useradd --system --user-group --home-dir /var/lib/asterisk \
+  --shell /usr/sbin/nologin asterisk || true
+sudo chown -R asterisk:asterisk /etc/asterisk /var/lib/asterisk \
+  /var/log/asterisk /var/spool/asterisk /usr/lib/asterisk
+sudo sed -i 's/^;\?runuser = .*/runuser = asterisk/' /etc/asterisk/asterisk.conf
+sudo sed -i 's/^;\?rungroup = .*/rungroup = asterisk/' /etc/asterisk/asterisk.conf
+sudo systemctl restart asterisk
+```
+
+On Debian/Ubuntu systems where the packaged Asterisk is known to include the
+required modules, this shorter path may still be sufficient:
 
 ```bash
 sudo apt install -y asterisk
 sudo systemctl enable --now asterisk
 ```
 
-For Snom XML display notifications, Asterisk must be able to load
-`res_pjsip_notify.so`. Some distributions refuse to load it if
-`pjsip_notify.conf` is missing, so create the file:
+Verify the PJSIP and NOTIFY modules. Some builds refuse to load
+`res_pjsip_notify.so` if `pjsip_notify.conf` is missing, so create the file:
 
 ```bash
 sudo touch /etc/asterisk/pjsip_notify.conf
 sudo asterisk -rx "module load res_pjsip_notify.so"
+sudo asterisk -rx "module load chan_pjsip.so"
+sudo asterisk -rx "module show like pjsip"
 sudo asterisk -rx "module show like pjsip_notify"
 ```
 
@@ -298,6 +378,7 @@ enabled = true
 outbound_prefix = "91"          # TETRA -> SIP: 91385 calls SIP user 385
 strip_outbound_prefix = true
 inbound_prefix = "T"            # SIP -> TETRA: Dial PJSIP/T2632585@flowstation
+inbound_setup_timeout_secs = 20  # no TETRA alert before this -> SIP 404 Not Found
 register = true
 codec = "PCMU"                  # currently the only supported SIP codec
 service_numbers = ["385", "600", "601"]
@@ -357,6 +438,20 @@ qualify_frequency=30
 
 `service_numbers` is deliberately an allowlist. If a TETRA user dials `91385`,
 FlowStation strips `91`, checks that `385` is listed, then calls SIP user `385`.
+To route every `91...` dial to Asterisk, set `service_numbers = ["*"]`.
+Alternatively, `outbound_prefix = "91*"` makes the prefix itself a wildcard. More
+specific prefix wildcards are also allowed inside `service_numbers`, for example
+`["38*"]` routes `9138...` to Asterisk after stripping `91`. Exact entries still
+work as before, so `service_numbers = ["385"]` permits `91385` and direct `385`,
+but not `91600`.
+
+For Asterisk-originated calls, FlowStation answers the initial SIP `INVITE` with
+`100 Trying`, sends TETRA `D-SETUP` to the target ISSI, and only sends SIP
+`180 Ringing` after the radio answers with TETRA alerting. If the ISSI is still
+listed in the local registry but does not answer the RF setup, FlowStation waits
+for `inbound_setup_timeout_secs` and then returns SIP `404 Not Found` before any
+ringing was sent. The value is clamped to 1-60 seconds and mapped to the nearest
+supported TETRA setup timer.
 
 ### DAPNET integration
 

--- a/crates/tetra-config/src/bluestation/sec_asterisk.rs
+++ b/crates/tetra-config/src/bluestation/sec_asterisk.rs
@@ -28,11 +28,89 @@ pub struct CfgAsterisk {
     pub password: SecretField,
     pub realm: String,
     pub options_interval_secs: u64,
+    /// Timeout for Asterisk-originated calls while waiting for the called TETRA MS to answer D-SETUP.
+    pub inbound_setup_timeout_secs: u32,
 }
 
 impl Default for CfgAsterisk {
     fn default() -> Self {
         apply_asterisk_patch(CfgAsteriskDto::default()).expect("default asterisk config must be valid")
+    }
+}
+
+impl CfgAsterisk {
+    /// Route a TETRA dial string to a SIP user according to the Asterisk outbound rules.
+    ///
+    /// Matching modes:
+    /// - `outbound_prefix = "91"` and empty `service_numbers` routes every `91...` dial.
+    /// - `outbound_prefix = "91*"` explicitly routes every `91...` dial.
+    /// - `service_numbers = ["*"]` routes every dial behind the configured prefix (needs a non-empty
+    ///   `outbound_prefix`; to route every dial set `outbound_prefix = "*"` instead).
+    /// - `service_numbers = ["38*"]` routes every stripped number starting with `38`.
+    /// - Exact `service_numbers` entries keep their old allowlist behaviour.
+    pub fn route_outbound_raw(&self, raw: &str) -> Option<String> {
+        if !self.enabled {
+            return None;
+        }
+
+        let raw = raw.trim();
+        if raw.is_empty() {
+            return None;
+        }
+
+        let configured_prefix = self.outbound_prefix.trim();
+        let prefix_wildcard = configured_prefix.ends_with('*');
+        let outbound_prefix = configured_prefix.trim_end_matches('*');
+        let prefix_matched = if outbound_prefix.is_empty() {
+            prefix_wildcard
+        } else {
+            raw.starts_with(outbound_prefix)
+        };
+
+        let routed = if prefix_matched && self.strip_outbound_prefix {
+            &raw[outbound_prefix.len()..]
+        } else {
+            raw
+        }
+        .trim();
+
+        if routed.is_empty() {
+            return None;
+        }
+
+        if prefix_wildcard && prefix_matched {
+            return Some(routed.to_string());
+        }
+
+        if self.service_numbers.is_empty() {
+            if prefix_matched {
+                return Some(routed.to_string());
+            }
+            return None;
+        }
+
+        if self.service_numbers.iter().any(|n| n == routed) {
+            return Some(routed.to_string());
+        }
+
+        let wildcard_allowed = outbound_prefix.is_empty() || prefix_matched;
+        if wildcard_allowed
+            && self.service_numbers.iter().any(|n| {
+                if n == "*" {
+                    // A bare "*" means "everything behind the configured prefix". Only honour it when
+                    // a prefix is actually set and matched — otherwise an empty prefix would route
+                    // every local dial to Asterisk. To route all dials, use `outbound_prefix = "*"`.
+                    prefix_matched
+                } else {
+                    n.strip_suffix('*')
+                        .is_some_and(|prefix| !prefix.is_empty() && routed.starts_with(prefix))
+                }
+            })
+        {
+            return Some(routed.to_string());
+        }
+
+        None
     }
 }
 
@@ -78,6 +156,8 @@ pub struct CfgAsteriskDto {
     pub realm: String,
     #[serde(default = "default_options_interval_secs")]
     pub options_interval_secs: u64,
+    #[serde(default = "default_inbound_setup_timeout_secs")]
+    pub inbound_setup_timeout_secs: u32,
 
     #[serde(flatten)]
     pub extra: HashMap<String, Value>,
@@ -106,6 +186,7 @@ impl Default for CfgAsteriskDto {
             password: String::new(),
             realm: default_realm(),
             options_interval_secs: default_options_interval_secs(),
+            inbound_setup_timeout_secs: default_inbound_setup_timeout_secs(),
             extra: HashMap::new(),
         }
     }
@@ -179,6 +260,10 @@ fn default_options_interval_secs() -> u64 {
     30
 }
 
+fn default_inbound_setup_timeout_secs() -> u32 {
+    20
+}
+
 pub fn apply_asterisk_patch(src: CfgAsteriskDto) -> Result<CfgAsterisk, String> {
     if src.enabled {
         if src.bind_port == 0 {
@@ -237,5 +322,114 @@ pub fn apply_asterisk_patch(src: CfgAsteriskDto) -> Result<CfgAsterisk, String> 
         password: SecretField::from(src.password),
         realm: src.realm,
         options_interval_secs: src.options_interval_secs,
+        inbound_setup_timeout_secs: src.inbound_setup_timeout_secs.clamp(1, 60),
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn enabled_cfg(service_numbers: Vec<&str>) -> CfgAsterisk {
+        let dto = CfgAsteriskDto {
+            enabled: true,
+            service_numbers: service_numbers.into_iter().map(str::to_string).collect(),
+            ..CfgAsteriskDto::default()
+        };
+        apply_asterisk_patch(dto).expect("test asterisk config should be valid")
+    }
+
+    #[test]
+    fn exact_service_numbers_still_allow_direct_and_prefixed_dials() {
+        let cfg = enabled_cfg(vec!["385"]);
+        assert_eq!(cfg.route_outbound_raw("91385"), Some("385".to_string()));
+        assert_eq!(cfg.route_outbound_raw("385"), Some("385".to_string()));
+        assert_eq!(cfg.route_outbound_raw("91600"), None);
+    }
+
+    #[test]
+    fn star_service_number_routes_everything_behind_prefix_only() {
+        let cfg = enabled_cfg(vec!["*"]);
+        assert_eq!(cfg.route_outbound_raw("91385"), Some("385".to_string()));
+        assert_eq!(cfg.route_outbound_raw("91600"), Some("600".to_string()));
+        assert_eq!(cfg.route_outbound_raw("385"), None);
+    }
+
+    #[test]
+    fn star_service_number_with_empty_prefix_does_not_route_everything() {
+        // With no outbound_prefix, a bare "*" must NOT hijack every local dial to Asterisk.
+        let dto = CfgAsteriskDto {
+            enabled: true,
+            outbound_prefix: String::new(),
+            service_numbers: vec!["*".to_string()],
+            ..CfgAsteriskDto::default()
+        };
+        let cfg = apply_asterisk_patch(dto).expect("test asterisk config should be valid");
+        assert_eq!(cfg.route_outbound_raw("385"), None);
+        assert_eq!(cfg.route_outbound_raw("91600"), None);
+
+        // A self-scoping wildcard like "38*" with an empty prefix is still fine.
+        let dto2 = CfgAsteriskDto {
+            enabled: true,
+            outbound_prefix: String::new(),
+            service_numbers: vec!["38*".to_string()],
+            ..CfgAsteriskDto::default()
+        };
+        let cfg2 = apply_asterisk_patch(dto2).expect("test asterisk config should be valid");
+        assert_eq!(cfg2.route_outbound_raw("385"), Some("385".to_string()));
+        assert_eq!(cfg2.route_outbound_raw("600"), None);
+
+        // The explicit route-all knob stays `outbound_prefix = "*"`.
+        let dto3 = CfgAsteriskDto {
+            enabled: true,
+            outbound_prefix: "*".to_string(),
+            service_numbers: vec![],
+            ..CfgAsteriskDto::default()
+        };
+        let cfg3 = apply_asterisk_patch(dto3).expect("test asterisk config should be valid");
+        assert_eq!(cfg3.route_outbound_raw("385"), Some("385".to_string()));
+        assert_eq!(cfg3.route_outbound_raw("600"), Some("600".to_string()));
+    }
+
+    #[test]
+    fn outbound_prefix_star_routes_everything_behind_prefix() {
+        let dto = CfgAsteriskDto {
+            enabled: true,
+            outbound_prefix: "91*".to_string(),
+            service_numbers: vec!["385".to_string()],
+            ..CfgAsteriskDto::default()
+        };
+        let cfg = apply_asterisk_patch(dto).expect("test asterisk config should be valid");
+        assert_eq!(cfg.route_outbound_raw("91385"), Some("385".to_string()));
+        assert_eq!(cfg.route_outbound_raw("91600"), Some("600".to_string()));
+        assert_eq!(cfg.route_outbound_raw("385"), Some("385".to_string()));
+    }
+
+    #[test]
+    fn service_number_prefix_wildcard_matches_stripped_number() {
+        let cfg = enabled_cfg(vec!["38*"]);
+        assert_eq!(cfg.route_outbound_raw("91385"), Some("385".to_string()));
+        assert_eq!(cfg.route_outbound_raw("91600"), None);
+    }
+
+    #[test]
+    fn inbound_setup_timeout_defaults_and_clamps_to_supported_range() {
+        assert_eq!(enabled_cfg(vec![]).inbound_setup_timeout_secs, 20);
+
+        let low = apply_asterisk_patch(CfgAsteriskDto {
+            enabled: true,
+            inbound_setup_timeout_secs: 0,
+            ..CfgAsteriskDto::default()
+        })
+        .expect("low timeout config");
+        assert_eq!(low.inbound_setup_timeout_secs, 1);
+
+        let high = apply_asterisk_patch(CfgAsteriskDto {
+            enabled: true,
+            inbound_setup_timeout_secs: 120,
+            ..CfgAsteriskDto::default()
+        })
+        .expect("high timeout config");
+        assert_eq!(high.inbound_setup_timeout_secs, 60);
+    }
 }

--- a/crates/tetra-entities/src/cmce/subentities/cc_bs/pdu.rs
+++ b/crates/tetra-entities/src/cmce/subentities/cc_bs/pdu.rs
@@ -709,10 +709,6 @@ impl CcBsSubentity {
     #[cfg(feature = "asterisk")]
     pub(super) fn asterisk_route_number(&self, network_call: &NetworkCircuitCall) -> Option<String> {
         let cfg = &self.config.config().asterisk;
-        if !cfg.enabled {
-            return None;
-        }
-
         let raw = if !network_call.number.trim().is_empty() {
             network_call.number.trim().to_string()
         } else if network_call.destination != 0 {
@@ -721,28 +717,7 @@ impl CcBsSubentity {
             return None;
         };
 
-        let mut routed = raw.as_str();
-        if !cfg.outbound_prefix.is_empty() && raw.starts_with(&cfg.outbound_prefix) && cfg.strip_outbound_prefix {
-            routed = &raw[cfg.outbound_prefix.len()..];
-        }
-
-        let routed = routed.trim();
-        if routed.is_empty() {
-            return None;
-        }
-
-        if cfg.service_numbers.is_empty() {
-            if !cfg.outbound_prefix.is_empty() && raw.starts_with(&cfg.outbound_prefix) {
-                return Some(routed.to_string());
-            }
-            return None;
-        }
-
-        if cfg.service_numbers.iter().any(|n| n == routed) {
-            Some(routed.to_string())
-        } else {
-            None
-        }
+        cfg.route_outbound_raw(&raw)
     }
 
     pub(super) fn signal_umac_circuit_open(

--- a/crates/tetra-entities/src/cmce/subentities/cc_bs/procedures/isi.rs
+++ b/crates/tetra-entities/src/cmce/subentities/cc_bs/procedures/isi.rs
@@ -7,6 +7,25 @@ use super::*;
 /// group-call interworking belongs beside CC procedures, while PC remains the
 /// CMCE route discriminator.
 impl CcBsSubentity {
+    fn network_setup_timeout_from_secs(secs: u32) -> CallTimeoutSetupPhase {
+        match secs {
+            0 | 1 => CallTimeoutSetupPhase::T1s,
+            2 => CallTimeoutSetupPhase::T2s,
+            3..=5 => CallTimeoutSetupPhase::T5s,
+            6..=10 => CallTimeoutSetupPhase::T10s,
+            11..=20 => CallTimeoutSetupPhase::T20s,
+            21..=30 => CallTimeoutSetupPhase::T30s,
+            _ => CallTimeoutSetupPhase::T60s,
+        }
+    }
+
+    fn network_setup_timeout(&self, network_entity: TetraEntity) -> CallTimeoutSetupPhase {
+        match network_entity {
+            TetraEntity::Asterisk => Self::network_setup_timeout_from_secs(self.config.config().asterisk.inbound_setup_timeout_secs),
+            _ => CallTimeoutSetupPhase::T60s,
+        }
+    }
+
     /// Handle network-initiated circuit setup request (Brew/Asterisk -> local called MS).
     pub(in crate::cmce::subentities::cc_bs) fn fsm_on_network_circuit_setup_request(
         &mut self,
@@ -119,6 +138,7 @@ impl CcBsSubentity {
         let ts = circuit_called.ts;
         let usage = circuit_called.usage;
         let call_timeout = CallTimeout::try_from(call.timeout as u64).unwrap_or(CallTimeout::T5m);
+        let setup_timeout = self.network_setup_timeout(network_entity);
         let circuit_mode = CircuitModeType::try_from(call.mode as u64).unwrap_or(CircuitModeType::TchS);
         let external_subscriber_number = Self::encode_external_subscriber_number(&call.number);
         let calling_party_extension = call.number.trim().parse::<u32>().ok().filter(|value| *value <= 0x00ff_ffff);
@@ -135,7 +155,7 @@ impl CcBsSubentity {
         };
 
         tracing::info!(
-            "CMCE: accepting {:?} setup request uuid={} call_id={} src={} dst={} ts={} duplex={} number='{}'",
+            "CMCE: accepting {:?} setup request uuid={} call_id={} src={} dst={} ts={} duplex={} setup_timeout={} number='{}'",
             network_entity,
             brew_uuid,
             call_id,
@@ -143,6 +163,7 @@ impl CcBsSubentity {
             call.destination,
             ts,
             simplex_duplex,
+            setup_timeout,
             call.number
         );
 
@@ -226,7 +247,7 @@ impl CcBsSubentity {
                 state: IndividualCallState::IncomingSetupPending,
                 formal_state: CcFormalState::Idle.after(CcFormalEvent::SetupRequest),
                 setup_timer_started: Some(self.dltime),
-                setup_timeout: Some(CallTimeoutSetupPhase::T60s),
+                setup_timeout: Some(setup_timeout),
                 active_timer_started: None,
                 call_timeout,
                 called_over_brew: false,
@@ -927,5 +948,18 @@ impl CcBsSubentity {
                 usage,
             }),
         });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn asterisk_setup_timeout_maps_to_supported_tetra_timer() {
+        assert_eq!(CcBsSubentity::network_setup_timeout_from_secs(1), CallTimeoutSetupPhase::T1s);
+        assert_eq!(CcBsSubentity::network_setup_timeout_from_secs(20), CallTimeoutSetupPhase::T20s);
+        assert_eq!(CcBsSubentity::network_setup_timeout_from_secs(21), CallTimeoutSetupPhase::T30s);
+        assert_eq!(CcBsSubentity::network_setup_timeout_from_secs(60), CallTimeoutSetupPhase::T60s);
     }
 }

--- a/crates/tetra-entities/src/net_asterisk/entity.rs
+++ b/crates/tetra-entities/src/net_asterisk/entity.rs
@@ -5,7 +5,7 @@ use std::time::{Duration, Instant};
 
 use tetra_config::bluestation::{AsteriskRuntimeStatus, CfgAsterisk, SharedConfig};
 use tetra_core::{Sap, TdmaTime, tetra_entities::TetraEntity};
-use tetra_pdus::cmce::enums::call_timeout::CallTimeout;
+use tetra_pdus::cmce::enums::{call_timeout::CallTimeout, disconnect_cause::DisconnectCause};
 use tetra_saps::{
     SapMsg, SapMsgInner,
     control::call_control::{CallControl, NetworkCircuitCall},
@@ -147,7 +147,7 @@ pub struct AsteriskEntity {
     sip_socket: UdpSocket,
     remote: SocketAddr,
     dialogs: HashMap<Uuid, SipDialog>,
-    rtp_by_ts: HashMap<(u16, u8), Uuid>,
+    rtp_by_slot: HashMap<(u16, u8), Uuid>,
     next_rtp_port: u16,
     branch_counter: u64,
     register_call_id: String,
@@ -181,7 +181,7 @@ impl AsteriskEntity {
             sip_socket,
             remote,
             dialogs: HashMap::new(),
-            rtp_by_ts: HashMap::new(),
+            rtp_by_slot: HashMap::new(),
             branch_counter: 1,
             register_cseq: 1,
             register_auth: None,
@@ -853,7 +853,7 @@ impl AsteriskEntity {
             reason
         );
         self.send_invite_response(uuid, code, reason, None);
-        self.release_dialog(uuid, false);
+        self.release_dialog(uuid, false, None);
     }
 
     fn handle_inbound_alert(&mut self, uuid: Uuid) {
@@ -978,7 +978,7 @@ impl AsteriskEntity {
     fn mark_media_ready(&mut self, brew_uuid: Uuid, call_id: u16, carrier_num: u16, ts: u8) {
         if let Some(dialog) = self.dialogs.get_mut(&brew_uuid) {
             dialog.media_ready = Some((call_id, carrier_num, ts));
-            self.rtp_by_ts.insert((carrier_num, ts), brew_uuid);
+            self.rtp_by_slot.insert((carrier_num, ts), brew_uuid);
             tracing::info!(
                 "AsteriskEntity: media ready uuid={} call_id={} carrier={} ts={}",
                 brew_uuid,
@@ -989,9 +989,10 @@ impl AsteriskEntity {
         }
     }
 
-    fn release_dialog(&mut self, brew_uuid: Uuid, from_cmce: bool) {
-        let Some((cancel, media_ready, inbound)) = self.dialogs.get(&brew_uuid).map(|dialog| {
+    fn release_dialog(&mut self, brew_uuid: Uuid, from_cmce: bool, cause: Option<u8>) {
+        let Some((state, cancel, media_ready, inbound)) = self.dialogs.get(&brew_uuid).map(|dialog| {
             (
+                dialog.state,
                 !matches!(dialog.state, DialogState::Established),
                 dialog.media_ready,
                 dialog.inbound,
@@ -1001,13 +1002,22 @@ impl AsteriskEntity {
         };
         if from_cmce {
             if inbound && cancel {
-                self.send_invite_response(brew_uuid, 480, "Temporarily Unavailable", None);
+                let setup_timed_out = cause == Some(DisconnectCause::ExpiryOfTimer.into_raw() as u8);
+                if state == DialogState::Inviting && setup_timed_out {
+                    tracing::info!(
+                        "AsteriskEntity: inbound setup timed out before alert uuid={} -> SIP 404 Not Found",
+                        brew_uuid
+                    );
+                    self.send_invite_response(brew_uuid, 404, "Not Found", None);
+                } else {
+                    self.send_invite_response(brew_uuid, 480, "Temporarily Unavailable", None);
+                }
             } else {
                 self.send_bye_or_cancel(brew_uuid, cancel);
             }
         }
         if let Some((_, carrier_num, ts)) = media_ready {
-            self.rtp_by_ts.remove(&(carrier_num, ts));
+            self.rtp_by_slot.remove(&(carrier_num, ts));
         }
         if let Some(dialog) = self.dialogs.get_mut(&brew_uuid) {
             dialog.state = DialogState::Released;
@@ -1016,7 +1026,7 @@ impl AsteriskEntity {
     }
 
     fn handle_ul_voice(&mut self, prim: TmdCircuitDataInd) {
-        let Some(uuid) = self.rtp_by_ts.get(&(prim.carrier_num, prim.ts)).copied() else {
+        let Some(uuid) = self.rtp_by_slot.get(&(prim.carrier_num, prim.ts)).copied() else {
             return;
         };
         let mut send_result = None;
@@ -1138,14 +1148,14 @@ impl AsteriskEntity {
                     self.answer_request(&msg, addr, 200, "OK");
                     if let Some(uuid) = self.find_dialog_by_call_id(msg.call_id()) {
                         self.send_release_to_cmce(queue, uuid, 16);
-                        self.release_dialog(uuid, false);
+                        self.release_dialog(uuid, false, None);
                     }
                 }
                 "CANCEL" => {
                     self.answer_request(&msg, addr, 200, "OK");
                     if let Some(uuid) = self.find_dialog_by_call_id(msg.call_id()) {
                         self.send_release_to_cmce(queue, uuid, 16);
-                        self.release_dialog(uuid, false);
+                        self.release_dialog(uuid, false, None);
                     }
                 }
                 "ACK" => {}
@@ -1266,7 +1276,7 @@ impl AsteriskEntity {
                 }
                 self.set_error(format!("INVITE uuid={} failed with SIP {}", uuid, code));
                 self.send_release_to_cmce(queue, uuid, 34);
-                self.release_dialog(uuid, false);
+                self.release_dialog(uuid, false, None);
             }
             _ => {}
         }
@@ -1389,8 +1399,8 @@ impl TetraEntityTrait for AsteriskEntity {
             }) => {
                 self.mark_media_ready(brew_uuid, call_id, carrier_num, ts);
             }
-            SapMsgInner::CmceCallControl(CallControl::NetworkCircuitRelease { brew_uuid, .. }) => {
-                self.release_dialog(brew_uuid, true);
+            SapMsgInner::CmceCallControl(CallControl::NetworkCircuitRelease { brew_uuid, cause }) => {
+                self.release_dialog(brew_uuid, true, Some(cause));
             }
             SapMsgInner::CmceCallControl(CallControl::NetworkCircuitDtmf { brew_uuid, data, .. }) => {
                 tracing::debug!("AsteriskEntity: DTMF for uuid={} bytes={} currently ignored", brew_uuid, data.len());

--- a/crates/tetra-entities/src/net_dashboard/html.rs
+++ b/crates/tetra-entities/src/net_dashboard/html.rs
@@ -2930,6 +2930,7 @@ tbody tr:hover td{background:color-mix(in srgb,var(--bg3) 70%, transparent);}
             <div class="info-row"><div class="info-key" data-i18n="ast_remote">Remote Asterisk</div><div class="info-val" id="ast-remote">—</div></div>
             <div class="info-row"><div class="info-key" data-i18n="ast_rtp">RTP ports</div><div class="info-val" id="ast-rtp">—</div></div>
             <div class="info-row"><div class="info-key" data-i18n="ast_codec">Codec</div><div class="info-val" id="ast-codec">—</div></div>
+            <div class="info-row"><div class="info-key">Inbound setup timeout</div><div class="info-val" id="ast-setup-timeout">—</div></div>
             <div class="info-row"><div class="info-key" data-i18n="ast_last_rx">Last RX</div><div class="info-val" id="ast-last-rx">—</div></div>
             <div class="info-row"><div class="info-key" data-i18n="ast_last_tx">Last TX</div><div class="info-val" id="ast-last-tx">—</div></div>
             <div class="info-row"><div class="info-key" data-i18n="ast_last_error">Last error</div><div class="info-val" id="ast-last-error">—</div></div>
@@ -6336,6 +6337,7 @@ async function loadAsteriskStatus(){
     set('ast-remote', rt.remote||c.remote);
     set('ast-rtp', rt.rtp_port_range||c.rtp_port_range);
     set('ast-codec', rt.codec||c.codec);
+    set('ast-setup-timeout', (c.inbound_setup_timeout_secs??20)+'s');
     set('ast-last-rx', rt.last_rx);
     set('ast-last-tx', rt.last_tx);
     set('ast-last-error', rt.last_error);

--- a/crates/tetra-entities/src/net_dashboard/server.rs
+++ b/crates/tetra-entities/src/net_dashboard/server.rs
@@ -4040,6 +4040,7 @@ fn serve_asterisk_status(stream: TcpStream, shared_config: &Option<tetra_config:
                     "remote": format!("{}:{}", c.asterisk.remote_host, c.asterisk.remote_port),
                     "rtp_port_range": format!("{}-{}", c.asterisk.rtp_port_min, c.asterisk.rtp_port_max),
                     "codec": c.asterisk.codec.clone(),
+                    "inbound_setup_timeout_secs": c.asterisk.inbound_setup_timeout_secs,
                     "outbound_prefix": c.asterisk.outbound_prefix.clone(),
                     "strip_outbound_prefix": c.asterisk.strip_outbound_prefix,
                     "service_numbers": c.asterisk.service_numbers.clone(),

--- a/example_config/config.toml
+++ b/example_config/config.toml
@@ -809,7 +809,8 @@ voice_service = true
 
 # OPTIONAL: Asterisk SIP/RTP bridge — parallel to Brew, not a replacement.
 # Only destinations listed in service_numbers are routed to Asterisk; everything else
-# stays on the normal local/Brew path.
+# stays on the normal local/Brew path. Use ["*"] to route every dial behind
+# outbound_prefix to Asterisk.
 #
 # Example: a TETRA dial string 91600 with outbound_prefix="91" and strip=true becomes
 # SIP user 600, but only because "600" is listed below.
@@ -825,9 +826,12 @@ voice_service = true
 # outbound_prefix = "91"
 # strip_outbound_prefix = true
 # inbound_prefix = "T"
+# inbound_setup_timeout_secs = 20 # SIP -> TETRA no-alert timeout; returns 404 before ringing
 # register = true
 # codec = "PCMU"
 # service_numbers = ["600", "601"]
+# service_numbers = ["*"]       # wildcard: 91... -> Asterisk for every suffix
+# outbound_prefix = "91*"       # alternative wildcard prefix spelling
 # rtp_port_min = 30000
 # rtp_port_max = 30100
 # bind_addr = "0.0.0.0"


### PR DESCRIPTION
Lands the Asterisk/SIP routing fix from #26 onto **beta** — the SIP 404 path wants a smoke-test on a real Asterisk before it goes to main, so it bakes here next to MeshCom.

## What's in it
- **Wildcard outbound dial routing** — `route_outbound_raw` centralizes the matching with exact entries plus `*` and prefix (`38*`) wildcards, replacing the old inline matcher. Covered by unit tests.
- **`inbound_setup_timeout_secs`** (default 20s, clamped 1–60) mapped to a discrete TETRA setup timer; an inbound setup that expires *before* alerting now returns SIP **404** instead of a generic **480** (other unavailable states still 480). Effective timeout is shown on the Asterisk dashboard page.
- **README** Debian 13 / Asterisk 22 source-build notes.

## One change on top of #26
A bare `"*"` in `service_numbers` now only routes when a non-empty `outbound_prefix` actually matched. Before, `service_numbers=["*"]` with no prefix routed **every** local dial to Asterisk — an easy way to accidentally hijack all TETRA traffic to SIP. The explicit route-all knob stays `outbound_prefix = "*"`. Added a regression test for the empty-prefix case and tightened the doc + example config.

## Blast radius
The outbound matcher lives behind `#[cfg(feature = "asterisk")]`. The one always-compiled change is the setup-timer mapping in `cc_bs/procedures/isi.rs`, which returns the same `T60s` as before for every non-Asterisk network entity (Brew etc.) — verified building with the feature off; no behaviour change to Brew/CMCE call control.

## Testing
- `cargo test -p tetra-config` — 36 passed (incl. the new empty-prefix test)
- full workspace suite green (entities lib 192, all integration suites)
- `cargo build -p tetra-entities --features asterisk` clean; clippy clean

## Still wants a real-Asterisk test
The SIP 404-vs-480 response branch has no automated coverage (it's a live UDP path), so smoke-test inbound expiry on a real Asterisk before relying on it.

Credit: Asterisk/SIP fix by @Torben-DJ2TH (#26).
