### PR TITLE
 Fix local echo service 999

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,17 @@ colour_code = 1
 | `ul_inactivity_secs` | `3` | UL silence before forced TX-CEASED (1–30s) |
 | `periodic_registration_secs` | `3600` | T351 interval; `0` = disabled |
 
+### Internal service ISSIs
+
+FlowStation reserves a few short ISSIs for services that terminate inside the
+base station instead of being routed to another radio or network bridge:
+
+| ISSI | Service | Notes |
+|---:|---|---|
+| `999` | Local voice echo / loopback | P2P calls to `999` are intercepted before the local registration check and before Brew/Asterisk routing. FlowStation allocates one bidirectional traffic slot, sends `D-CALL-PROCEEDING` and `D-CONNECT` with channel allocation to the caller, opens UMAC with `LocalLoopback`, and reflects the caller's own uplink audio back to the same terminal. The virtual `999` party does not need to be registered. |
+| `9998` | WX/METAR SDS service | Optional weather SDS service when `[wx_service]` is enabled. |
+| `9999` | BS control/source ISSI | Used by SDS command control, local control messages, and as the default source ISSI for injected SDS, DAPNET, MeshCom, GeoAlarm, Snom, and TPG2200 actions. SDS ACKs for `9999` are absorbed locally and are not forwarded to Brew. |
+
 ### Brew interconnect (BrandMeister / TetraPack)
 
 ```toml
@@ -546,7 +557,12 @@ Available at `http://<bts-ip>:8080` when `[dashboard]` is configured.
 
 **SDS ACK for ISSI 9999** — SDS ACK for the local BS control ISSI was being forwarded to Brew, generating spurious traffic. Now absorbed locally.
 
-**Chan_alloc in DConnect for echo service 999** — echo service calls were allocated without a traffic channel, causing audio to fail.
+**Local echo service 999** — P2P calls to ISSI `999` bypass normal
+local-registration and network-bridge checks. FlowStation creates an explicit
+local loopback call for the caller, sends `D-CONNECT` with channel allocation,
+opens a same-slot `LocalLoopback` traffic circuit, and skips the virtual `999`
+leg during release/floor signalling. This fixes the regression where `999`
+could be treated as an unregistered ISSI and routed to Brew.
 
 ---
 

--- a/crates/tetra-entities/src/cmce/subentities/cc_bs/mod.rs
+++ b/crates/tetra-entities/src/cmce/subentities/cc_bs/mod.rs
@@ -55,7 +55,7 @@ use pdu::is_emergency_priority;
 use procedures::{GroupTransitionError, IndividualTransitionError};
 use state::{
     ActiveCall, CachedSetup, CallOrigin, CcFormalEvent, CcFormalState, GroupCallState, IndividualCall, IndividualCallState,
-    TxDemandQueueResult,
+    LOCAL_ECHO_ISSI, TxDemandQueueResult,
 };
 
 /// Clause 11 Call Control CMCE sub-entity

--- a/crates/tetra-entities/src/cmce/subentities/cc_bs/pdu.rs
+++ b/crates/tetra-entities/src/cmce/subentities/cc_bs/pdu.rs
@@ -984,7 +984,7 @@ impl CcBsSubentity {
         };
 
         let send_calling_leg = !call.calling_over_brew;
-        let send_called_leg = !call.called_over_brew;
+        let send_called_leg = !call.called_over_brew && !call.is_local_echo_call();
 
         const SETUP_RELEASE_REPEATS: usize = 3;
 

--- a/crates/tetra-entities/src/cmce/subentities/cc_bs/procedures/setup.rs
+++ b/crates/tetra-entities/src/cmce/subentities/cc_bs/procedures/setup.rs
@@ -69,6 +69,226 @@ impl CcBsSubentity {
         }
     }
 
+    fn fsm_on_u_setup_p2p_local_echo(
+        &mut self,
+        queue: &mut MessageQueue,
+        message: &SapMsg,
+        pdu: &USetup,
+        calling_party: TetraAddress,
+        called_addr: TetraAddress,
+    ) {
+        let SapMsgInner::LcmcMleUnitdataInd(prim) = &message.msg else {
+            tracing::warn!("CMCE: cannot create local echo call from non-LCMC message");
+            return;
+        };
+
+        if let Some((active_call_id, state, cause)) = self.setup_collision_cause(calling_party.ssi, None) {
+            tracing::info!(
+                "CMCE: rejecting local echo U-SETUP from ISSI {} (collision call_id={} state={:?} cause={})",
+                calling_party.ssi,
+                active_call_id,
+                state,
+                cause
+            );
+            self.reject_setup_request(queue, message, calling_party, cause, "local echo setup collision");
+            return;
+        }
+
+        if is_emergency_priority(pdu.call_priority) {
+            tracing::info!(
+                "CMCE: EMERGENCY local echo call set-up from ISSI {} (priority {})",
+                calling_party.ssi,
+                pdu.call_priority
+            );
+        }
+
+        // Local echo has no second MS leg. One bidirectional traffic slot is enough, regardless
+        // of whether the requesting terminal marks the P2P call as simplex or duplex.
+        self.ensure_timeslots_for_priority(queue, 1, pdu.call_priority);
+        let circuit = {
+            let mut state = self.config.state_write();
+            match self.circuits.allocate_circuit_with_allocator(
+                Direction::Both,
+                pdu.basic_service_information.communication_type,
+                pdu.simplex_duplex_selection,
+                &mut state.timeslot_alloc,
+                TimeslotOwner::Cmce,
+            ) {
+                Ok(circuit) => circuit.clone(),
+                Err(e) => {
+                    tracing::info!(
+                        "CMCE: rejecting local echo U-SETUP from ISSI {} (no free channel: {:?})",
+                        calling_party.ssi,
+                        e
+                    );
+                    drop(state);
+                    self.reject_setup_request(
+                        queue,
+                        message,
+                        calling_party,
+                        DisconnectCause::CongestionInInfrastructure,
+                        "failed to allocate local echo circuit",
+                    );
+                    return;
+                }
+            }
+        };
+
+        let call_id = circuit.call_id;
+        let carrier_num = circuit.carrier_num;
+        let ts = circuit.ts;
+        let usage = circuit.usage;
+        let call_timeout = Self::p2p_call_timeout(pdu.simplex_duplex_selection);
+
+        tracing::info!(
+            "CMCE: local echo U-SETUP from ISSI {} to ISSI {} -> call_id={} carrier={} ts={} usage={} duplex={}",
+            calling_party.ssi,
+            called_addr.ssi,
+            call_id,
+            carrier_num,
+            ts,
+            usage,
+            pdu.simplex_duplex_selection
+        );
+
+        let call = IndividualCall {
+            calling_addr: calling_party,
+            called_addr,
+            calling_handle: prim.handle,
+            calling_link_id: prim.link_id,
+            calling_endpoint_id: prim.endpoint_id,
+            called_handle: None,
+            called_link_id: None,
+            called_endpoint_id: None,
+            calling_carrier_num: carrier_num,
+            calling_ts: ts,
+            called_carrier_num: carrier_num,
+            called_ts: ts,
+            calling_usage: usage,
+            called_usage: usage,
+            simplex_duplex: pdu.simplex_duplex_selection,
+            priority: pdu.call_priority,
+            state: IndividualCallState::CallSetupPending,
+            formal_state: CcFormalState::Idle.after(CcFormalEvent::SetupRequest),
+            setup_timer_started: Some(self.dltime),
+            setup_timeout: Some(CallTimeoutSetupPhase::T10s),
+            active_timer_started: None,
+            call_timeout,
+            called_over_brew: false,
+            calling_over_brew: false,
+            network_entity: TetraEntity::Brew,
+            brew_uuid: None,
+            network_call: None,
+            connect_request_sent: false,
+            floor_holder: None,
+            queued_tx_demand: None,
+        };
+
+        if let Err(err) = self.fsm_individual_create_setup_call(call_id, call) {
+            tracing::warn!("CMCE: local echo call_id={} creation failed: {:?}", call_id, err);
+            self.abort_individual_setup(
+                queue,
+                call_id,
+                calling_party,
+                prim.handle,
+                prim.link_id,
+                prim.endpoint_id,
+                &[CarrierSlot { carrier_num, ts }],
+                DisconnectCause::NoIdleCcEntity,
+            );
+            return;
+        }
+
+        if let Err(err) = self.fsm_individual_transition_to_active(call_id) {
+            tracing::warn!("CMCE: local echo call_id={} activation failed: {:?}", call_id, err);
+            self.abort_individual_setup(
+                queue,
+                call_id,
+                calling_party,
+                prim.handle,
+                prim.link_id,
+                prim.endpoint_id,
+                &[CarrierSlot { carrier_num, ts }],
+                DisconnectCause::IncompatibleTrafficCase,
+            );
+            return;
+        }
+
+        Self::signal_umac_circuit_open(queue, &circuit, self.dltime, None, None, CircuitDlMediaSource::LocalLoopback);
+
+        self.send_d_call_proceeding(queue, message, pdu, call_id, CallTimeoutSetupPhase::T10s, pdu.hook_method_selection);
+
+        let mut timeslots = [false; 4];
+        timeslots[ts as usize - 1] = true;
+        let chan_alloc = CmceChanAllocReq {
+            usage: Some(usage),
+            alloc_type: ChanAllocType::Replace,
+            carrier: Some(carrier_num),
+            timeslots,
+            ul_dl_assigned: UlDlAssignment::Both,
+        };
+
+        let d_connect = DConnect {
+            call_identifier: call_id,
+            call_time_out: call_timeout,
+            hook_method_selection: pdu.hook_method_selection,
+            simplex_duplex_selection: pdu.simplex_duplex_selection,
+            transmission_grant: TransmissionGrant::Granted,
+            transmission_request_permission: false,
+            call_ownership: true,
+            call_priority: None,
+            basic_service_information: None,
+            temporary_address: None,
+            notification_indicator: None,
+            facility: None,
+            proprietary: None,
+        };
+
+        tracing::info!("-> {:?}", d_connect);
+        let mut connect_sdu = BitBuffer::new_autoexpand(30);
+        d_connect.to_bitbuf(&mut connect_sdu).expect("Failed to serialize DConnect");
+        connect_sdu.seek(0);
+
+        queue.push_back(SapMsg {
+            sap: Sap::LcmcSap,
+            src: TetraEntity::Cmce,
+            dest: TetraEntity::Mle,
+            msg: SapMsgInner::LcmcMleUnitdataReq(LcmcMleUnitdataReq {
+                sdu: connect_sdu,
+                handle: prim.handle,
+                endpoint_id: prim.endpoint_id,
+                link_id: prim.link_id,
+                layer2service: Layer2Service::Unacknowledged,
+                pdu_prio: 0,
+                layer2_qos: 0,
+                stealing_permission: false,
+                stealing_repeats_flag: false,
+                chan_alloc: Some(chan_alloc),
+                main_address: calling_party,
+                tx_reporter: None,
+            }),
+        });
+
+        if !pdu.simplex_duplex_selection {
+            if let Some(call) = self.individual_calls.get_mut(&call_id) {
+                call.grant_floor(calling_party);
+            }
+            self.notify_floor_granted(
+                queue,
+                GroupFloorGrant {
+                    call_id,
+                    source_issi: calling_party.ssi,
+                    dest_gssi: LOCAL_ECHO_ISSI,
+                    carrier_num,
+                    ts,
+                    is_group: false,
+                },
+                true,
+                BrewNotification::Never,
+            );
+        }
+    }
+
     /// Handle U-SETUP for group calls (non-P2P communication types).
     pub(in crate::cmce::subentities::cc_bs) fn fsm_on_u_setup_group(
         &mut self,
@@ -375,6 +595,11 @@ impl CcBsSubentity {
         }
 
         let called_addr = TetraAddress::new(called_ssi, SsiType::Issi);
+
+        if called_addr.ssi == LOCAL_ECHO_ISSI {
+            self.fsm_on_u_setup_p2p_local_echo(queue, message, pdu, calling_party, called_addr);
+            return;
+        }
 
         // PBX/phone calls (no concrete local ISSI) always go through Brew.
         if called_ssi == 0 {

--- a/crates/tetra-entities/src/cmce/subentities/cc_bs/procedures/uplink.rs
+++ b/crates/tetra-entities/src/cmce/subentities/cc_bs/procedures/uplink.rs
@@ -49,6 +49,7 @@ impl CcBsSubentity {
     fn individual_floor_party_is_local(call: &IndividualCall, party: IndividualFloorParty) -> bool {
         !(call.calling_over_brew && party.addr.ssi == call.calling_addr.ssi
             || call.called_over_brew && party.addr.ssi == call.called_addr.ssi)
+            && !(call.is_local_echo_call() && party.addr.ssi == LOCAL_ECHO_ISSI)
     }
 
     fn send_individual_d_tx_granted(

--- a/crates/tetra-entities/src/cmce/subentities/cc_bs/state/mod.rs
+++ b/crates/tetra-entities/src/cmce/subentities/cc_bs/state/mod.rs
@@ -45,6 +45,8 @@ fn call_timeout_to_timeslots(timeout: CallTimeout) -> Option<i32> {
     }
 }
 
+pub(super) const LOCAL_ECHO_ISSI: u32 = 999;
+
 pub(super) struct CachedSetup {
     pub(super) pdu: DSetup,
     pub(super) dest_addr: TetraAddress,
@@ -427,6 +429,16 @@ pub(super) struct IndividualCall {
 }
 
 impl IndividualCall {
+    #[inline]
+    pub(super) fn is_local_echo_call(&self) -> bool {
+        self.called_addr.ssi == LOCAL_ECHO_ISSI
+            && self.called_handle.is_none()
+            && self.called_carrier_num == self.calling_carrier_num
+            && self.called_ts == self.calling_ts
+            && !self.calling_over_brew
+            && !self.called_over_brew
+    }
+
     #[inline]
     pub(super) fn is_alerted(&self) -> bool {
         matches!(

--- a/crates/tetra-entities/tests/test_cmce_bs.rs
+++ b/crates/tetra-entities/tests/test_cmce_bs.rs
@@ -17,7 +17,7 @@ use tetra_pdus::cmce::pdus::{
     u_tx_demand::UTxDemand,
 };
 use tetra_saps::control::brew::{BrewSubscriberAction, MmSubscriberUpdate};
-use tetra_saps::control::call_control::{CallControl, NetworkCircuitCall};
+use tetra_saps::control::call_control::{CallControl, CircuitDlMediaSource, NetworkCircuitCall};
 use tetra_saps::control::enums::circuit_mode_type::CircuitModeType;
 use tetra_saps::control::enums::communication_type::CommunicationType;
 use tetra_saps::lcmc::LcmcMleUnitdataInd;
@@ -496,6 +496,96 @@ fn count_d_setups(msgs: &[SapMsg]) -> usize {
                     if dl_pdu_type(&prim.sdu) == Some(CmcePduTypeDl::DSetup))
         })
         .count()
+}
+
+#[test]
+fn test_local_echo_999_bypasses_registration_and_brew() {
+    debug::setup_logging_verbose();
+
+    const LOCAL_ECHO_ISSI: u32 = 999;
+    let calling_issi = 1000001;
+    let dltime = TdmaTime { h: 0, m: 1, f: 1, t: 1 };
+    let mut test = ComponentTest::new(StackMode::Bs, Some(dltime));
+    test.populate_entities(
+        vec![TetraEntity::Cmce],
+        vec![TetraEntity::Mle, TetraEntity::Umac, TetraEntity::Brew],
+    );
+
+    // The virtual echo party is deliberately not registered.
+    test.submit_message(build_individual_u_setup_msg_with_mode(calling_issi, LOCAL_ECHO_ISSI, true));
+    test.run_stack(Some(1));
+    let msgs = test.dump_sinks();
+
+    let (mut connect_sdu, connect_alloc) =
+        find_lcmc_req(&msgs, calling_issi, CmcePduTypeDl::DConnect).expect("local echo must answer the caller immediately");
+    let d_connect = DConnect::from_bitbuf(&mut connect_sdu).expect("local echo D-CONNECT must parse");
+    assert_eq!(d_connect.transmission_grant, TransmissionGrant::Granted);
+    assert_eq!(connect_alloc, Some(UlDlAssignment::Both));
+
+    assert!(
+        find_lcmc_req(&msgs, LOCAL_ECHO_ISSI, CmcePduTypeDl::DSetup).is_none(),
+        "the virtual echo party must not receive a radio-side D-SETUP"
+    );
+    assert!(
+        !msgs.iter().any(|msg| matches!(
+            &msg.msg,
+            SapMsgInner::CmceCallControl(CallControl::NetworkCircuitSetupRequest { .. })
+        )),
+        "ISSI 999 must never be routed to Brew"
+    );
+
+    let open_circuits: Vec<_> = msgs
+        .iter()
+        .filter_map(|msg| match &msg.msg {
+            SapMsgInner::CmceCallControl(CallControl::Open(circuit)) => Some(circuit),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(open_circuits.len(), 1, "local echo must use exactly one traffic circuit");
+    assert_eq!(open_circuits[0].direction, Direction::Both);
+    assert_eq!(open_circuits[0].dl_media_source, CircuitDlMediaSource::LocalLoopback);
+    assert_eq!(open_circuits[0].peer_ts, None);
+}
+
+#[test]
+fn test_local_echo_999_release_skips_virtual_radio_leg() {
+    debug::setup_logging_verbose();
+
+    const LOCAL_ECHO_ISSI: u32 = 999;
+    let calling_issi = 1000001;
+    let dltime = TdmaTime { h: 0, m: 1, f: 1, t: 1 };
+    let mut test = ComponentTest::new(StackMode::Bs, Some(dltime));
+    test.populate_entities(
+        vec![TetraEntity::Cmce],
+        vec![TetraEntity::Mle, TetraEntity::Umac, TetraEntity::Brew],
+    );
+
+    test.submit_message(build_individual_u_setup_msg_with_mode(calling_issi, LOCAL_ECHO_ISSI, true));
+    test.run_stack(Some(1));
+    let setup_msgs = test.dump_sinks();
+    let (mut connect_sdu, _) = find_lcmc_req(&setup_msgs, calling_issi, CmcePduTypeDl::DConnect).expect("expected local echo D-CONNECT");
+    let call_id = DConnect::from_bitbuf(&mut connect_sdu)
+        .expect("local echo D-CONNECT must parse")
+        .call_identifier;
+
+    test.submit_message(build_u_disconnect_msg(calling_issi, call_id));
+    test.run_stack(Some(1));
+    let release_msgs = test.dump_sinks();
+
+    assert!(
+        find_lcmc_req(&release_msgs, calling_issi, CmcePduTypeDl::DRelease).is_some(),
+        "the caller must receive D-RELEASE"
+    );
+    assert!(
+        find_lcmc_req(&release_msgs, LOCAL_ECHO_ISSI, CmcePduTypeDl::DRelease).is_none(),
+        "the virtual echo party must not receive a radio-side D-RELEASE"
+    );
+    assert!(
+        release_msgs
+            .iter()
+            .any(|msg| matches!(&msg.msg, SapMsgInner::CmceCallControl(CallControl::CloseSlot { .. }))),
+        "the local echo traffic circuit must be closed"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- intercept P2P calls to ISSI `999` before subscriber registration and network-bridge routing
- create an immediately active, single-slot `LocalLoopback` circuit with carrier-aware channel allocation
- suppress radio-side release and floor signalling for the virtual echo party
- document the reserved internal service ISSIs
- add regression coverage for setup, Brew isolation, media routing, and release cleanup

## Root cause

The original local echo handler was lost during the dual-carrier merge while the README still described the service as fixed. As a result, ISSI `999` was treated as an unregistered subscriber and routed to Brew, or rejected when Brew was unavailable.

## Impact

Calling `999` now works without registering a virtual subscriber and without an active Brew connection. The caller receives `D-CALL-PROCEEDING` and `D-CONNECT` with a bidirectional traffic-channel allocation, and UMAC loops the caller's uplink audio back on the same carrier and timeslot.

## Validation

- `DOCS_RS=1 cargo test -p tetra-entities`
  - 191 unit tests passed, 5 ignored
  - 33 CMCE integration tests passed, 1 pre-existing ignored
  - all LLC, MM, SDS, UMAC BS/MS integration tests passed
- `DOCS_RS=1 cargo check -p bluestation-bs --no-default-features`
- `git diff --check`
