### PR TITLE
Integrate second Brew server

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,6 +315,32 @@ forwarding between Brew backhauls. `local_issi_blocklist` is applied after the
 allowlist and can be used to exclude a terminal from one Brew server without
 changing larger allowlist ranges/lists.
 
+`local_issi_whitelist` / `issi_whitelist` and
+`local_issi_blacklist` / `issi_blacklist` remain accepted aliases. The explicit
+`allowlist` and `blocklist` names above are preferred.
+
+Different Brew implementations may use different subscriber message type
+numbers. Defaults are compatible with TetraPack (`0/1/2/8/9`); override them per
+server only when its documentation requires it:
+
+```toml
+subscriber_type_deregister = 0
+subscriber_type_register = 1
+subscriber_type_reregister = 2
+subscriber_type_affiliate = 8
+subscriber_type_deaffiliate = 9
+```
+
+Loop protection also rejects Brew-originated subscriber state for
+`cell_info.local_ssi_ranges` and for every ISSI assigned to either local Brew
+allowlist. A local terminal is therefore never mirrored back from Brew into
+CMCE as an external listener.
+
+In a dual-Brew setup, assign the configured source ISSI for dashboard and
+integration-generated SDS (normally `9999`) to exactly one server's
+`local_issi_allowlist`. This selects which backhaul carries those messages; it
+does not expose Brew-originated state for that reserved local ISSI.
+
 ### Asterisk SIP/RTP bridge
 
 FlowStation can register as a PJSIP endpoint and bridge calls between TETRA

--- a/README.md
+++ b/README.md
@@ -289,11 +289,37 @@ username = 123456700
 password = "your_password"
 ```
 
+Optional second Brew backhaul:
+
+```toml
+[brew]
+host = "core-a.example"
+username = 123456700
+password = "..."
+local_issi_allowlist = [2632585]
+local_issi_blocklist = []
+
+[brew2]
+host = "core-b.example"
+username = 123456701
+password = "..."
+local_issi_allowlist = [2635411]
+local_issi_blocklist = []
+```
+
+When both `[brew]` and `[brew2]` are configured, each section must define a
+non-empty `local_issi_allowlist`, and the lists must not overlap. Registrations,
+SDS, voice forwarding, RSSI export, and group-call lifecycle events are routed to
+exactly one Brew server by the local source ISSI, preventing loops or A↔B
+forwarding between Brew backhauls. `local_issi_blocklist` is applied after the
+allowlist and can be used to exclude a terminal from one Brew server without
+changing larger allowlist ranges/lists.
+
 ### Asterisk SIP/RTP bridge
 
 FlowStation can register as a PJSIP endpoint and bridge calls between TETRA
 terminals and Asterisk phones. Brew remains available in parallel; only configured
-service numbers are routed to Asterisk.
+service numbers are routed to Asterisk, unless a wildcard is configured.
 
 ```toml
 [asterisk]
@@ -360,6 +386,12 @@ qualify_frequency=30
 
 `service_numbers` is deliberately an allowlist. If a TETRA user dials `91385`,
 FlowStation strips `91`, checks that `385` is listed, then calls SIP user `385`.
+To route every `91...` dial to Asterisk, set `service_numbers = ["*"]`.
+Alternatively, `outbound_prefix = "91*"` makes the prefix itself a wildcard. More
+specific prefix wildcards are also allowed inside `service_numbers`, for example
+`["38*"]` routes `9138...` to Asterisk after stripping `91`. Exact entries still
+work as before, so `service_numbers = ["385"]` permits `91385` and direct `385`,
+but not `91600`.
 
 ### Telegram alerts
 

--- a/bins/bluestation-bs/src/main.rs
+++ b/bins/bluestation-bs/src/main.rs
@@ -209,7 +209,7 @@ fn build_bs_stack(
         let hcfg = cfg.config().health.clone();
         if hcfg.enabled {
             use std::time::Duration;
-            tetra_entities::health::registry().set_brew_configured(cfg.config().brew.is_some());
+            tetra_entities::health::registry().set_brew_configured(cfg.config().brew.is_some() || cfg.config().brew2.is_some());
             tetra_entities::health::spawn_health_monitor(
                 sink.clone(),
                 tetra_entities::health::HealthMonitorConfig {
@@ -284,12 +284,21 @@ fn build_bs_stack(
     // Register Brew entity if enabled
     if let Some(ref brew_cfg) = cfg.config().brew {
         let transport = new_websocket_transport(brew_cfg);
-        let mut brew_entity = BrewEntity::new(cfg.clone(), transport);
+        let mut brew_entity = BrewEntity::new(cfg.clone(), TetraEntity::Brew, brew_cfg.clone(), transport);
         if let Some(ref sink) = tsink {
             brew_entity.set_telemetry_sink(sink.clone());
         }
         router.register_entity(Box::new(brew_entity));
         eprintln!(" -> Brew/TetraPack integration enabled");
+    }
+    if let Some(ref brew_cfg) = cfg.config().brew2 {
+        let transport = new_websocket_transport(brew_cfg);
+        let mut brew_entity = BrewEntity::new(cfg.clone(), TetraEntity::Brew2, brew_cfg.clone(), transport);
+        if let Some(ref sink) = tsink {
+            brew_entity.set_telemetry_sink(sink.clone());
+        }
+        router.register_entity(Box::new(brew_entity));
+        eprintln!(" -> Brew2/TetraPack integration enabled");
     }
 
     // Register Asterisk SIP/RTP entity if enabled. Only compiled in with the

--- a/crates/tetra-config/src/bluestation/config.rs
+++ b/crates/tetra-config/src/bluestation/config.rs
@@ -75,6 +75,9 @@ pub struct StackConfig {
     /// Brew protocol (TetraPack/BrandMeister) configuration
     pub brew: Option<CfgBrew>,
 
+    /// Optional secondary Brew protocol bridge.
+    pub brew2: Option<CfgBrew>,
+
     /// Asterisk SIP/RTP bridge configuration.
     pub asterisk: CfgAsterisk,
 
@@ -308,6 +311,28 @@ impl StackConfig {
             && self.recovery.issi_allowlist.len() as u32 > self.recovery.max_cached_issis
         {
             return Err("recovery.issi_allowlist has more entries than recovery.max_cached_issis");
+        }
+
+        if self.brew.is_some() && self.brew2.is_some() {
+            let brew = self.brew.as_ref().expect("checked");
+            let brew2 = self.brew2.as_ref().expect("checked");
+            if !brew.has_local_issi_allowlist() || !brew2.has_local_issi_allowlist() {
+                return Err("brew and brew2 require non-empty local_issi_allowlist when both are configured");
+            }
+
+            let Some(brew_allowlist) = brew.effective_local_issi_allowlist() else {
+                return Err("brew local_issi_allowlist is required when brew2 is configured");
+            };
+            let Some(brew2_allowlist) = brew2.effective_local_issi_allowlist() else {
+                return Err("brew2 local_issi_allowlist is required when brew is configured");
+            };
+            if brew_allowlist.is_empty() || brew2_allowlist.is_empty() {
+                return Err("brew and brew2 effective local_issi_allowlist must not be empty");
+            }
+            let brew_set: std::collections::HashSet<u32> = brew_allowlist.into_iter().collect();
+            if brew2_allowlist.into_iter().any(|issi| brew_set.contains(&issi)) {
+                return Err("brew and brew2 local_issi_allowlist must not overlap");
+            }
         }
 
         Ok(())

--- a/crates/tetra-config/src/bluestation/parsing.rs
+++ b/crates/tetra-config/src/bluestation/parsing.rs
@@ -779,4 +779,90 @@ pbx_gateway_issi = [16777184, 16777186]
         let brew = cfg.brew.expect("brew config should be present");
         assert_eq!(brew.pbx_gateway_issis, Some(vec![16_777_184, 16_777_186]));
     }
+
+    fn dual_brew_toml(brew_lists: &str, brew2_lists: &str) -> String {
+        minimal_toml("")
+            + &format!(
+                r#"
+[brew]
+host = "brew-one.invalid"
+tls = false
+username = 123456700
+password = "one"
+{}
+
+[brew2]
+host = "brew-two.invalid"
+tls = false
+username = 123456701
+password = "two"
+{}
+"#,
+                brew_lists, brew2_lists
+            )
+    }
+
+    #[test]
+    fn dual_brew_requires_nonempty_disjoint_local_allowlists() {
+        let missing = from_toml_str(&dual_brew_toml("", "")).expect("dual Brew config parses");
+        assert_eq!(
+            missing.validate(),
+            Err("brew and brew2 require non-empty local_issi_allowlist when both are configured")
+        );
+
+        let overlapping = from_toml_str(&dual_brew_toml(
+            "local_issi_allowlist = [2632585, 2635411]",
+            "local_issi_allowlist = [2635411, 2636000]",
+        ))
+        .expect("dual Brew config parses");
+        assert_eq!(overlapping.validate(), Err("brew and brew2 local_issi_allowlist must not overlap"));
+
+        let valid = from_toml_str(&dual_brew_toml(
+            "local_issi_allowlist = [2632585]",
+            "local_issi_allowlist = [2636000]",
+        ))
+        .expect("dual Brew config parses");
+        assert!(valid.validate().is_ok());
+    }
+
+    #[test]
+    fn dual_brew_blocklist_wins_and_must_leave_each_server_an_issi() {
+        let blocked = from_toml_str(&dual_brew_toml(
+            "local_issi_allowlist = [2632585]\nlocal_issi_blocklist = [2632585]",
+            "local_issi_allowlist = [2636000]",
+        ))
+        .expect("dual Brew config parses");
+        assert_eq!(
+            blocked.validate(),
+            Err("brew and brew2 effective local_issi_allowlist must not be empty")
+        );
+
+        let valid = from_toml_str(&dual_brew_toml(
+            "local_issi_allowlist = [2632585, 2635411]\nlocal_issi_blocklist = [2635411]",
+            "local_issi_allowlist = [2636000]",
+        ))
+        .expect("dual Brew config parses");
+        let brew = valid.brew.as_ref().expect("brew config");
+        assert!(brew.local_issi_allowed(2632585));
+        assert!(!brew.local_issi_allowed(2635411));
+        assert!(valid.validate().is_ok());
+    }
+
+    #[test]
+    fn brew_list_aliases_and_subscriber_types_parse_per_server() {
+        let cfg = from_toml_str(&dual_brew_toml(
+            "local_issi_whitelist = [2632585]\nsubscriber_type_affiliate = 18",
+            "local_issi_allowlist = [2636000]\nissi_blacklist = [2636001]\nsubscriber_type_register = 11",
+        ))
+        .expect("dual Brew aliases parse");
+
+        let brew = cfg.brew.as_ref().expect("brew config");
+        let brew2 = cfg.brew2.as_ref().expect("brew2 config");
+        assert_eq!(brew.local_issi_allowlist, Some(vec![2_632_585]));
+        assert_eq!(brew.subscriber_type_affiliate, 18);
+        assert_eq!(brew2.local_issi_blocklist, vec![2_636_001]);
+        assert_eq!(brew2.subscriber_type_register, 11);
+        assert_eq!(brew2.subscriber_type_deregister, 0);
+        assert!(cfg.validate().is_ok());
+    }
 }

--- a/crates/tetra-config/src/bluestation/parsing.rs
+++ b/crates/tetra-config/src/bluestation/parsing.rs
@@ -122,6 +122,11 @@ pub fn from_toml_str(toml_str: &str) -> Result<StackConfig, Box<dyn std::error::
     {
         return Err(format!("Unrecognized fields in brew config: {:?}", sorted_keys(&brew.extra)).into());
     }
+    if let Some(ref brew2) = root.brew2
+        && !brew2.extra.is_empty()
+    {
+        return Err(format!("Unrecognized fields in brew2 config: {:?}", sorted_keys(&brew2.extra)).into());
+    }
 
     // Optional asterisk section
     if let Some(ref asterisk) = root.asterisk
@@ -136,14 +141,12 @@ pub fn from_toml_str(toml_str: &str) -> Result<StackConfig, Box<dyn std::error::
     {
         return Err(format!("Unrecognized fields in dapnet config: {:?}", sorted_keys(&dapnet.extra)).into());
     }
-
     // Optional geoalarm section
     if let Some(ref geoalarm) = root.geoalarm
         && !geoalarm.extra.is_empty()
     {
         return Err(format!("Unrecognized fields in geoalarm config: {:?}", sorted_keys(&geoalarm.extra)).into());
     }
-
     // Optional meshcom section
     if let Some(ref meshcom) = root.meshcom
         && !meshcom.extra.is_empty()
@@ -237,6 +240,7 @@ pub fn from_toml_str(toml_str: &str) -> Result<StackConfig, Box<dyn std::error::
         net: net_dto_to_cfg(root.net_info),
         cell: cell_cfg,
         brew: None,
+        brew2: None,
         asterisk: apply_asterisk_patch(root.asterisk.unwrap_or_default())?,
         dapnet: apply_dapnet_patch(root.dapnet.unwrap_or_default())?,
         geoalarm: apply_geoalarm_patch(root.geoalarm.unwrap_or_default())?,
@@ -256,6 +260,9 @@ pub fn from_toml_str(toml_str: &str) -> Result<StackConfig, Box<dyn std::error::
 
     if let Some(brew) = root.brew {
         cfg.brew = Some(apply_brew_patch(brew));
+    }
+    if let Some(brew2) = root.brew2 {
+        cfg.brew2 = Some(apply_brew_patch(brew2));
     }
 
     if let Some(dashboard) = root.dashboard {
@@ -314,6 +321,7 @@ struct TomlConfigRoot {
     cell_info: CellInfoDto,
 
     brew: Option<CfgBrewDto>,
+    brew2: Option<CfgBrewDto>,
     asterisk: Option<CfgAsteriskDto>,
     dapnet: Option<CfgDapnetDto>,
     geoalarm: Option<CfgGeoalarmDto>,

--- a/crates/tetra-config/src/bluestation/sec_brew.rs
+++ b/crates/tetra-config/src/bluestation/sec_brew.rs
@@ -33,6 +33,21 @@ pub struct CfgBrew {
     /// Optional PBX gateway ISSIs that should be routable over Brew even if they don't match
     /// normal Tetrapack subscriber ISSI constraints.
     pub pbx_gateway_issis: Option<Vec<u32>>,
+    /// Local TETRA ISSIs allowed to register and originate traffic over this Brew server.
+    /// None keeps legacy single-Brew behaviour; with two Brew servers it must be set.
+    pub local_issi_allowlist: Option<Vec<u32>>,
+    /// Local TETRA ISSIs that must never register or originate traffic over this Brew server.
+    pub local_issi_blocklist: Vec<u32>,
+    /// Subscriber message type used by this Brew server for deregistration.
+    pub subscriber_type_deregister: u8,
+    /// Subscriber message type used by this Brew server for first registration.
+    pub subscriber_type_register: u8,
+    /// Subscriber message type used by this Brew server for re-registration.
+    pub subscriber_type_reregister: u8,
+    /// Subscriber message type used by this Brew server for group affiliation.
+    pub subscriber_type_affiliate: u8,
+    /// Subscriber message type used by this Brew server for group de-affiliation.
+    pub subscriber_type_deaffiliate: u8,
 }
 
 #[derive(Default, Deserialize)]
@@ -71,8 +86,55 @@ pub struct CfgBrewDto {
     #[serde(alias = "pbx_gateway_issi")]
     pub pbx_gateway_issis: Option<Vec<u32>>,
 
+    /// Local TETRA ISSIs allowed to register and originate traffic over this Brew server.
+    #[serde(default, alias = "local_issi_whitelist", alias = "issi_allowlist", alias = "issi_whitelist")]
+    pub local_issi_allowlist: Option<Vec<u32>>,
+
+    /// Local TETRA ISSIs that must never register or originate traffic over this Brew server.
+    #[serde(default, alias = "local_issi_blacklist", alias = "issi_blocklist", alias = "issi_blacklist")]
+    pub local_issi_blocklist: Vec<u32>,
+
+    /// Subscriber message type mapping. Defaults are the classic Brew/TetraPack values:
+    /// deregister=0, register=1, reregister=2, affiliate=8, deaffiliate=9.
+    #[serde(default = "default_subscriber_type_deregister")]
+    pub subscriber_type_deregister: u8,
+    #[serde(default = "default_subscriber_type_register")]
+    pub subscriber_type_register: u8,
+    #[serde(default = "default_subscriber_type_reregister")]
+    pub subscriber_type_reregister: u8,
+    #[serde(default = "default_subscriber_type_affiliate")]
+    pub subscriber_type_affiliate: u8,
+    #[serde(default = "default_subscriber_type_deaffiliate")]
+    pub subscriber_type_deaffiliate: u8,
+
     #[serde(flatten)]
     pub extra: HashMap<String, Value>,
+}
+
+impl CfgBrew {
+    pub fn has_local_issi_allowlist(&self) -> bool {
+        self.local_issi_allowlist.as_ref().is_some_and(|issis| !issis.is_empty())
+    }
+
+    pub fn local_issi_allowed(&self, issi: u32) -> bool {
+        if self.local_issi_blocklist.contains(&issi) {
+            return false;
+        }
+
+        self.local_issi_allowlist
+            .as_ref()
+            .map_or(true, |allowlist| allowlist.contains(&issi))
+    }
+
+    pub fn effective_local_issi_allowlist(&self) -> Option<Vec<u32>> {
+        self.local_issi_allowlist.as_ref().map(|allowlist| {
+            allowlist
+                .iter()
+                .copied()
+                .filter(|issi| !self.local_issi_blocklist.contains(issi))
+                .collect()
+        })
+    }
 }
 
 fn default_brew_port() -> u16 {
@@ -85,6 +147,26 @@ fn default_brew_reconnect_delay() -> u64 {
 
 fn default_brew_feature_sds_enabled() -> bool {
     true
+}
+
+fn default_subscriber_type_deregister() -> u8 {
+    0
+}
+
+fn default_subscriber_type_register() -> u8 {
+    1
+}
+
+fn default_subscriber_type_reregister() -> u8 {
+    2
+}
+
+fn default_subscriber_type_affiliate() -> u8 {
+    8
+}
+
+fn default_subscriber_type_deaffiliate() -> u8 {
+    9
 }
 
 /// Convert a CfgBrewDto (from TOML) into a CfgBrew (used in the stack config)
@@ -101,5 +183,12 @@ pub fn apply_brew_patch(src: CfgBrewDto) -> CfgBrew {
         feature_rssi_export: src.feature_rssi_export,
         whitelisted_ssis: src.whitelisted_ssis,
         pbx_gateway_issis: src.pbx_gateway_issis,
+        local_issi_allowlist: src.local_issi_allowlist,
+        local_issi_blocklist: src.local_issi_blocklist,
+        subscriber_type_deregister: src.subscriber_type_deregister,
+        subscriber_type_register: src.subscriber_type_register,
+        subscriber_type_reregister: src.subscriber_type_reregister,
+        subscriber_type_affiliate: src.subscriber_type_affiliate,
+        subscriber_type_deaffiliate: src.subscriber_type_deaffiliate,
     }
 }

--- a/crates/tetra-config/src/bluestation/state.rs
+++ b/crates/tetra-config/src/bluestation/state.rs
@@ -1,5 +1,6 @@
 use std::collections::{HashMap, HashSet, VecDeque};
 use tetra_core::TimeslotAllocator;
+use tetra_core::tetra_entities::TetraEntity;
 
 /// A one-shot or repeating SDS broadcast message injected at runtime via the dashboard.
 ///
@@ -485,6 +486,8 @@ pub struct StackState {
     pub timeslot_alloc: TimeslotAllocator,
     /// Backhaul/network connection to SwMI (e.g., Brew/TetraPack). False -> fallback mode.
     pub network_connected: bool,
+    /// Per Brew entity connection state. `network_connected` is the aggregate over this map.
+    pub brew_entity_connected: HashMap<TetraEntity, bool>,
     /// Centralized subscriber registry for local-first routing decisions.
     pub subscribers: SubscriberRegistry,
     /// Queue of live SDS messages injected at runtime via the dashboard.
@@ -630,6 +633,7 @@ impl Default for StackState {
         Self {
             timeslot_alloc: TimeslotAllocator::default(),
             network_connected: false,
+            brew_entity_connected: HashMap::new(),
             subscribers: SubscriberRegistry::new(),
             live_sds_queue: VecDeque::new(),
             next_live_sds_id: 1,

--- a/crates/tetra-core/src/tetra_entities.rs
+++ b/crates/tetra-core/src/tetra_entities.rs
@@ -29,4 +29,7 @@ pub enum TetraEntity {
 
     /// Asterisk SIP/RTP bridge
     Asterisk,
+
+    /// Secondary Brew protocol bridge.
+    Brew2,
 }

--- a/crates/tetra-entities/src/cmce/cmce_bs.rs
+++ b/crates/tetra-entities/src/cmce/cmce_bs.rs
@@ -258,8 +258,8 @@ impl TetraEntityTrait for CmceBs {
                     let SapMsgInner::MmSubscriberUpdate(update) = message.msg else {
                         unreachable!();
                     };
-                    if source == TetraEntity::Brew {
-                        if !crate::net_brew::is_brew_external_subscriber_allowed(&self.config, update.issi) {
+                    if crate::net_brew::is_brew_entity(source) {
+                        if !crate::net_brew::is_brew_external_subscriber_allowed_for_entity(&self.config, source, update.issi) {
                             tracing::trace!(
                                 "CMCE: ignoring Brew subscriber update issi={} action={:?}",
                                 update.issi,

--- a/crates/tetra-entities/src/cmce/subentities/cc_bs/lifecycle.rs
+++ b/crates/tetra-entities/src/cmce/subentities/cc_bs/lifecycle.rs
@@ -20,19 +20,47 @@ pub(super) struct CallTimeslot {
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(super) enum BrewNotification {
     Never,
-    IfGroupRoutable(u32),
+    ToEntityForLocalSource { entity: TetraEntity, source_issi: u32 },
+    ForLocalSource { source_issi: u32, dest_gssi: u32 },
 }
 
 impl BrewNotification {
-    fn enabled(self, config: &SharedConfig) -> bool {
+    fn destination(self, config: &SharedConfig) -> Option<TetraEntity> {
         match self {
-            BrewNotification::Never => false,
-            BrewNotification::IfGroupRoutable(gssi) => brew::is_brew_gssi_routable(config, gssi),
+            BrewNotification::Never => None,
+            BrewNotification::ToEntityForLocalSource { entity, source_issi } => {
+                if brew::is_active_for_entity(config, entity) && brew::is_brew_local_issi_allowed_for_entity(config, entity, source_issi) {
+                    Some(entity)
+                } else {
+                    None
+                }
+            }
+            BrewNotification::ForLocalSource { source_issi, dest_gssi } => {
+                let entity = brew::route_entity_for_local_issi(config, source_issi)?;
+                if brew::is_brew_gssi_routable_for_entity(config, entity, dest_gssi) {
+                    Some(entity)
+                } else {
+                    None
+                }
+            }
         }
     }
 }
 
 impl CcBsSubentity {
+    pub(super) fn brew_notification_for_group_call(call: &ActiveCall, local_source_issi: u32) -> BrewNotification {
+        match &call.origin {
+            CallOrigin::Network { network_entity, .. } => BrewNotification::ToEntityForLocalSource {
+                entity: *network_entity,
+                source_issi: local_source_issi,
+            },
+            CallOrigin::Local { .. } => BrewNotification::ForLocalSource {
+                source_issi: local_source_issi,
+                dest_gssi: call.dest_gssi,
+            },
+        }
+    }
+
     fn push_control(queue: &mut MessageQueue, dest: TetraEntity, control: CallControl) {
         queue.push_back(SapMsg {
             sap: Sap::Control,
@@ -72,10 +100,10 @@ impl CcBsSubentity {
             );
         }
 
-        if notify_brew.enabled(&self.config) {
+        if let Some(brew_entity) = notify_brew.destination(&self.config) {
             Self::push_control(
                 queue,
-                TetraEntity::Brew,
+                brew_entity,
                 CallControl::FloorGranted {
                     call_id: grant.call_id,
                     source_issi: grant.source_issi,
@@ -118,10 +146,10 @@ impl CcBsSubentity {
             );
         }
 
-        if notify_brew.enabled(&self.config) {
+        if let Some(brew_entity) = notify_brew.destination(&self.config) {
             Self::push_control(
                 queue,
-                TetraEntity::Brew,
+                brew_entity,
                 CallControl::FloorReleased {
                     call_id: slot.call_id,
                     carrier_num: slot.carrier_num,
@@ -144,10 +172,10 @@ impl CcBsSubentity {
             );
         }
 
-        if notify_brew.enabled(&self.config) {
+        if let Some(brew_entity) = notify_brew.destination(&self.config) {
             Self::push_control(
                 queue,
-                TetraEntity::Brew,
+                brew_entity,
                 CallControl::CallEnded {
                     call_id: slot.call_id,
                     carrier_num: slot.carrier_num,
@@ -157,8 +185,8 @@ impl CcBsSubentity {
         }
     }
 
-    pub(super) fn notify_network_call_end(&self, queue: &mut MessageQueue, brew_uuid: uuid::Uuid) {
-        Self::push_control(queue, TetraEntity::Brew, CallControl::NetworkCallEnd { brew_uuid });
+    pub(super) fn notify_network_call_end(&self, queue: &mut MessageQueue, network_entity: TetraEntity, brew_uuid: uuid::Uuid) {
+        Self::push_control(queue, network_entity, CallControl::NetworkCallEnd { brew_uuid });
     }
 
     pub(super) fn notify_network_circuit_release(

--- a/crates/tetra-entities/src/cmce/subentities/cc_bs/pdu.rs
+++ b/crates/tetra-entities/src/cmce/subentities/cc_bs/pdu.rs
@@ -393,10 +393,8 @@ impl CcBsSubentity {
 
         for (call_id, origin) in to_drop {
             tracing::info!("CMCE: dropping call_id={} gssi={} (no listeners)", call_id, gssi);
-            if let CallOrigin::Network { brew_uuid } = origin {
-                if brew::is_brew_gssi_routable(&self.config, gssi) {
-                    self.notify_network_call_end(queue, brew_uuid);
-                };
+            if let CallOrigin::Network { network_entity, brew_uuid } = origin {
+                self.notify_network_call_end(queue, network_entity, brew_uuid);
             };
             self.release_group_call(queue, call_id, DisconnectCause::SwmiRequestedDisconnection);
         }
@@ -893,7 +891,14 @@ impl CcBsSubentity {
         if let Some(call) = self.active_calls.get(&call_id) {
             let ts = call.ts;
             let dest_ssi = call.dest_gssi;
-            let is_local = matches!(call.origin, CallOrigin::Local { .. });
+            let brew_notification = if matches!(&call.origin, CallOrigin::Local { .. }) {
+                BrewNotification::ForLocalSource {
+                    source_issi: call.source_issi,
+                    dest_gssi: dest_ssi,
+                }
+            } else {
+                BrewNotification::Never
+            };
 
             let carrier_num = call.carrier_num;
             if let Ok(circuit) = self.circuits.close_circuit_slot(Direction::Both, carrier_num, ts) {
@@ -901,16 +906,7 @@ impl CcBsSubentity {
             }
 
             // Ensure UMAC clears any hangtime override for this slot even if the circuit close is delayed.
-            self.notify_call_ended(
-                queue,
-                CallTimeslot { call_id, carrier_num, ts },
-                true,
-                if is_local {
-                    BrewNotification::IfGroupRoutable(dest_ssi)
-                } else {
-                    BrewNotification::Never
-                },
-            );
+            self.notify_call_ended(queue, CallTimeslot { call_id, carrier_num, ts }, true, brew_notification);
 
             self.release_timeslot_slot(CarrierSlot { carrier_num, ts });
         }

--- a/crates/tetra-entities/src/cmce/subentities/cc_bs/procedures/group.rs
+++ b/crates/tetra-entities/src/cmce/subentities/cc_bs/procedures/group.rs
@@ -109,24 +109,32 @@ impl CcBsSubentity {
         call_id: u16,
         requesting_party: TetraAddress,
     ) -> Result<(), GroupTransitionError> {
-        let Some(call) = self.active_calls.get_mut(&call_id) else {
-            return Err(GroupTransitionError::UnknownCall(call_id));
-        };
+        let (carrier_num, ts, current_speaker, queue_result, brew_notification) = {
+            let Some(call) = self.active_calls.get_mut(&call_id) else {
+                return Err(GroupTransitionError::UnknownCall(call_id));
+            };
 
-        let state = call.state();
-        let formal_state = call.formal_state;
-        Self::validate_group_transition(call_id, state, formal_state, GroupEvent::TxDemand)?;
+            let state = call.state();
+            let formal_state = call.formal_state;
+            Self::validate_group_transition(call_id, state, formal_state, GroupEvent::TxDemand)?;
 
-        let ts = call.ts;
-        let carrier_num = call.carrier_num;
-        let dest_ssi = call.dest_gssi;
-        let current_speaker = call.source_issi;
-        let grant_now = matches!(state, GroupCallState::NoActiveSpeaker { .. });
-        let queue_result = if grant_now {
-            call.grant_floor(requesting_party.ssi, Some(requesting_party));
-            None
-        } else {
-            Some(call.queue_tx_demand(requesting_party))
+            let carrier_num = call.carrier_num;
+            let ts = call.ts;
+            let current_speaker = call.source_issi;
+            let grant_now = matches!(state, GroupCallState::NoActiveSpeaker { .. });
+            let queue_result = if grant_now {
+                call.grant_floor(requesting_party.ssi, Some(requesting_party));
+                None
+            } else {
+                Some(call.queue_tx_demand(requesting_party))
+            };
+            let brew_notification = if grant_now {
+                Self::brew_notification_for_group_call(call, requesting_party.ssi)
+            } else {
+                BrewNotification::Never
+            };
+
+            (carrier_num, ts, current_speaker, queue_result, brew_notification)
         };
 
         let Some(cached) = self.cached_setups.get(&call_id) else {
@@ -193,7 +201,7 @@ impl CcBsSubentity {
                 is_group: true,
             },
             true,
-            BrewNotification::IfGroupRoutable(dest_ssi),
+            brew_notification,
         );
 
         Ok(())
@@ -205,33 +213,36 @@ impl CcBsSubentity {
         call_id: u16,
         sender: TetraAddress,
     ) -> Result<(), GroupTransitionError> {
-        let Some(call) = self.active_calls.get_mut(&call_id) else {
-            return Err(GroupTransitionError::UnknownCall(call_id));
+        let (carrier_num, ts, queued_request, brew_notification) = {
+            let Some(call) = self.active_calls.get_mut(&call_id) else {
+                return Err(GroupTransitionError::UnknownCall(call_id));
+            };
+
+            let state = call.state();
+            let formal_state = call.formal_state;
+            Self::validate_group_transition(call_id, state, formal_state, GroupEvent::TxCeased)?;
+
+            if !call.is_current_speaker(sender.ssi) {
+                return Err(GroupTransitionError::NotCurrentSpeaker {
+                    call_id,
+                    sender_issi: sender.ssi,
+                    current_speaker_issi: call.source_issi,
+                });
+            }
+
+            let carrier_num = call.carrier_num;
+            let ts = call.ts;
+            let queued_request = call.take_queued_tx_demand();
+            let notify_source = queued_request.map_or(sender.ssi, |requester| requester.ssi);
+            if let Some(requester) = queued_request {
+                call.grant_floor(requester.ssi, Some(requester));
+            } else {
+                call.enter_hangtime(self.dltime);
+            }
+            let brew_notification = Self::brew_notification_for_group_call(call, notify_source);
+
+            (carrier_num, ts, queued_request, brew_notification)
         };
-
-        let state = call.state();
-        let formal_state = call.formal_state;
-        Self::validate_group_transition(call_id, state, formal_state, GroupEvent::TxCeased)?;
-
-        if !call.is_current_speaker(sender.ssi) {
-            return Err(GroupTransitionError::NotCurrentSpeaker {
-                call_id,
-                sender_issi: sender.ssi,
-                current_speaker_issi: call.source_issi,
-            });
-        }
-
-        let ts = call.ts;
-        let carrier_num = call.carrier_num;
-        let dest_ssi = call.dest_gssi;
-        let queued_request = call.take_queued_tx_demand();
-        if let Some(requester) = queued_request {
-            // Transmitting -> Transmitting, hand over floor directly to queued requester.
-            call.grant_floor(requester.ssi, Some(requester));
-        } else {
-            // Transmitting -> NoActiveSpeaker.
-            call.enter_hangtime(self.dltime);
-        }
 
         let Some(cached) = self.cached_setups.get(&call_id) else {
             return Err(GroupTransitionError::MissingCachedSetup(call_id));
@@ -261,7 +272,7 @@ impl CcBsSubentity {
                     is_group: true,
                 },
                 true,
-                BrewNotification::IfGroupRoutable(dest_ssi),
+                brew_notification,
             );
             return Ok(());
         }
@@ -286,7 +297,7 @@ impl CcBsSubentity {
             queue,
             CallTimeslot { call_id, carrier_num, ts },
             true,
-            BrewNotification::IfGroupRoutable(dest_ssi),
+            brew_notification,
         );
 
         Ok(())
@@ -296,6 +307,7 @@ impl CcBsSubentity {
         &mut self,
         queue: &mut MessageQueue,
         call_id: u16,
+        network_entity: TetraEntity,
         brew_uuid: uuid::Uuid,
         source_issi: u32,
     ) -> Result<(), GroupTransitionError> {
@@ -309,11 +321,14 @@ impl CcBsSubentity {
 
         call.grant_floor(source_issi, None);
         call.brew_uuid = Some(brew_uuid);
-        if let CallOrigin::Network { brew_uuid: old_uuid } = call.origin
-            && old_uuid != brew_uuid
+        if let CallOrigin::Network {
+            network_entity: old_entity,
+            brew_uuid: old_uuid,
+        } = &call.origin
+            && (*old_uuid != brew_uuid || *old_entity != network_entity)
         {
             tracing::warn!("CMCE FSM: network call start changed brew_uuid call_id={}", call_id);
-            call.origin = CallOrigin::Network { brew_uuid };
+            call.origin = CallOrigin::Network { network_entity, brew_uuid };
         }
 
         let ts = call.ts;
@@ -328,7 +343,7 @@ impl CcBsSubentity {
         queue.push_back(SapMsg {
             sap: Sap::Control,
             src: TetraEntity::Cmce,
-            dest: TetraEntity::Brew,
+            dest: network_entity,
             msg: SapMsgInner::CmceCallControl(CallControl::NetworkCallReady {
                 brew_uuid,
                 call_id,

--- a/crates/tetra-entities/src/cmce/subentities/cc_bs/procedures/isi.rs
+++ b/crates/tetra-entities/src/cmce/subentities/cc_bs/procedures/isi.rs
@@ -76,6 +76,28 @@ impl CcBsSubentity {
             return;
         }
 
+        if brew::is_brew_entity(network_entity)
+            && !brew::is_brew_local_issi_allowed_for_entity(&self.config, network_entity, called_addr.ssi)
+        {
+            tracing::info!(
+                "CMCE: rejecting {:?} setup request uuid={} src={} dst={} (called ISSI not allowed on this Brew backhaul)",
+                network_entity,
+                brew_uuid,
+                call.source_issi,
+                call.destination
+            );
+            queue.push_back(SapMsg {
+                sap: Sap::Control,
+                src: TetraEntity::Cmce,
+                dest: network_entity,
+                msg: SapMsgInner::CmceCallControl(CallControl::NetworkCircuitSetupReject {
+                    brew_uuid,
+                    cause: DisconnectCause::CalledPartyNotReachable.into_raw() as u8,
+                }),
+            });
+            return;
+        }
+
         if let Some((active_call_id, state)) = self.find_individual_call_by_issi(called_addr.ssi) {
             tracing::info!(
                 "CMCE: rejecting Brew setup request uuid={} src={} dst={} number='{}' (called ISSI busy in call_id={} state={:?})",
@@ -262,7 +284,11 @@ impl CcBsSubentity {
         ) {
             match err {
                 IndividualTransitionError::DuplicateCall(_) => {
-                    tracing::warn!("CMCE: duplicate call_id={} while creating inbound Brew setup", call_id);
+                    tracing::warn!(
+                        "CMCE: duplicate call_id={} while creating inbound {:?} setup",
+                        call_id,
+                        network_entity
+                    );
                 }
                 IndividualTransitionError::InvalidTransition { state, .. } => {
                     tracing::warn!(
@@ -713,6 +739,7 @@ impl CcBsSubentity {
     pub(in crate::cmce::subentities::cc_bs) fn fsm_on_network_call_start(
         &mut self,
         queue: &mut MessageQueue,
+        network_entity: TetraEntity,
         brew_uuid: uuid::Uuid,
         source_issi: u32,
         dest_gssi: u32,
@@ -722,13 +749,14 @@ impl CcBsSubentity {
         // inbound predicate which — unlike is_brew_gssi_routable — must NOT apply the
         // outbound whitelist (see brew_routable::is_brew_inbound_allowed). A GSSI that
         // is not admissible is dropped gracefully instead of crashing the base station.
-        if !brew::is_brew_inbound_allowed(&self.config, dest_gssi) {
+        if !brew::is_brew_inbound_allowed_for_entity(&self.config, network_entity, dest_gssi) {
             tracing::info!(
-                "CMCE: ignoring network call start uuid={} gssi={} (inbound not allowed)",
+                "CMCE: ignoring {:?} network call start uuid={} gssi={} (inbound not allowed)",
+                network_entity,
                 brew_uuid,
                 dest_gssi
             );
-            self.notify_network_call_end(queue, brew_uuid);
+            self.notify_network_call_end(queue, network_entity, brew_uuid);
             return;
         }
 
@@ -740,7 +768,7 @@ impl CcBsSubentity {
             );
             self.drop_group_calls_if_unlistened(queue, dest_gssi);
 
-            self.notify_network_call_end(queue, brew_uuid);
+            self.notify_network_call_end(queue, network_entity, brew_uuid);
             return;
         }
 
@@ -758,7 +786,7 @@ impl CcBsSubentity {
                 old_speaker
             );
 
-            if let Err(err) = self.fsm_group_on_network_call_start(queue, call_id, brew_uuid, source_issi) {
+            if let Err(err) = self.fsm_group_on_network_call_start(queue, call_id, network_entity, brew_uuid, source_issi) {
                 match err {
                     GroupTransitionError::UnknownCall(_) => {
                         tracing::warn!(
@@ -914,6 +942,7 @@ impl CcBsSubentity {
         self.active_calls.insert(
             call_id,
             ActiveCall::new_network(
+                network_entity,
                 brew_uuid,
                 dest_gssi,
                 source_issi,
@@ -939,7 +968,7 @@ impl CcBsSubentity {
         queue.push_back(SapMsg {
             sap: Sap::Control,
             src: TetraEntity::Cmce,
-            dest: TetraEntity::Brew,
+            dest: network_entity,
             msg: SapMsgInner::CmceCallControl(CallControl::NetworkCallReady {
                 brew_uuid,
                 call_id,

--- a/crates/tetra-entities/src/cmce/subentities/cc_bs/procedures/setup.rs
+++ b/crates/tetra-entities/src/cmce/subentities/cc_bs/procedures/setup.rs
@@ -532,7 +532,10 @@ impl CcBsSubentity {
                 is_group: true,
             },
             false,
-            BrewNotification::IfGroupRoutable(dest_gssi),
+            BrewNotification::ForLocalSource {
+                source_issi: calling_party.ssi,
+                dest_gssi,
+            },
         );
     }
 
@@ -893,40 +896,54 @@ impl CcBsSubentity {
         let SapMsgInner::LcmcMleUnitdataInd(prim) = &message.msg else {
             panic!()
         };
-        #[cfg_attr(not(feature = "asterisk"), allow(unused_mut))]
         let mut network_call = Self::build_network_circuit_call_from_u_setup(pdu, calling_party.ssi);
 
-        // Decide whether this dialed (non-ISSI) number routes to the Asterisk SIP/RTP bridge
-        // instead of Brew. Asterisk takes precedence; otherwise the call falls through to Brew.
-        // Without the asterisk feature there is no SIP bridge, so every call falls through to Brew.
-        #[cfg(feature = "asterisk")]
-        let network_entity = {
-            let asterisk_number = self.asterisk_route_number(&network_call);
-            let entity = if asterisk_number.is_some() {
-                TetraEntity::Asterisk
-            } else {
-                TetraEntity::Brew
-            };
-            if let Some(number) = asterisk_number {
-                tracing::info!(
-                    "CMCE: routing U-SETUP src={} dialed='{}' to Asterisk SIP number='{}'",
-                    calling_party.ssi,
-                    network_call.number,
-                    number
-                );
-                network_call.number = number;
-                network_call.destination = 0;
-                network_call.duplex = 1;
-            }
-            entity
-        };
-        #[cfg(not(feature = "asterisk"))]
-        let network_entity = TetraEntity::Brew;
+        // Treat short service ISSIs as dial strings before choosing a network bridge.
+        if network_call.destination > 0 && network_call.destination < 1_000_000 && network_call.number.is_empty() {
+            network_call.number = network_call.destination.to_string();
+            network_call.destination = 0;
+            network_call.duplex = 0;
+        }
 
-        if network_entity == TetraEntity::Brew && !brew::is_active(&self.config) {
+        #[cfg(feature = "asterisk")]
+        let asterisk_number = self.asterisk_route_number(&network_call);
+        #[cfg(not(feature = "asterisk"))]
+        let asterisk_number: Option<String> = None;
+
+        let network_entity = if asterisk_number.is_some() {
+            TetraEntity::Asterisk
+        } else if let Some(entity) = brew::route_entity_for_local_issi(&self.config, calling_party.ssi) {
+            entity
+        } else {
             tracing::info!(
-                "CMCE: rejecting U-SETUP P2P from ISSI {} (Brew disabled, called_ssi={})",
+                "CMCE: rejecting U-SETUP P2P from ISSI {} (no unique Brew route for local source)",
+                calling_party.ssi
+            );
+            self.reject_setup_request(
+                queue,
+                message,
+                calling_party,
+                DisconnectCause::CalledPartyNotReachable,
+                "source ISSI is not assigned to a Brew server",
+            );
+            return;
+        };
+
+        if let Some(number) = asterisk_number {
+            tracing::info!(
+                "CMCE: routing U-SETUP src={} dialed='{}' to Asterisk SIP number='{}'",
                 calling_party.ssi,
+                network_call.number,
+                number
+            );
+            network_call.number = number;
+            network_call.destination = 0;
+            network_call.duplex = 1;
+        } else if !brew::is_active_for_entity(&self.config, network_entity) {
+            tracing::info!(
+                "CMCE: rejecting U-SETUP P2P from ISSI {} ({:?} disabled, called_ssi={})",
+                calling_party.ssi,
+                network_entity,
                 called_addr.ssi
             );
             self.reject_setup_request(
@@ -937,6 +954,47 @@ impl CcBsSubentity {
                 "Brew disabled",
             );
             return;
+        } else {
+            let selected_connected = self
+                .config
+                .state_read()
+                .brew_entity_connected
+                .get(&network_entity)
+                .copied()
+                .unwrap_or(false);
+            if !selected_connected {
+                tracing::info!(
+                    "CMCE: rejecting U-SETUP over {:?} src={} dst={} (selected backhaul disconnected)",
+                    network_entity,
+                    calling_party.ssi,
+                    called_addr.ssi
+                );
+                self.reject_setup_request(
+                    queue,
+                    message,
+                    calling_party,
+                    DisconnectCause::RequestedServiceNotAvailable,
+                    "backhaul disconnected",
+                );
+                return;
+            }
+
+            if !brew::is_brew_issi_routable_for_entity(&self.config, network_entity, calling_party.ssi) {
+                tracing::info!(
+                    "CMCE: rejecting U-SETUP P2P over {:?} src={} dst={} (source ISSI not routable)",
+                    network_entity,
+                    calling_party.ssi,
+                    called_addr.ssi
+                );
+                self.reject_setup_request(
+                    queue,
+                    message,
+                    calling_party,
+                    DisconnectCause::CalledPartyNotReachable,
+                    "source ISSI not Brew-routable",
+                );
+                return;
+            }
         }
 
         if let Some((active_call_id, state, cause)) = self.setup_collision_cause(calling_party.ssi, None) {
@@ -951,46 +1009,12 @@ impl CcBsSubentity {
             return;
         }
 
-        // The backhaul-connected and ISSI-routability gates are Brew-specific (they check the
-        // Brew websocket state and the Brew ISSI whitelist). Asterisk-bridged calls bypass them.
-        if network_entity == TetraEntity::Brew && !self.config.state_read().network_connected {
-            tracing::info!(
-                "CMCE: rejecting U-SETUP over Brew src={} dst={} (backhaul disconnected)",
-                calling_party.ssi,
-                called_addr.ssi
-            );
-            self.reject_setup_request(
-                queue,
-                message,
-                calling_party,
-                DisconnectCause::RequestedServiceNotAvailable,
-                "backhaul disconnected",
-            );
-            return;
-        }
-
-        if network_entity == TetraEntity::Brew && !brew::is_brew_issi_routable(&self.config, calling_party.ssi) {
-            tracing::info!(
-                "CMCE: rejecting U-SETUP P2P over Brew src={} dst={} (source ISSI not routable)",
-                calling_party.ssi,
-                called_addr.ssi
-            );
-            self.reject_setup_request(
-                queue,
-                message,
-                calling_party,
-                DisconnectCause::CalledPartyNotReachable,
-                "source ISSI not Brew-routable",
-            );
-            return;
-        }
-
         let has_external_called_party = Self::has_external_called_party(pdu, &network_call);
         let destination_routable = network_entity == TetraEntity::Asterisk
             || network_call.destination == 0
-            || brew::is_brew_issi_routable(&self.config, network_call.destination);
+            || brew::is_brew_issi_routable_for_entity(&self.config, network_entity, network_call.destination);
 
-        if !has_external_called_party && !destination_routable {
+        if brew::is_brew_entity(network_entity) && !has_external_called_party && !destination_routable {
             tracing::info!(
                 "CMCE: rejecting U-SETUP P2P over Brew src={} dst={} (destination ISSI not routable)",
                 calling_party.ssi,
@@ -1006,7 +1030,7 @@ impl CcBsSubentity {
             return;
         }
 
-        if has_external_called_party && !destination_routable && network_call.destination != 0 {
+        if brew::is_brew_entity(network_entity) && has_external_called_party && !destination_routable && network_call.destination != 0 {
             tracing::debug!(
                 "CMCE: overriding non-routable destination SSI {} with 0 for external-number call src={} number='{}'",
                 network_call.destination,

--- a/crates/tetra-entities/src/cmce/subentities/cc_bs/routes/isi.rs
+++ b/crates/tetra-entities/src/cmce/subentities/cc_bs/routes/isi.rs
@@ -134,12 +134,13 @@ impl CcBsSubentity {
     pub(super) fn rx_network_call_start(
         &mut self,
         queue: &mut MessageQueue,
+        network_entity: TetraEntity,
         brew_uuid: uuid::Uuid,
         source_issi: u32,
         dest_gssi: u32,
         priority: u8,
     ) {
-        self.fsm_on_network_call_start(queue, brew_uuid, source_issi, dest_gssi, priority);
+        self.fsm_on_network_call_start(queue, network_entity, brew_uuid, source_issi, dest_gssi, priority);
     }
 
     /// Handle network call end request

--- a/crates/tetra-entities/src/cmce/subentities/cc_bs/routes/ra.rs
+++ b/crates/tetra-entities/src/cmce/subentities/cc_bs/routes/ra.rs
@@ -17,7 +17,7 @@ impl CcBsSubentity {
                 dest_gssi,
                 priority,
             } => {
-                self.rx_network_call_start(queue, brew_uuid, source_issi, dest_gssi, priority);
+                self.rx_network_call_start(queue, src_entity, brew_uuid, source_issi, dest_gssi, priority);
             }
             CallControl::NetworkCallEnd { brew_uuid } => {
                 self.rx_network_call_end(queue, brew_uuid);

--- a/crates/tetra-entities/src/cmce/subentities/cc_bs/state/mod.rs
+++ b/crates/tetra-entities/src/cmce/subentities/cc_bs/state/mod.rs
@@ -63,6 +63,7 @@ pub(super) enum CallOrigin {
     },
     /// Network-initiated call from TetraPack/Brew
     Network {
+        network_entity: TetraEntity,
         brew_uuid: uuid::Uuid, // For Brew tracking
     },
 }
@@ -212,6 +213,7 @@ impl ActiveCall {
 
     #[allow(clippy::too_many_arguments)]
     pub(super) fn new_network(
+        network_entity: TetraEntity,
         brew_uuid: uuid::Uuid,
         dest_gssi: u32,
         source_issi: u32,
@@ -223,7 +225,7 @@ impl ActiveCall {
         priority: u8,
     ) -> Self {
         Self {
-            origin: CallOrigin::Network { brew_uuid },
+            origin: CallOrigin::Network { network_entity, brew_uuid },
             dest_gssi,
             source_issi,
             created_at,
@@ -437,6 +439,11 @@ impl IndividualCall {
             && self.called_ts == self.calling_ts
             && !self.calling_over_brew
             && !self.called_over_brew
+    }
+
+    #[inline]
+    pub(super) fn is_network_party(&self, addr: TetraAddress) -> bool {
+        (self.calling_over_brew && addr.ssi == self.calling_addr.ssi) || (self.called_over_brew && addr.ssi == self.called_addr.ssi)
     }
 
     #[inline]

--- a/crates/tetra-entities/src/cmce/subentities/cc_bs/timers.rs
+++ b/crates/tetra-entities/src/cmce/subentities/cc_bs/timers.rs
@@ -609,6 +609,7 @@ impl CcBsSubentity {
             call_id
         );
         let dest_gssi = call.dest_gssi;
+        let brew_notification = Self::brew_notification_for_group_call(call, call.source_issi);
         call.enter_hangtime(self.dltime);
 
         self.send_d_tx_ceased_facch(queue, call_id, dest_gssi, carrier_num, ts);
@@ -617,7 +618,7 @@ impl CcBsSubentity {
             queue,
             CallTimeslot { call_id, carrier_num, ts },
             true,
-            BrewNotification::IfGroupRoutable(dest_gssi),
+            brew_notification,
         );
     }
 

--- a/crates/tetra-entities/src/cmce/subentities/sds_bs.rs
+++ b/crates/tetra-entities/src/cmce/subentities/sds_bs.rs
@@ -545,28 +545,26 @@ impl SdsBsSubentity {
         // an on-air requester that may legitimately be absent from the static registry, and those
         // must keep going out over RF — so they are intentionally excluded here.
         const DASHBOARD_ISSI: u32 = 9999;
-        let is_local_issi =
-            !dest_is_group && self.config.state_read().subscribers.is_registered(dest_ssi);
-        let is_local_group =
-            dest_is_group && self.config.state_read().subscribers.has_group_members(dest_ssi);
+        let is_local_issi = !dest_is_group && self.config.state_read().subscribers.is_registered(dest_ssi);
+        let is_local_group = dest_is_group && self.config.state_read().subscribers.has_group_members(dest_ssi);
 
-        if source_ssi == DASHBOARD_ISSI
-            && !is_local_issi
-            && !is_local_group
-            && net_brew::feature_sds_enabled(&self.config)
-        {
-            tracing::info!("SDS: forwarding dashboard SDS to Brew: {} -> {}", source_ssi, dest_ssi);
-            queue.push_back(SapMsg {
-                sap: Sap::Control,
-                src: TetraEntity::Cmce,
-                dest: TetraEntity::Brew,
-                msg: SapMsgInner::CmceSdsData(CmceSdsData {
-                    source_issi: source_ssi,
-                    dest_issi: dest_ssi,
-                    user_defined_data: sds_data,
-                }),
-            });
-            return true;
+        if source_ssi == DASHBOARD_ISSI && !is_local_issi && !is_local_group {
+            if let Some(brew_entity) = net_brew::route_entity_for_local_issi(&self.config, source_ssi)
+                .filter(|entity| net_brew::feature_sds_enabled_for_entity(&self.config, *entity))
+            {
+                tracing::info!("SDS: forwarding dashboard SDS to {:?}: {} -> {}", brew_entity, source_ssi, dest_ssi);
+                queue.push_back(SapMsg {
+                    sap: Sap::Control,
+                    src: TetraEntity::Cmce,
+                    dest: brew_entity,
+                    msg: SapMsgInner::CmceSdsData(CmceSdsData {
+                        source_issi: source_ssi,
+                        dest_issi: dest_ssi,
+                        user_defined_data: sds_data,
+                    }),
+                });
+                return true;
+            }
         }
 
         // Deliver over RF. As before, we do NOT gate on the SDS subscriber registry: a terminal
@@ -630,19 +628,28 @@ impl SdsBsSubentity {
         let is_local_issi = !dest_is_group && self.config.state_read().subscribers.is_registered(dest_ssi);
         let is_local_group = dest_is_group && self.config.state_read().subscribers.has_group_members(dest_ssi);
 
-        if source_ssi == DASHBOARD_ISSI && !is_local_issi && !is_local_group && net_brew::feature_sds_enabled(&self.config) {
-            tracing::info!("SDS: forwarding raw Type-4 dashboard SDS to Brew: {} -> {}", source_ssi, dest_ssi);
-            queue.push_back(SapMsg {
-                sap: Sap::Control,
-                src: TetraEntity::Cmce,
-                dest: TetraEntity::Brew,
-                msg: SapMsgInner::CmceSdsData(CmceSdsData {
-                    source_issi: source_ssi,
-                    dest_issi: dest_ssi,
-                    user_defined_data: sds_data,
-                }),
-            });
-            return true;
+        if source_ssi == DASHBOARD_ISSI && !is_local_issi && !is_local_group {
+            if let Some(brew_entity) = net_brew::route_entity_for_local_issi(&self.config, source_ssi)
+                .filter(|entity| net_brew::feature_sds_enabled_for_entity(&self.config, *entity))
+            {
+                tracing::info!(
+                    "SDS: forwarding raw Type-4 dashboard SDS to {:?}: {} -> {}",
+                    brew_entity,
+                    source_ssi,
+                    dest_ssi
+                );
+                queue.push_back(SapMsg {
+                    sap: Sap::Control,
+                    src: TetraEntity::Cmce,
+                    dest: brew_entity,
+                    msg: SapMsgInner::CmceSdsData(CmceSdsData {
+                        source_issi: source_ssi,
+                        dest_issi: dest_ssi,
+                        user_defined_data: sds_data,
+                    }),
+                });
+                return true;
+            }
         }
 
         if !dest_is_group && !is_local_issi {

--- a/crates/tetra-entities/src/cmce/subentities/sds_bs.rs
+++ b/crates/tetra-entities/src/cmce/subentities/sds_bs.rs
@@ -423,12 +423,14 @@ impl SdsBsSubentity {
                 source_issi: source_ssi,
                 dest_issi: dest_ssi,
             });
-        } else if net_brew::feature_sds_enabled(&self.config) {
-            tracing::info!("SDS: forwarding to Brew: {} -> {}", source_ssi, dest_ssi);
+        } else if let Some(brew_entity) = net_brew::route_entity_for_local_issi(&self.config, source_ssi)
+            && net_brew::feature_sds_enabled_for_entity(&self.config, brew_entity)
+        {
+            tracing::info!("SDS: forwarding to {:?}: {} -> {}", brew_entity, source_ssi, dest_ssi);
             queue.push_back(SapMsg {
                 sap: Sap::Control,
                 src: TetraEntity::Cmce,
-                dest: TetraEntity::Brew,
+                dest: brew_entity,
                 msg: SapMsgInner::CmceSdsData(CmceSdsData {
                     source_issi: source_ssi,
                     dest_issi: dest_ssi,
@@ -726,7 +728,9 @@ impl SdsBsSubentity {
         // Emergency status is LOCAL-only by design — never forwarded to Brew unless the operator
         // opts in via [emergency] forward_to_brew. Non-emergency statuses keep their normal routing.
         let is_emergency = matches!(pdu.pre_coded_status, PreCodedStatus::Emergency);
-        let brew_ok = net_brew::is_active(&self.config) && (!is_emergency || self.config.config().emergency.forward_to_brew);
+        let brew_entity = net_brew::route_entity_for_local_issi(&self.config, source_ssi);
+        let brew_ok = brew_entity.is_some_and(|entity| net_brew::feature_sds_enabled_for_entity(&self.config, entity))
+            && (!is_emergency || self.config.config().emergency.forward_to_brew);
 
         // Route: local delivery, Brew forward, or drop
         if self.config.state_read().subscribers.is_registered(dest_ssi) {
@@ -760,11 +764,12 @@ impl SdsBsSubentity {
                 SdsUserData::Type1(pdu.pre_coded_status.into_raw())
             };
 
-            tracing::info!("SDS-STATUS: forwarding to Brew: {} -> {}", source_ssi, dest_ssi);
+            let brew_entity = brew_entity.expect("checked by brew_ok");
+            tracing::info!("SDS-STATUS: forwarding to {:?}: {} -> {}", brew_entity, source_ssi, dest_ssi);
             queue.push_back(SapMsg {
                 sap: Sap::Control,
                 src: TetraEntity::Cmce,
-                dest: TetraEntity::Brew,
+                dest: brew_entity,
                 msg: SapMsgInner::CmceSdsData(CmceSdsData {
                     source_issi: source_ssi,
                     dest_issi: dest_ssi,

--- a/crates/tetra-entities/src/mm/mm_bs.rs
+++ b/crates/tetra-entities/src/mm/mm_bs.rs
@@ -335,28 +335,34 @@ impl MmBs {
         // decides whether to send REGISTER or REREGISTER based on its own state.
         // Affiliate/Deaffiliate only sent when there are brew-routable groups.
         if net_brew::is_active(&self.config) {
-            let brew_groups = groups
-                .iter()
-                .filter(|gssi| net_brew::is_brew_gssi_routable(&self.config, **gssi))
-                .copied()
-                .collect::<Vec<u32>>();
-            let should_send = match action {
-                BrewSubscriberAction::Register | BrewSubscriberAction::Deregister => net_brew::is_brew_issi_routable(&self.config, issi),
-                BrewSubscriberAction::Affiliate | BrewSubscriberAction::Deaffiliate => !brew_groups.is_empty(),
-            };
-            if should_send {
-                let brew_update = MmSubscriberUpdate {
-                    issi,
-                    groups: brew_groups,
-                    action,
+            for dest in net_brew::BREW_ENTITIES {
+                if !net_brew::is_brew_local_issi_allowed_for_entity(&self.config, dest, issi)
+                    || !net_brew::is_brew_issi_routable_for_entity(&self.config, dest, issi)
+                {
+                    continue;
+                }
+                let brew_groups = groups
+                    .iter()
+                    .filter(|gssi| net_brew::is_brew_gssi_routable_for_entity(&self.config, dest, **gssi))
+                    .copied()
+                    .collect::<Vec<u32>>();
+                let should_send = match action {
+                    BrewSubscriberAction::Register | BrewSubscriberAction::Deregister => true,
+                    BrewSubscriberAction::Affiliate | BrewSubscriberAction::Deaffiliate => !brew_groups.is_empty(),
                 };
-                let msg = SapMsg {
-                    sap: Sap::Control,
-                    src: TetraEntity::Mm,
-                    dest: TetraEntity::Brew,
-                    msg: SapMsgInner::MmSubscriberUpdate(brew_update),
-                };
-                queue.push_back(msg);
+                if should_send {
+                    let brew_update = MmSubscriberUpdate {
+                        issi,
+                        groups: brew_groups,
+                        action,
+                    };
+                    queue.push_back(SapMsg {
+                        sap: Sap::Control,
+                        src: TetraEntity::Mm,
+                        dest,
+                        msg: SapMsgInner::MmSubscriberUpdate(brew_update),
+                    });
+                }
             }
         }
 
@@ -2092,12 +2098,16 @@ impl TetraEntityTrait for MmBs {
                         }
                         // Forward to Brew entity for optional export to Brew server.
                         // BrewEntity applies its own rate limiting and checks feature_rssi_export.
-                        queue.push_back(SapMsg {
-                            sap: Sap::Control,
-                            src: TetraEntity::Mm,
-                            dest: TetraEntity::Brew,
-                            msg: SapMsgInner::MsRssiUpdate { issi, rssi_dbfs },
-                        });
+                        for dest in net_brew::BREW_ENTITIES {
+                            if net_brew::is_active_for_entity(&self.config, dest) {
+                                queue.push_back(SapMsg {
+                                    sap: Sap::Control,
+                                    src: TetraEntity::Mm,
+                                    dest,
+                                    msg: SapMsgInner::MsRssiUpdate { issi, rssi_dbfs },
+                                });
+                            }
+                        }
                     }
                     SapMsgInner::MmSubscriberUpdate(update) => {
                         // CMCE can ask MM to deregister an MS (e.g. kick from dashboard)

--- a/crates/tetra-entities/src/net_brew/components/brew_routable.rs
+++ b/crates/tetra-entities/src/net_brew/components/brew_routable.rs
@@ -142,8 +142,7 @@ pub fn is_brew_external_subscriber_allowed_for_entity(config: &SharedConfig, ent
     }
 
     !BREW_ENTITIES.into_iter().any(|candidate| {
-        brew_config_for_entity(config, candidate)
-            .is_some_and(|brew| brew.has_local_issi_allowlist() && brew.local_issi_allowed(issi))
+        brew_config_for_entity(config, candidate).is_some_and(|brew| brew.has_local_issi_allowlist() && brew.local_issi_allowed(issi))
     })
 }
 
@@ -167,9 +166,7 @@ pub fn is_brew_issi_routable_for_entity(config: &SharedConfig, entity: TetraEnti
         // 7-digit subscriber ISSIs are always routable.
         // Short ISSIs (< 1_000_000) are service numbers handled by TetraPack Core —
         // let them through so the core can respond (echo test 600, etc.)
-        (issi >= 1_000_000 && issi <= 9_999_999)
-            || issi < 1_000_000
-            || is_pbx_gateway_issi(&brew_config, issi)
+        (issi >= 1_000_000 && issi <= 9_999_999) || issi < 1_000_000 || is_pbx_gateway_issi(&brew_config, issi)
     } else {
         true
     }
@@ -250,7 +247,8 @@ port = 443
 tls = true
 username = 0
 password = ""
-local_issi_allowlist = [2632585]
+local_issi_allowlist = [2632585, 2632586]
+local_issi_blocklist = [2632586]
 
 [brew2]
 host = "example2.invalid"
@@ -267,5 +265,9 @@ local_issi_allowlist = [2633869]
             assert!(!is_brew_external_subscriber_allowed_for_entity(&cfg, entity, 2633869));
             assert!(is_brew_external_subscriber_allowed_for_entity(&cfg, entity, 2147004));
         }
+        assert_eq!(route_entity_for_local_issi(&cfg, 2632585), Some(TetraEntity::Brew));
+        assert_eq!(route_entity_for_local_issi(&cfg, 2633869), Some(TetraEntity::Brew2));
+        assert_eq!(route_entity_for_local_issi(&cfg, 2632586), None, "blocklist must win");
+        assert_eq!(route_entity_for_local_issi(&cfg, 2147004), None, "unassigned ISSI must stay local");
     }
 }

--- a/crates/tetra-entities/src/net_brew/components/brew_routable.rs
+++ b/crates/tetra-entities/src/net_brew/components/brew_routable.rs
@@ -1,39 +1,92 @@
-use tetra_config::bluestation::SharedConfig;
+use tetra_config::bluestation::{CfgBrew, SharedConfig};
+use tetra_core::tetra_entities::TetraEntity;
+
+pub const BREW_ENTITIES: [TetraEntity; 2] = [TetraEntity::Brew, TetraEntity::Brew2];
+
+#[inline]
+pub fn is_brew_entity(entity: TetraEntity) -> bool {
+    matches!(entity, TetraEntity::Brew | TetraEntity::Brew2)
+}
+
+#[inline]
+pub fn brew_config_for_entity(config: &SharedConfig, entity: TetraEntity) -> Option<CfgBrew> {
+    let cfg = config.config();
+    match entity {
+        TetraEntity::Brew => cfg.brew.clone(),
+        TetraEntity::Brew2 => cfg.brew2.clone(),
+        _ => None,
+    }
+}
 
 /// Returns true if the Brew component is active
 #[inline]
 pub fn is_active(config: &SharedConfig) -> bool {
-    config.config().brew.is_some()
+    config.config().brew.is_some() || config.config().brew2.is_some()
+}
+
+#[inline]
+pub fn is_active_for_entity(config: &SharedConfig, entity: TetraEntity) -> bool {
+    brew_config_for_entity(config, entity).is_some()
 }
 
 /// Returns true if the SDS over Brew feature is enabled
 #[inline]
 pub fn feature_sds_enabled(config: &SharedConfig) -> bool {
-    config.config().brew.as_ref().map_or(false, |brew| brew.feature_sds_enabled)
+    BREW_ENTITIES
+        .iter()
+        .copied()
+        .any(|entity| feature_sds_enabled_for_entity(config, entity))
+}
+
+#[inline]
+pub fn feature_sds_enabled_for_entity(config: &SharedConfig, entity: TetraEntity) -> bool {
+    brew_config_for_entity(config, entity).is_some_and(|brew| brew.feature_sds_enabled)
 }
 
 /// Returns true if the configured Brew server is TetraPack (core.tetrapack.online)
-fn is_tetrapack(config: &SharedConfig) -> bool {
-    if let Some(brew_config) = &config.config().brew {
-        brew_config.host == "core.tetrapack.online"
-    } else {
-        false
-    }
+fn is_tetrapack_server(brew_config: &CfgBrew) -> bool {
+    brew_config.host == "core.tetrapack.online"
 }
 
-fn is_pbx_gateway_issi(config: &SharedConfig, issi: u32) -> bool {
-    config
-        .config()
-        .brew
+fn is_pbx_gateway_issi(brew_config: &CfgBrew, issi: u32) -> bool {
+    brew_config
+        .pbx_gateway_issis
         .as_ref()
-        .and_then(|brew| brew.pbx_gateway_issis.as_ref())
         .is_some_and(|allowed| allowed.contains(&issi))
+}
+
+#[inline]
+pub fn is_brew_local_issi_allowed_for_entity(config: &SharedConfig, entity: TetraEntity, issi: u32) -> bool {
+    brew_config_for_entity(config, entity).is_some_and(|brew| brew.local_issi_allowed(issi))
+}
+
+/// Pick the one Brew entity that may represent this local TETRA ISSI.
+///
+/// Returning `None` on ambiguity is deliberate: a local terminal must never be registered or
+/// forwarded through two Brew backhauls at the same time.
+pub fn route_entity_for_local_issi(config: &SharedConfig, issi: u32) -> Option<TetraEntity> {
+    let mut routed = None;
+    for entity in BREW_ENTITIES {
+        if is_brew_local_issi_allowed_for_entity(config, entity, issi) {
+            if routed.is_some() {
+                return None;
+            }
+            routed = Some(entity);
+        }
+    }
+    routed
 }
 
 /// Determine if a given GSSI should be routed over Brew, or is restricted to local handling
 pub fn is_brew_gssi_routable(config: &SharedConfig, ssi: u32) -> bool {
-    let Some(brew_config) = &config.config().brew else {
-        // Brew not configured, so no routing to Brew
+    BREW_ENTITIES
+        .iter()
+        .copied()
+        .any(|entity| is_brew_gssi_routable_for_entity(config, entity, ssi))
+}
+
+pub fn is_brew_gssi_routable_for_entity(config: &SharedConfig, entity: TetraEntity, ssi: u32) -> bool {
+    let Some(brew_config) = brew_config_for_entity(config, entity) else {
         return false;
     };
     if config.config().cell.local_ssi_ranges.contains(ssi) {
@@ -73,14 +126,25 @@ pub fn is_brew_inbound_allowed(config: &SharedConfig, ssi: u32) -> bool {
     is_active(config) && !config.config().cell.local_ssi_ranges.contains(ssi)
 }
 
+#[inline]
+pub fn is_brew_inbound_allowed_for_entity(config: &SharedConfig, entity: TetraEntity, ssi: u32) -> bool {
+    is_active_for_entity(config, entity) && !config.config().cell.local_ssi_ranges.contains(ssi)
+}
+
 /// Determine whether Brew-originated external subscriber state may be mirrored into CMCE.
 ///
-/// Subscriber events for a local-only SSI are looped-back state, not external listeners.
-/// Filtering them at the Brew boundary avoids needless CMCE queue traffic and prevents local
-/// subscribers from being represented a second time as network subscribers.
+/// Subscriber events for SSI ranges or explicit local Brew assignments are looped-back state, not
+/// external listeners. They must not be represented a second time through either Brew connection.
 #[inline]
-pub fn is_brew_external_subscriber_allowed(config: &SharedConfig, issi: u32) -> bool {
-    is_active(config) && !config.config().cell.local_ssi_ranges.contains(issi)
+pub fn is_brew_external_subscriber_allowed_for_entity(config: &SharedConfig, entity: TetraEntity, issi: u32) -> bool {
+    if brew_config_for_entity(config, entity).is_none() || config.config().cell.local_ssi_ranges.contains(issi) {
+        return false;
+    }
+
+    !BREW_ENTITIES.into_iter().any(|candidate| {
+        brew_config_for_entity(config, candidate)
+            .is_some_and(|brew| brew.has_local_issi_allowlist() && brew.local_issi_allowed(issi))
+    })
 }
 
 /// Determine if a given ISSI should be sent to the Brew server.
@@ -88,14 +152,24 @@ pub fn is_brew_external_subscriber_allowed(config: &SharedConfig, issi: u32) -> 
 /// Special service ISSIs (e.g. 600 echo, short numbers) are always forwarded to Brew —
 /// TetraPack Core handles them internally; blocking them here causes "Service Denied".
 pub fn is_brew_issi_routable(config: &SharedConfig, issi: u32) -> bool {
-    if config.config().brew.is_none() {
+    BREW_ENTITIES
+        .iter()
+        .copied()
+        .any(|entity| is_brew_issi_routable_for_entity(config, entity, issi))
+}
+
+pub fn is_brew_issi_routable_for_entity(config: &SharedConfig, entity: TetraEntity, issi: u32) -> bool {
+    let Some(brew_config) = brew_config_for_entity(config, entity) else {
         return false;
-    }
-    if is_tetrapack(config) {
+    };
+
+    if is_tetrapack_server(&brew_config) {
         // 7-digit subscriber ISSIs are always routable.
         // Short ISSIs (< 1_000_000) are service numbers handled by TetraPack Core —
         // let them through so the core can respond (echo test 600, etc.)
-        (issi >= 1_000_000 && issi <= 9_999_999) || issi < 1_000_000 || is_pbx_gateway_issi(config, issi)
+        (issi >= 1_000_000 && issi <= 9_999_999)
+            || issi < 1_000_000
+            || is_pbx_gateway_issi(&brew_config, issi)
     } else {
         true
     }
@@ -144,8 +218,54 @@ password = ""
     fn external_subscriber_state_respects_local_ssi_ranges() {
         let cfg = shared_config("local_ssi_ranges = [[999, 999], [9998, 9999]]");
 
-        assert!(!is_brew_external_subscriber_allowed(&cfg, 999));
-        assert!(!is_brew_external_subscriber_allowed(&cfg, 9999));
-        assert!(is_brew_external_subscriber_allowed(&cfg, 2632585));
+        assert!(!is_brew_external_subscriber_allowed_for_entity(&cfg, TetraEntity::Brew, 999));
+        assert!(!is_brew_external_subscriber_allowed_for_entity(&cfg, TetraEntity::Brew, 9999));
+        assert!(is_brew_external_subscriber_allowed_for_entity(&cfg, TetraEntity::Brew, 2632585));
+    }
+
+    #[test]
+    fn external_subscriber_state_respects_explicit_local_issi_allowlists() {
+        let toml = r#"
+config_version = "0.6"
+stack_mode = "Bs"
+
+[phy_io]
+backend = "None"
+
+[net_info]
+mcc = 901
+mnc = 9999
+
+[cell_info]
+main_carrier = 1584
+freq_band = 4
+freq_offset = 0
+duplex_spacing = 4
+reverse_operation = false
+location_area = 1
+
+[brew]
+host = "example.invalid"
+port = 443
+tls = true
+username = 0
+password = ""
+local_issi_allowlist = [2632585]
+
+[brew2]
+host = "example2.invalid"
+port = 443
+tls = true
+username = 0
+password = ""
+local_issi_allowlist = [2633869]
+"#;
+        let cfg = SharedConfig::from_parts(from_toml_str(toml).expect("test config parses"), None);
+
+        for entity in BREW_ENTITIES {
+            assert!(!is_brew_external_subscriber_allowed_for_entity(&cfg, entity, 2632585));
+            assert!(!is_brew_external_subscriber_allowed_for_entity(&cfg, entity, 2633869));
+            assert!(is_brew_external_subscriber_allowed_for_entity(&cfg, entity, 2147004));
+        }
     }
 }

--- a/crates/tetra-entities/src/net_brew/entity.rs
+++ b/crates/tetra-entities/src/net_brew/entity.rs
@@ -108,6 +108,7 @@ struct UlForwardedCall {
 
 pub struct BrewEntity {
     entity: TetraEntity,
+    log_label: String,
     config: SharedConfig,
 
     /// Also contained in the SharedConfig, but kept for fast, convenient access
@@ -143,12 +144,10 @@ pub struct BrewEntity {
 
     /// Whether the worker is connected
     connected: bool,
-    /// True once we've already told MM about this connection (so it re-registers local MS exactly
-    /// ONCE per connect, not on every inbound message). The server version is detected from every
-    /// GROUP_TX with a mnemonic — many per second — so without this latch the BrewReconnected
-    /// notification (and the D-LOCATION-UPDATE-COMMAND sweep it triggers) would fire continuously
-    /// and flood every radio with re-registration commands. Reset on (re)connect and disconnect.
+    /// True once MM has been told about this transport connection.
     brew_reconnect_announced: bool,
+    /// True once the lazily detected protocol version was emitted for this connection.
+    brew_version_announced: bool,
     /// Optional telemetry sink for emitting brew status events
     telemetry_sink: Option<TelemetrySink>,
 
@@ -167,6 +166,7 @@ impl BrewEntity {
     /// implementation can be used (WebSocket, QUIC, TCP, …).
     pub fn new<T: NetworkTransport + 'static>(config: SharedConfig, entity: TetraEntity, brew_config: CfgBrew, transport: T) -> Self {
         assert!(super::is_brew_entity(entity), "BrewEntity requires a Brew router entity");
+        let log_label = Self::make_log_label(entity, &brew_config);
         // Create channels
         let (event_sender, event_receiver) = unbounded::<BrewEvent>();
         let (command_sender, command_receiver) = unbounded::<BrewCommand>();
@@ -174,10 +174,18 @@ impl BrewEntity {
         // Spawn worker thread with the provided transport
         let worker_config = config.clone();
         let worker_brew_config = brew_config.clone();
+        let worker_log_label = log_label.clone();
         let handle = thread::Builder::new()
             .name(format!("{:?}-worker", entity).to_lowercase())
             .spawn(move || {
-                let mut worker = BrewWorker::new(worker_config, worker_brew_config, event_sender, command_receiver, transport);
+                let mut worker = BrewWorker::new(
+                    worker_log_label,
+                    worker_config,
+                    worker_brew_config,
+                    event_sender,
+                    command_receiver,
+                    transport,
+                );
                 worker.run();
             })
             .expect("failed to spawn BrewWorker thread");
@@ -190,6 +198,7 @@ impl BrewEntity {
 
         Self {
             entity,
+            log_label,
             config,
             brew_config,
             dltime: TdmaTime::default(),
@@ -203,10 +212,25 @@ impl BrewEntity {
             subscriber_groups: HashMap::new(),
             connected: false,
             brew_reconnect_announced: false,
+            brew_version_announced: false,
             telemetry_sink: None,
             rssi_last_sent: HashMap::new(),
             worker_handle: Some(handle),
         }
+    }
+
+    fn make_log_label(entity: TetraEntity, brew_config: &CfgBrew) -> String {
+        let name = match entity {
+            TetraEntity::Brew => "Brew",
+            TetraEntity::Brew2 => "Brew2",
+            _ => "Brew?",
+        };
+        let scheme = if brew_config.tls { "wss" } else { "ws" };
+        format!("{name} {scheme}://{}:{}", brew_config.host, brew_config.port)
+    }
+
+    fn log_label(&self) -> &str {
+        &self.log_label
     }
 
     /// Set telemetry sink for emitting brew status events.
@@ -219,38 +243,36 @@ impl BrewEntity {
         while let Ok(event) = self.event_receiver.try_recv() {
             match event {
                 BrewEvent::Connected { server_version } => {
-                    tracing::debug!("BrewEntity: connected to TetraPack server (Brew v{})", server_version);
+                    tracing::debug!("[{}] BrewEntity: connected to server (Brew v{})", self.log_label(), server_version);
                     self.connected = true;
-                    // Re-arm the one-shot reconnect notification for this fresh connection.
                     self.brew_reconnect_announced = false;
+                    self.brew_version_announced = false;
                     self.resync_subscribers();
                     self.set_network_connected(true, server_version);
+                    self.announce_brew_reconnected(queue);
                 }
                 BrewEvent::VersionDetected { version } => {
-                    // VersionDetected fires on EVERY inbound GROUP_TX that carries a mnemonic
-                    // (many per second). Only act on the first one of each connection, or we would
-                    // flood MM with BrewReconnected — and every radio with re-registration
-                    // D-LOCATION-UPDATE-COMMANDs — continuously.
-                    if !self.brew_reconnect_announced {
-                        self.brew_reconnect_announced = true;
-                        tracing::info!("BrewEntity: server Brew version detected from message length: v{}", version);
+                    // GROUP_TX may reveal the version repeatedly. Version telemetry is one-shot,
+                    // while reconnect recovery is tied to the actual socket connection above.
+                    if !self.brew_version_announced {
+                        self.brew_version_announced = true;
+                        tracing::info!(
+                            "[{}] BrewEntity: server Brew version detected from message length: v{}",
+                            self.log_label(),
+                            version
+                        );
                         self.emit_brew_version(version);
-                        // Notify MM (once) that Brew (re)connected so it re-registers local MS.
-                        // Without this, MS that were registered before a disconnect believe they
-                        // are still affiliated and never re-register — PTT denied until power-cycle.
-                        queue.push_back(SapMsg {
-                            sap: tetra_core::Sap::Control,
-                            src: self.entity,
-                            dest: TetraEntity::Mm,
-                            msg: SapMsgInner::BrewReconnected,
-                        });
                     }
                 }
                 BrewEvent::Disconnected(reason) => {
-                    tracing::warn!("BrewEntity: Brew backhaul disconnected: {} — releasing all active calls", reason);
+                    tracing::warn!(
+                        "[{}] BrewEntity: backhaul disconnected: {} — releasing all active calls",
+                        self.log_label(),
+                        reason
+                    );
                     self.connected = false;
-                    // Re-arm so the next reconnect re-registers local MS exactly once.
                     self.brew_reconnect_announced = false;
+                    self.brew_version_announced = false;
                     self.set_network_connected(false, 0);
                     // ETSI EN 300 392-2 §14.9.4: BS must release all circuits immediately
                     // when backhaul connection is lost. MS will receive D-RELEASE.
@@ -285,13 +307,33 @@ impl BrewEntity {
                     tracing::debug!("BrewEntity: SDS report uuid={} status={}", uuid, status);
                 }
                 BrewEvent::SubscriberEvent { msg_type, issi, groups } => {
-                    tracing::trace!("BrewEntity: subscriber event type={} issi={} groups={:?}", msg_type, issi, groups);
+                    tracing::trace!(
+                        "[{}] BrewEntity: subscriber event type={} issi={} groups={:?}",
+                        self.log_label(),
+                        msg_type,
+                        issi,
+                        groups
+                    );
                     // External subscriber (e.g. SvxLink gateway) affiliated/deaffiliated on Brew server.
                     // Notify CMCE so it updates group_listeners — without this, has_listener()
                     // returns false for GSSIs where only external subscribers are present,
                     // causing BS to reject U-SETUP with "no listeners".
                     match msg_type {
-                        crate::net_brew::protocol::BREW_SUBSCRIBER_AFFILIATE => {
+                        t if t == self.brew_config.subscriber_type_register => {
+                            tracing::trace!(
+                                "[{}] BrewEntity: external subscriber issi={} -> REGISTER (presence only)",
+                                self.log_label(),
+                                issi
+                            );
+                        }
+                        t if t == self.brew_config.subscriber_type_reregister => {
+                            tracing::trace!(
+                                "[{}] BrewEntity: external subscriber issi={} -> REREGISTER (presence only)",
+                                self.log_label(),
+                                issi
+                            );
+                        }
+                        t if t == self.brew_config.subscriber_type_affiliate => {
                             if !groups.is_empty() {
                                 self.queue_external_subscriber_update(
                                     queue,
@@ -302,7 +344,7 @@ impl BrewEntity {
                                 );
                             }
                         }
-                        crate::net_brew::protocol::BREW_SUBSCRIBER_DEAFFILIATE => {
+                        t if t == self.brew_config.subscriber_type_deaffiliate => {
                             if !groups.is_empty() {
                                 self.queue_external_subscriber_update(
                                     queue,
@@ -313,10 +355,16 @@ impl BrewEntity {
                                 );
                             }
                         }
-                        crate::net_brew::protocol::BREW_SUBSCRIBER_DEREGISTER => {
+                        t if t == self.brew_config.subscriber_type_deregister => {
                             self.queue_external_subscriber_update(queue, issi, Vec::new(), BrewSubscriberAction::Deregister, "DEREGISTER");
                         }
-                        _ => {}
+                        _ => tracing::debug!(
+                            "[{}] BrewEntity: ignored unknown subscriber type={} issi={} groups={:?}",
+                            self.log_label(),
+                            msg_type,
+                            issi,
+                            groups
+                        ),
                     }
                 }
                 BrewEvent::ServerError { error_type, data } => {
@@ -482,7 +530,8 @@ impl BrewEntity {
     ) {
         if !super::is_brew_external_subscriber_allowed_for_entity(&self.config, self.entity, issi) {
             tracing::trace!(
-                "BrewEntity: external subscriber issi={} → {} ignored (local SSI range)",
+                "[{}] BrewEntity: external subscriber issi={} → {} ignored (local/reserved SSI)",
+                self.log_label(),
                 issi,
                 action_label
             );
@@ -490,7 +539,8 @@ impl BrewEntity {
         }
 
         tracing::trace!(
-            "BrewEntity: external subscriber issi={} → {} groups={:?}",
+            "[{}] BrewEntity: external subscriber issi={} → {} groups={:?}",
+            self.log_label(),
             issi,
             action_label,
             groups
@@ -699,6 +749,19 @@ impl BrewEntity {
                 server_version: version,
             });
         }
+    }
+
+    fn announce_brew_reconnected(&mut self, queue: &mut MessageQueue) {
+        if self.brew_reconnect_announced {
+            return;
+        }
+        self.brew_reconnect_announced = true;
+        queue.push_back(SapMsg {
+            sap: tetra_core::Sap::Control,
+            src: self.entity,
+            dest: TetraEntity::Mm,
+            msg: SapMsgInner::BrewReconnected,
+        });
     }
 
     /// Handle new group call from Brew, reusing hanging call circuits if available.

--- a/crates/tetra-entities/src/net_brew/entity.rs
+++ b/crates/tetra-entities/src/net_brew/entity.rs
@@ -107,6 +107,7 @@ struct UlForwardedCall {
 // ─── BrewEntity ───────────────────────────────────────────────────
 
 pub struct BrewEntity {
+    entity: TetraEntity,
     config: SharedConfig,
 
     /// Also contained in the SharedConfig, but kept for fast, convenient access
@@ -164,28 +165,31 @@ impl BrewEntity {
     ///
     /// The transport is moved into a worker thread. Any [`NetworkTransport`]
     /// implementation can be used (WebSocket, QUIC, TCP, …).
-    pub fn new<T: NetworkTransport + 'static>(config: SharedConfig, transport: T) -> Self {
+    pub fn new<T: NetworkTransport + 'static>(config: SharedConfig, entity: TetraEntity, brew_config: CfgBrew, transport: T) -> Self {
+        assert!(super::is_brew_entity(entity), "BrewEntity requires a Brew router entity");
         // Create channels
         let (event_sender, event_receiver) = unbounded::<BrewEvent>();
         let (command_sender, command_receiver) = unbounded::<BrewCommand>();
 
         // Spawn worker thread with the provided transport
-        let brew_config = config.config().as_ref().brew.clone().unwrap(); // Never fails
         let worker_config = config.clone();
+        let worker_brew_config = brew_config.clone();
         let handle = thread::Builder::new()
-            .name("brew-worker".to_string())
+            .name(format!("{:?}-worker", entity).to_lowercase())
             .spawn(move || {
-                let mut worker = BrewWorker::new(worker_config, event_sender, command_receiver, transport);
+                let mut worker = BrewWorker::new(worker_config, worker_brew_config, event_sender, command_receiver, transport);
                 worker.run();
             })
             .expect("failed to spawn BrewWorker thread");
 
         {
             let mut state = config.state_write();
-            state.network_connected = false;
+            state.brew_entity_connected.insert(entity, false);
+            state.network_connected = state.brew_entity_connected.values().any(|connected| *connected);
         }
 
         Self {
+            entity,
             config,
             brew_config,
             dltime: TdmaTime::default(),
@@ -236,7 +240,7 @@ impl BrewEntity {
                         // are still affiliated and never re-register — PTT denied until power-cycle.
                         queue.push_back(SapMsg {
                             sap: tetra_core::Sap::Control,
-                            src: TetraEntity::Brew,
+                            src: self.entity,
                             dest: TetraEntity::Mm,
                             msg: SapMsgInner::BrewReconnected,
                         });
@@ -334,7 +338,7 @@ impl BrewEntity {
                     );
                     queue.push_back(SapMsg {
                         sap: tetra_core::Sap::Control,
-                        src: TetraEntity::Brew,
+                        src: self.entity,
                         dest: TetraEntity::Cmce,
                         msg: SapMsgInner::CmceCallControl(CallControl::NetworkCircuitSetupRequest {
                             brew_uuid: uuid,
@@ -346,7 +350,7 @@ impl BrewEntity {
                     tracing::info!("BrewEntity: CIRCUIT SETUP ACCEPT uuid={}", uuid);
                     queue.push_back(SapMsg {
                         sap: tetra_core::Sap::Control,
-                        src: TetraEntity::Brew,
+                        src: self.entity,
                         dest: TetraEntity::Cmce,
                         msg: SapMsgInner::CmceCallControl(CallControl::NetworkCircuitSetupAccept { brew_uuid: uuid }),
                     });
@@ -355,7 +359,7 @@ impl BrewEntity {
                     tracing::info!("BrewEntity: CIRCUIT SETUP REJECT uuid={} cause={}", uuid, cause);
                     queue.push_back(SapMsg {
                         sap: tetra_core::Sap::Control,
-                        src: TetraEntity::Brew,
+                        src: self.entity,
                         dest: TetraEntity::Cmce,
                         msg: SapMsgInner::CmceCallControl(CallControl::NetworkCircuitSetupReject { brew_uuid: uuid, cause }),
                     });
@@ -364,7 +368,7 @@ impl BrewEntity {
                     tracing::info!("BrewEntity: CIRCUIT CALL ALERT uuid={}", uuid);
                     queue.push_back(SapMsg {
                         sap: tetra_core::Sap::Control,
-                        src: TetraEntity::Brew,
+                        src: self.entity,
                         dest: TetraEntity::Cmce,
                         msg: SapMsgInner::CmceCallControl(CallControl::NetworkCircuitAlert { brew_uuid: uuid }),
                     });
@@ -380,7 +384,7 @@ impl BrewEntity {
                     );
                     queue.push_back(SapMsg {
                         sap: tetra_core::Sap::Control,
-                        src: TetraEntity::Brew,
+                        src: self.entity,
                         dest: TetraEntity::Cmce,
                         msg: SapMsgInner::CmceCallControl(CallControl::NetworkCircuitConnectRequest {
                             brew_uuid: uuid,
@@ -397,7 +401,7 @@ impl BrewEntity {
                     );
                     queue.push_back(SapMsg {
                         sap: tetra_core::Sap::Control,
-                        src: TetraEntity::Brew,
+                        src: self.entity,
                         dest: TetraEntity::Cmce,
                         msg: SapMsgInner::CmceCallControl(CallControl::NetworkCircuitConnectConfirm {
                             brew_uuid: uuid,
@@ -415,7 +419,7 @@ impl BrewEntity {
                     );
                     queue.push_back(SapMsg {
                         sap: tetra_core::Sap::Control,
-                        src: TetraEntity::Brew,
+                        src: self.entity,
                         dest: TetraEntity::Cmce,
                         msg: SapMsgInner::CmceCallControl(CallControl::NetworkCircuitSimplexGranted {
                             brew_uuid: uuid,
@@ -433,7 +437,7 @@ impl BrewEntity {
                     );
                     queue.push_back(SapMsg {
                         sap: tetra_core::Sap::Control,
-                        src: TetraEntity::Brew,
+                        src: self.entity,
                         dest: TetraEntity::Cmce,
                         msg: SapMsgInner::CmceCallControl(CallControl::NetworkCircuitSimplexIdle {
                             brew_uuid: uuid,
@@ -446,7 +450,7 @@ impl BrewEntity {
                     tracing::info!("BrewEntity: CIRCUIT CALL RELEASE uuid={} cause={}", uuid, cause);
                     queue.push_back(SapMsg {
                         sap: tetra_core::Sap::Control,
-                        src: TetraEntity::Brew,
+                        src: self.entity,
                         dest: TetraEntity::Cmce,
                         msg: SapMsgInner::CmceCallControl(CallControl::NetworkCircuitRelease { brew_uuid: uuid, cause }),
                     });
@@ -476,7 +480,7 @@ impl BrewEntity {
         action: BrewSubscriberAction,
         action_label: &str,
     ) {
-        if !super::is_brew_external_subscriber_allowed(&self.config, issi) {
+        if !super::is_brew_external_subscriber_allowed_for_entity(&self.config, self.entity, issi) {
             tracing::trace!(
                 "BrewEntity: external subscriber issi={} → {} ignored (local SSI range)",
                 issi,
@@ -493,7 +497,7 @@ impl BrewEntity {
         );
         queue.push_back(SapMsg {
             sap: tetra_core::Sap::Control,
-            src: TetraEntity::Brew,
+            src: self.entity,
             dest: TetraEntity::Cmce,
             msg: SapMsgInner::MmSubscriberUpdate(MmSubscriberUpdate { issi, groups, action }),
         });
@@ -502,14 +506,13 @@ impl BrewEntity {
     /// Handle RSSI update from MM. Forwards to Brew server if feature_rssi_export is enabled,
     /// applying rate limiting (one update per MS every 5 seconds) to avoid flooding the server.
     fn handle_rssi_update(&mut self, issi: u32, rssi_dbfs: f32) {
-        let brew_cfg = self.config.config();
-        let Some(ref brew) = brew_cfg.brew else {
-            return;
-        };
-        if !brew.feature_rssi_export {
+        if !self.brew_config.feature_rssi_export {
             return;
         }
         if !self.connected {
+            return;
+        }
+        if !super::is_brew_local_issi_allowed_for_entity(&self.config, self.entity, issi) {
             return;
         }
 
@@ -531,7 +534,8 @@ impl BrewEntity {
     fn handle_subscriber_update(&mut self, update: MmSubscriberUpdate) {
         let issi = update.issi;
         let groups = update.groups;
-        let routable = super::is_brew_issi_routable(&self.config, issi);
+        let routable = super::is_brew_local_issi_allowed_for_entity(&self.config, self.entity, issi)
+            && super::is_brew_issi_routable_for_entity(&self.config, self.entity, issi);
 
         match update.action {
             BrewSubscriberAction::Register => {
@@ -626,7 +630,9 @@ impl BrewEntity {
 
     fn resync_subscribers(&self) {
         for (issi, groups) in &self.subscriber_groups {
-            if !super::is_brew_issi_routable(&self.config, *issi) {
+            let routable = super::is_brew_local_issi_allowed_for_entity(&self.config, self.entity, *issi)
+                && super::is_brew_issi_routable_for_entity(&self.config, self.entity, *issi);
+            if !routable {
                 tracing::debug!("BrewEntity: resync skipping issi={} (filtered)", issi);
                 continue;
             }
@@ -653,17 +659,34 @@ impl BrewEntity {
         self.connected = connected;
         let changed = {
             let mut state = self.config.state_write();
-            if state.network_connected != connected {
-                state.network_connected = connected;
-                tracing::info!("BrewEntity: backhaul {}", if connected { "CONNECTED" } else { "DISCONNECTED" });
+            let old_aggregate = state.network_connected;
+            state.brew_entity_connected.insert(self.entity, connected);
+            let aggregate = state.brew_entity_connected.values().any(|connected| *connected);
+            if old_aggregate != aggregate {
+                state.network_connected = aggregate;
+                tracing::info!(
+                    "BrewEntity: backhaul aggregate {} ({:?} {})",
+                    if aggregate { "CONNECTED" } else { "DISCONNECTED" },
+                    self.entity,
+                    if connected { "connected" } else { "disconnected" }
+                );
                 true
             } else {
+                tracing::info!(
+                    "BrewEntity: {:?} backhaul {}",
+                    self.entity,
+                    if connected { "CONNECTED" } else { "DISCONNECTED" }
+                );
                 false
             }
         };
         if changed {
             if let Some(ref sink) = self.telemetry_sink {
-                let _ = sink.send(TelemetryEvent::BrewConnected { connected, server_version });
+                let aggregate = self.config.state_read().network_connected;
+                let _ = sink.send(TelemetryEvent::BrewConnected {
+                    connected: aggregate,
+                    server_version,
+                });
             }
         }
     }
@@ -709,7 +732,7 @@ impl BrewEntity {
                 // Forward speaker change to CMCE
                 queue.push_back(SapMsg {
                     sap: Sap::Control,
-                    src: TetraEntity::Brew,
+                    src: self.entity,
                     dest: TetraEntity::Cmce,
                     msg: SapMsgInner::CmceCallControl(CallControl::NetworkCallStart {
                         brew_uuid: uuid,
@@ -758,7 +781,7 @@ impl BrewEntity {
             // Forward to CMCE (will reuse circuit automatically)
             queue.push_back(SapMsg {
                 sap: Sap::Control,
-                src: TetraEntity::Brew,
+                src: self.entity,
                 dest: TetraEntity::Cmce,
                 msg: SapMsgInner::CmceCallControl(CallControl::NetworkCallStart {
                     brew_uuid: uuid,
@@ -796,7 +819,7 @@ impl BrewEntity {
 
         queue.push_back(SapMsg {
             sap: Sap::Control,
-            src: TetraEntity::Brew,
+            src: self.entity,
             dest: TetraEntity::Cmce,
             msg: SapMsgInner::CmceCallControl(CallControl::NetworkCallStart {
                 brew_uuid: uuid,
@@ -840,7 +863,7 @@ impl BrewEntity {
         // Request CMCE to end the call
         queue.push_back(SapMsg {
             sap: Sap::Control,
-            src: TetraEntity::Brew,
+            src: self.entity,
             dest: TetraEntity::Cmce,
             msg: SapMsgInner::CmceCallControl(CallControl::NetworkCallEnd { brew_uuid: uuid }),
         });
@@ -1013,7 +1036,7 @@ impl BrewEntity {
             );
             queue.push_back(SapMsg {
                 sap: Sap::TmdSap,
-                src: TetraEntity::Brew,
+                src: self.entity,
                 dest: TetraEntity::Umac,
                 msg: SapMsgInner::TmdCircuitDataReq(TmdCircuitDataReq {
                     carrier_num,
@@ -1032,7 +1055,7 @@ impl BrewEntity {
             self.dl_jitter.remove(&uuid);
             queue.push_back(SapMsg {
                 sap: Sap::Control,
-                src: TetraEntity::Brew,
+                src: self.entity,
                 dest: TetraEntity::Cmce,
                 msg: SapMsgInner::CmceCallControl(CallControl::NetworkCallEnd { brew_uuid: uuid }),
             });
@@ -1089,7 +1112,7 @@ impl BrewEntity {
             );
             queue.push_back(SapMsg {
                 sap: Sap::Control,
-                src: TetraEntity::Brew,
+                src: self.entity,
                 dest: TetraEntity::Cmce,
                 msg: SapMsgInner::CmceCallControl(CallControl::NetworkCallEnd { brew_uuid }),
             });
@@ -1163,7 +1186,7 @@ impl BrewEntity {
 
 impl TetraEntityTrait for BrewEntity {
     fn entity(&self) -> TetraEntity {
-        TetraEntity::Brew
+        self.entity
     }
 
     fn set_config(&mut self, config: SharedConfig) {
@@ -1436,7 +1459,9 @@ impl BrewEntity {
             tracing::trace!("BrewEntity: not connected, ignoring local call start");
             return;
         }
-        if !super::is_brew_issi_routable(&self.config, source_issi) {
+        let source_allowed = super::is_brew_local_issi_allowed_for_entity(&self.config, self.entity, source_issi)
+            && super::is_brew_issi_routable_for_entity(&self.config, self.entity, source_issi);
+        if !source_allowed {
             tracing::debug!(
                 "BrewEntity: suppressing GROUP_TX for source_issi={} (filtered, not sent to Brew)",
                 source_issi
@@ -1654,6 +1679,15 @@ impl BrewEntity {
             );
             return;
         }
+        if !super::is_brew_local_issi_allowed_for_entity(&self.config, self.entity, destination) {
+            tracing::warn!(
+                "BrewEntity: SDS dest ISSI {} is not allowed on {:?}, dropping uuid={}",
+                destination,
+                self.entity,
+                uuid
+            );
+            return;
+        }
 
         // Brew protocol always delivers SDS as variable-length (Type 4). This means the
         // downlink D-SDS-DATA will use SDTI=3, even if the original uplink was a 16-bit
@@ -1664,7 +1698,7 @@ impl BrewEntity {
         // Set dltime to next ts1 to ensure it gets sent on MCCH
         queue.push_back(SapMsg {
             sap: Sap::Control,
-            src: TetraEntity::Brew,
+            src: self.entity,
             dest: TetraEntity::Cmce,
             msg: SapMsgInner::CmceSdsData(CmceSdsData {
                 source_issi: source,
@@ -1688,6 +1722,22 @@ impl BrewEntity {
                 "BrewEntity: not connected, dropping outgoing SDS {} -> {}",
                 sds.source_issi,
                 sds.dest_issi
+            );
+            return;
+        }
+        if !self.brew_config.feature_sds_enabled {
+            tracing::debug!(
+                "BrewEntity: ignoring outgoing SDS because SDS over Brew is disabled for {:?}",
+                self.entity
+            );
+            return;
+        }
+        if !super::is_brew_local_issi_allowed_for_entity(&self.config, self.entity, sds.source_issi) {
+            tracing::debug!(
+                "BrewEntity: ignoring outgoing SDS {} -> {} because source ISSI is not allowed on {:?}",
+                sds.source_issi,
+                sds.dest_issi,
+                self.entity
             );
             return;
         }

--- a/crates/tetra-entities/src/net_brew/mod.rs
+++ b/crates/tetra-entities/src/net_brew/mod.rs
@@ -9,13 +9,13 @@ pub mod entity;
 pub mod protocol;
 pub mod worker;
 
-pub use components::brew_routable::feature_sds_enabled;
 /// Convenience re-export of commonly externally used functions
-pub use components::brew_routable::is_active;
-pub use components::brew_routable::is_brew_external_subscriber_allowed;
-pub use components::brew_routable::is_brew_gssi_routable;
-pub use components::brew_routable::is_brew_inbound_allowed;
-pub use components::brew_routable::is_brew_issi_routable;
+pub use components::brew_routable::{
+    BREW_ENTITIES, is_active, is_active_for_entity, is_brew_entity, is_brew_external_subscriber_allowed_for_entity,
+    is_brew_gssi_routable, is_brew_gssi_routable_for_entity, is_brew_inbound_allowed, is_brew_inbound_allowed_for_entity,
+    is_brew_issi_routable, is_brew_issi_routable_for_entity, is_brew_local_issi_allowed_for_entity, route_entity_for_local_issi,
+};
+pub use components::brew_routable::{brew_config_for_entity, feature_sds_enabled, feature_sds_enabled_for_entity};
 
 use std::time::Duration;
 

--- a/crates/tetra-entities/src/net_brew/protocol.rs
+++ b/crates/tetra-entities/src/net_brew/protocol.rs
@@ -576,83 +576,64 @@ pub fn build_dtmf_frame(session_uuid: &Uuid, length_bits: u16, data: &[u8]) -> V
 }
 
 pub fn build_subscriber_register(issi: u32, groups: &[u32]) -> Vec<u8> {
+    build_subscriber_register_with_type(issi, groups, BREW_SUBSCRIBER_REGISTER)
+}
+
+pub fn build_subscriber_register_with_type(issi: u32, groups: &[u32], msg_type: u8) -> Vec<u8> {
+    build_subscriber_message(issi, msg_type, groups)
+}
+
+fn build_subscriber_message(issi: u32, msg_type: u8, groups: &[u32]) -> Vec<u8> {
     let now = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .unwrap_or_default();
 
     let mut buf = Vec::with_capacity(18 + groups.len() * 4);
     buf.push(BREW_CLASS_SUBSCRIBER);
-    buf.push(BREW_SUBSCRIBER_REGISTER);
+    buf.push(msg_type);
     write_u32_le(&mut buf, issi);
     write_u64_le(&mut buf, now.as_secs());
     write_u32_le(&mut buf, now.subsec_nanos());
+    for &gssi in groups {
+        write_u32_le(&mut buf, gssi);
+    }
     buf
 }
 
 /// Build a subscriber re-registration message (for already-registered subscribers)
 pub fn build_subscriber_reregister(issi: u32) -> Vec<u8> {
-    let now = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap_or_default();
+    build_subscriber_reregister_with_type(issi, BREW_SUBSCRIBER_REREGISTER)
+}
 
-    let mut buf = Vec::with_capacity(18);
-    buf.push(BREW_CLASS_SUBSCRIBER);
-    buf.push(BREW_SUBSCRIBER_REREGISTER);
-    write_u32_le(&mut buf, issi);
-    write_u64_le(&mut buf, now.as_secs());
-    write_u32_le(&mut buf, now.subsec_nanos());
-    buf
+pub fn build_subscriber_reregister_with_type(issi: u32, msg_type: u8) -> Vec<u8> {
+    build_subscriber_message(issi, msg_type, &[])
 }
 
 /// Build a subscriber affiliation message
 pub fn build_subscriber_affiliate(issi: u32, groups: &[u32]) -> Vec<u8> {
-    let now = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap_or_default();
+    build_subscriber_affiliate_with_type(issi, groups, BREW_SUBSCRIBER_AFFILIATE)
+}
 
-    let mut buf = Vec::with_capacity(18 + groups.len() * 4);
-    buf.push(BREW_CLASS_SUBSCRIBER);
-    buf.push(BREW_SUBSCRIBER_AFFILIATE);
-    write_u32_le(&mut buf, issi);
-    write_u64_le(&mut buf, now.as_secs());
-    write_u32_le(&mut buf, now.subsec_nanos());
-    for &gssi in groups {
-        write_u32_le(&mut buf, gssi);
-    }
-    buf
+pub fn build_subscriber_affiliate_with_type(issi: u32, groups: &[u32], msg_type: u8) -> Vec<u8> {
+    build_subscriber_message(issi, msg_type, groups)
 }
 
 /// Build a subscriber deaffiliation message
 pub fn build_subscriber_deaffiliate(issi: u32, groups: &[u32]) -> Vec<u8> {
-    let now = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap_or_default();
+    build_subscriber_deaffiliate_with_type(issi, groups, BREW_SUBSCRIBER_DEAFFILIATE)
+}
 
-    let mut buf = Vec::with_capacity(18 + groups.len() * 4);
-    buf.push(BREW_CLASS_SUBSCRIBER);
-    buf.push(BREW_SUBSCRIBER_DEAFFILIATE);
-    write_u32_le(&mut buf, issi);
-    write_u64_le(&mut buf, now.as_secs());
-    write_u32_le(&mut buf, now.subsec_nanos());
-    for &gssi in groups {
-        write_u32_le(&mut buf, gssi);
-    }
-    buf
+pub fn build_subscriber_deaffiliate_with_type(issi: u32, groups: &[u32], msg_type: u8) -> Vec<u8> {
+    build_subscriber_message(issi, msg_type, groups)
 }
 
 /// Build a subscriber deregistration message
 pub fn build_subscriber_deregister(issi: u32) -> Vec<u8> {
-    let now = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap_or_default();
+    build_subscriber_deregister_with_type(issi, BREW_SUBSCRIBER_DEREGISTER)
+}
 
-    let mut buf = Vec::with_capacity(18);
-    buf.push(BREW_CLASS_SUBSCRIBER);
-    buf.push(BREW_SUBSCRIBER_DEREGISTER);
-    write_u32_le(&mut buf, issi);
-    write_u64_le(&mut buf, now.as_secs());
-    write_u32_le(&mut buf, now.subsec_nanos());
-    buf
+pub fn build_subscriber_deregister_with_type(issi: u32, msg_type: u8) -> Vec<u8> {
+    build_subscriber_message(issi, msg_type, &[])
 }
 
 /// Build a group call transmission start message (GROUP_TX)

--- a/crates/tetra-entities/src/net_brew/worker.rs
+++ b/crates/tetra-entities/src/net_brew/worker.rs
@@ -202,6 +202,7 @@ struct PendingSds {
 /// Runs in a separate thread. Communicates with [`super::entity::BrewEntity`] via
 /// crossbeam channels ([`BrewEvent`] and [`BrewCommand`]).
 pub struct BrewWorker<T: NetworkTransport> {
+    log_label: String,
     config: SharedConfig,
     brew_config: CfgBrew,
     /// Network transport (WebSocket, QUIC, TCP, …)
@@ -218,6 +219,7 @@ pub struct BrewWorker<T: NetworkTransport> {
 
 impl<T: NetworkTransport> BrewWorker<T> {
     pub fn new(
+        log_label: String,
         config: SharedConfig,
         brew_config: CfgBrew,
         event_sender: Sender<BrewEvent>,
@@ -225,6 +227,7 @@ impl<T: NetworkTransport> BrewWorker<T> {
         transport: T,
     ) -> Self {
         Self {
+            log_label,
             config,
             brew_config,
             transport,
@@ -235,22 +238,27 @@ impl<T: NetworkTransport> BrewWorker<T> {
         }
     }
 
+    fn log_label(&self) -> &str {
+        &self.log_label
+    }
+
     /// Main worker entry point — runs until disconnect or fatal error
     pub fn run(&mut self) {
-        tracing::info!("BrewWorker: starting");
+        tracing::info!("[{}] BrewWorker: starting", self.log_label());
 
         loop {
             // Attempt connection via transport
             match self.transport.connect() {
                 Ok(()) => {
-                    tracing::info!("BrewWorker: transport connected");
+                    tracing::info!("[{}] BrewWorker: transport connected", self.log_label());
                     let _ = self.event_sender.send(BrewEvent::Connected {
                         server_version: self.transport.server_brew_version(),
                     });
                 }
                 Err(e) => {
                     tracing::error!(
-                        "BrewWorker: connection error: {}, reconnecting in {:?}",
+                        "[{}] BrewWorker: connection error: {}, reconnecting in {:?}",
+                        self.log_label(),
                         e,
                         self.brew_config.reconnect_delay
                     );
@@ -263,12 +271,13 @@ impl<T: NetworkTransport> BrewWorker<T> {
             // Run the message loop until error or clean shutdown
             match self.message_loop() {
                 Ok(()) => {
-                    tracing::info!("BrewWorker: connection closed normally");
+                    tracing::info!("[{}] BrewWorker: connection closed normally", self.log_label());
                     break;
                 }
                 Err(e) => {
                     tracing::error!(
-                        "BrewWorker: connection error: {}, reconnecting in {:?}",
+                        "[{}] BrewWorker: connection error: {}, reconnecting in {:?}",
+                        self.log_label(),
                         e,
                         self.brew_config.reconnect_delay
                     );
@@ -287,17 +296,22 @@ impl<T: NetworkTransport> BrewWorker<T> {
                 group_list.sort_unstable();
                 let deaff_msg = build_subscriber_deaffiliate(*issi, &group_list);
                 if let Err(e) = self.transport.send_reliable(&deaff_msg) {
-                    tracing::error!("BrewWorker: failed to send deaffiliation: {}", e);
+                    tracing::error!("[{}] BrewWorker: failed to send deaffiliation: {}", self.log_label(), e);
                 } else {
-                    tracing::info!("BrewWorker: deaffiliated issi={} groups={:?}", issi, group_list);
+                    tracing::info!(
+                        "[{}] BrewWorker: deaffiliated issi={} groups={:?}",
+                        self.log_label(),
+                        issi,
+                        group_list
+                    );
                 }
             }
 
             let dereg_msg = build_subscriber_deregister(*issi);
             if let Err(e) = self.transport.send_reliable(&dereg_msg) {
-                tracing::error!("BrewWorker: failed to send deregistration: {}", e);
+                tracing::error!("[{}] BrewWorker: failed to send deregistration: {}", self.log_label(), e);
             } else {
-                tracing::info!("BrewWorker: deregistered ISSI {}", issi);
+                tracing::info!("[{}] BrewWorker: deregistered ISSI {}", self.log_label(), issi);
             }
         }
         self.transport.disconnect();
@@ -312,7 +326,7 @@ impl<T: NetworkTransport> BrewWorker<T> {
             self.pending_sds.retain(|uuid, pending| {
                 let age = now.duration_since(pending.received_at);
                 if age > Duration::from_secs(30) {
-                    tracing::warn!("BrewWorker: expiring stale pending SDS uuid={}", uuid);
+                    tracing::warn!("[{}] BrewWorker: expiring stale pending SDS uuid={}", self.log_label(), uuid);
                     false
                 } else {
                     true
@@ -337,7 +351,10 @@ impl<T: NetworkTransport> BrewWorker<T> {
                     Err(crossbeam_channel::TryRecvError::Empty) => break,
                     Err(crossbeam_channel::TryRecvError::Disconnected) => {
                         // Entity was dropped — do graceful teardown
-                        tracing::info!("BrewWorker: command channel closed, performing graceful teardown");
+                        tracing::info!(
+                            "[{}] BrewWorker: command channel closed, performing graceful teardown",
+                            self.log_label()
+                        );
                         self.graceful_teardown();
                         return Ok(());
                     }
@@ -352,10 +369,11 @@ impl<T: NetworkTransport> BrewWorker<T> {
                             build_subscriber_register(issi, &[])
                         };
                         if let Err(e) = self.transport.send_reliable(&msg) {
-                            tracing::error!("BrewWorker: failed to send registration: {}", e);
+                            tracing::error!("[{}] BrewWorker: failed to send registration: {}", self.log_label(), e);
                         } else {
                             tracing::debug!(
-                                "BrewWorker: sent {} issi={}",
+                                "[{}] BrewWorker: sent {} issi={}",
+                                self.log_label(),
                                 if already_registered { "REREGISTER" } else { "REGISTER" },
                                 issi
                             );
@@ -365,9 +383,9 @@ impl<T: NetworkTransport> BrewWorker<T> {
                         self.subscriber_groups.remove(&issi);
                         let msg = build_subscriber_deregister(issi);
                         if let Err(e) = self.transport.send_reliable(&msg) {
-                            tracing::error!("BrewWorker: failed to send deregistration: {}", e);
+                            tracing::error!("[{}] BrewWorker: failed to send deregistration: {}", self.log_label(), e);
                         } else {
-                            tracing::debug!("BrewWorker: sent DEREGISTER issi={}", issi);
+                            tracing::debug!("[{}] BrewWorker: sent DEREGISTER issi={}", self.log_label(), issi);
                         }
                     }
                     BrewCommand::AffiliateGroups { issi, groups } => {
@@ -377,9 +395,14 @@ impl<T: NetworkTransport> BrewWorker<T> {
                         }
                         let msg = build_subscriber_affiliate(issi, &groups);
                         if let Err(e) = self.transport.send_reliable(&msg) {
-                            tracing::error!("BrewWorker: failed to send affiliation: {}", e);
+                            tracing::error!("[{}] BrewWorker: failed to send affiliation: {}", self.log_label(), e);
                         } else {
-                            tracing::debug!("BrewWorker: sent AFFILIATE issi={} groups={:?}", issi, groups);
+                            tracing::debug!(
+                                "[{}] BrewWorker: sent AFFILIATE issi={} groups={:?}",
+                                self.log_label(),
+                                issi,
+                                groups
+                            );
                         }
                     }
                     BrewCommand::DeaffiliateGroups { issi, groups } => {
@@ -390,9 +413,14 @@ impl<T: NetworkTransport> BrewWorker<T> {
                         }
                         let msg = build_subscriber_deaffiliate(issi, &groups);
                         if let Err(e) = self.transport.send_reliable(&msg) {
-                            tracing::error!("BrewWorker: failed to send deaffiliation: {}", e);
+                            tracing::error!("[{}] BrewWorker: failed to send deaffiliation: {}", self.log_label(), e);
                         } else {
-                            tracing::debug!("BrewWorker: sent DEAFFILIATE issi={} groups={:?}", issi, groups);
+                            tracing::debug!(
+                                "[{}] BrewWorker: sent DEAFFILIATE issi={} groups={:?}",
+                                self.log_label(),
+                                issi,
+                                groups
+                            );
                         }
                     }
                     BrewCommand::SendGroupTx {
@@ -404,23 +432,29 @@ impl<T: NetworkTransport> BrewWorker<T> {
                     } => {
                         let msg = build_group_tx(&uuid, source_issi, dest_gssi, priority, service, None);
                         if let Err(e) = self.transport.send_reliable(&msg) {
-                            tracing::error!("BrewWorker: failed to send GROUP_TX: {}", e);
+                            tracing::error!("[{}] BrewWorker: failed to send GROUP_TX: {}", self.log_label(), e);
                         } else {
-                            tracing::debug!("BrewWorker: sent GROUP_TX uuid={} src={} dst={}", uuid, source_issi, dest_gssi);
+                            tracing::debug!(
+                                "[{}] BrewWorker: sent GROUP_TX uuid={} src={} dst={}",
+                                self.log_label(),
+                                uuid,
+                                source_issi,
+                                dest_gssi
+                            );
                         }
                     }
                     BrewCommand::SendVoiceFrame { uuid, length_bits, data } => {
                         let msg = build_voice_frame(&uuid, length_bits, &data);
                         if let Err(e) = self.transport.send_reliable(&msg) {
-                            tracing::error!("BrewWorker: failed to send voice frame: {}", e);
+                            tracing::error!("[{}] BrewWorker: failed to send voice frame: {}", self.log_label(), e);
                         }
                     }
                     BrewCommand::SendGroupIdle { uuid, cause } => {
                         let msg = build_group_idle(&uuid, cause);
                         if let Err(e) = self.transport.send_reliable(&msg) {
-                            tracing::error!("BrewWorker: failed to send GROUP_IDLE: {}", e);
+                            tracing::error!("[{}] BrewWorker: failed to send GROUP_IDLE: {}", self.log_label(), e);
                         } else {
-                            tracing::debug!("BrewWorker: sent GROUP_IDLE uuid={} cause={}", uuid, cause);
+                            tracing::debug!("[{}] BrewWorker: sent GROUP_IDLE uuid={} cause={}", self.log_label(), uuid, cause);
                         }
                     }
                     BrewCommand::SendSds {
@@ -431,124 +465,169 @@ impl<T: NetworkTransport> BrewWorker<T> {
                         length_bits,
                     } => {
                         if !self.brew_config.feature_sds_enabled {
-                            tracing::warn!("BrewWorker: ignoring SendSds command because SDS over Brew is disabled in config");
+                            tracing::warn!(
+                                "[{}] BrewWorker: ignoring SendSds command because SDS over Brew is disabled in config",
+                                self.log_label()
+                            );
                             continue;
                         }
 
                         // Send SHORT_TRANSFER first (header with source/dest)
                         let short_msg = build_short_transfer(&uuid, source, destination);
                         if let Err(e) = self.transport.send_reliable(&short_msg) {
-                            tracing::error!("BrewWorker: failed to send SHORT_TRANSFER: {}", e);
+                            tracing::error!("[{}] BrewWorker: failed to send SHORT_TRANSFER: {}", self.log_label(), e);
                         } else {
-                            tracing::debug!("BrewWorker: sent SHORT_TRANSFER uuid={} src={} dst={}", uuid, source, destination);
+                            tracing::debug!(
+                                "[{}] BrewWorker: sent SHORT_TRANSFER uuid={} src={} dst={}",
+                                self.log_label(),
+                                uuid,
+                                source,
+                                destination
+                            );
                             // Then send SDS_TRANSFER with the payload
                             let sds_msg = build_sds_frame(&uuid, length_bits, &data);
                             if let Err(e) = self.transport.send_reliable(&sds_msg) {
-                                tracing::error!("BrewWorker: failed to send SDS_TRANSFER: {}", e);
+                                tracing::error!("[{}] BrewWorker: failed to send SDS_TRANSFER: {}", self.log_label(), e);
                             } else {
-                                tracing::debug!("BrewWorker: sent SDS_TRANSFER uuid={} {} bytes", uuid, data.len());
+                                tracing::debug!(
+                                    "[{}] BrewWorker: sent SDS_TRANSFER uuid={} {} bytes",
+                                    self.log_label(),
+                                    uuid,
+                                    data.len()
+                                );
                             }
                         }
                     }
                     BrewCommand::SendSdsReport { uuid, status } => {
                         if !self.brew_config.feature_sds_enabled {
-                            tracing::warn!("BrewWorker: ignoring SendSdsReport command because SDS over Brew is disabled in config");
+                            tracing::warn!(
+                                "[{}] BrewWorker: ignoring SendSdsReport command because SDS over Brew is disabled in config",
+                                self.log_label()
+                            );
                             continue;
                         }
 
                         let msg = build_sds_report(&uuid, status);
                         if let Err(e) = self.transport.send_reliable(&msg) {
-                            tracing::warn!("BrewWorker: failed to send SDS_REPORT: {}", e);
+                            tracing::warn!("[{}] BrewWorker: failed to send SDS_REPORT: {}", self.log_label(), e);
                         } else {
-                            tracing::debug!("BrewWorker: sent SDS_REPORT uuid={} status={}", uuid, status);
+                            tracing::debug!("[{}] BrewWorker: sent SDS_REPORT uuid={} status={}", self.log_label(), uuid, status);
                         }
                     }
                     BrewCommand::SendSetupRequest { uuid, call } => {
                         let data = build_setup_request(&uuid, &call);
                         if let Err(e) = self.transport.send_reliable(&data) {
-                            tracing::error!("BrewWorker: failed to send SETUP_REQUEST: {}", e);
+                            tracing::error!("[{}] BrewWorker: failed to send SETUP_REQUEST: {}", self.log_label(), e);
                         } else {
-                            tracing::debug!("Brew: sent SETUP_REQUEST uuid={}", uuid);
+                            tracing::debug!("[{}] BrewWorker: sent SETUP_REQUEST uuid={}", self.log_label(), uuid);
                         }
                     }
                     BrewCommand::SendSetupAccept { uuid } => {
                         let data = build_setup_accept(&uuid);
                         if let Err(e) = self.transport.send_reliable(&data) {
-                            tracing::error!("BrewWorker: failed to send SETUP_ACCEPT: {}", e);
+                            tracing::error!("[{}] BrewWorker: failed to send SETUP_ACCEPT: {}", self.log_label(), e);
                         } else {
-                            tracing::debug!("Brew: sent SETUP_ACCEPT uuid={}", uuid);
+                            tracing::debug!("[{}] BrewWorker: sent SETUP_ACCEPT uuid={}", self.log_label(), uuid);
                         }
                     }
                     BrewCommand::SendSetupReject { uuid, cause } => {
                         let data = build_setup_reject(&uuid, cause);
                         if let Err(e) = self.transport.send_reliable(&data) {
-                            tracing::error!("BrewWorker: failed to send SETUP_REJECT: {}", e);
+                            tracing::error!("[{}] BrewWorker: failed to send SETUP_REJECT: {}", self.log_label(), e);
                         } else {
-                            tracing::debug!("Brew: sent SETUP_REJECT uuid={} cause={}", uuid, cause);
+                            tracing::debug!("[{}] BrewWorker: sent SETUP_REJECT uuid={} cause={}", self.log_label(), uuid, cause);
                         }
                     }
                     BrewCommand::SendCallAlert { uuid } => {
                         let data = build_call_alert(&uuid);
                         if let Err(e) = self.transport.send_reliable(&data) {
-                            tracing::error!("BrewWorker: failed to send CALL_ALERT: {}", e);
+                            tracing::error!("[{}] BrewWorker: failed to send CALL_ALERT: {}", self.log_label(), e);
                         } else {
-                            tracing::debug!("Brew: sent CALL_ALERT uuid={}", uuid);
+                            tracing::debug!("[{}] BrewWorker: sent CALL_ALERT uuid={}", self.log_label(), uuid);
                         }
                     }
                     BrewCommand::SendConnectRequest { uuid, call } => {
                         let data = build_connect_request(&uuid, &call);
                         if let Err(e) = self.transport.send_reliable(&data) {
-                            tracing::error!("BrewWorker: failed to send CONNECT_REQUEST: {}", e);
+                            tracing::error!("[{}] BrewWorker: failed to send CONNECT_REQUEST: {}", self.log_label(), e);
                         } else {
-                            tracing::debug!("Brew: sent CONNECT_REQUEST uuid={}", uuid);
+                            tracing::debug!("[{}] BrewWorker: sent CONNECT_REQUEST uuid={}", self.log_label(), uuid);
                         }
                     }
                     BrewCommand::SendConnectConfirm { uuid, grant, permission } => {
                         let data = build_connect_confirm(&uuid, grant, permission);
                         if let Err(e) = self.transport.send_reliable(&data) {
-                            tracing::error!("BrewWorker: failed to send CONNECT_CONFIRM: {}", e);
+                            tracing::error!("[{}] BrewWorker: failed to send CONNECT_CONFIRM: {}", self.log_label(), e);
                         } else {
-                            tracing::debug!("Brew: sent CONNECT_CONFIRM uuid={} grant={} perm={}", uuid, grant, permission);
+                            tracing::debug!(
+                                "[{}] BrewWorker: sent CONNECT_CONFIRM uuid={} grant={} perm={}",
+                                self.log_label(),
+                                uuid,
+                                grant,
+                                permission
+                            );
                         }
                     }
                     BrewCommand::SendSimplexGranted { uuid, grant, permission } => {
                         let data = build_simplex_granted(&uuid, grant, permission);
                         if let Err(e) = self.transport.send_reliable(&data) {
-                            tracing::error!("BrewWorker: failed to send SIMPLEX_GRANTED: {}", e);
+                            tracing::error!("[{}] BrewWorker: failed to send SIMPLEX_GRANTED: {}", self.log_label(), e);
                         } else {
-                            tracing::debug!("Brew: sent SIMPLEX_GRANTED uuid={} grant={} perm={}", uuid, grant, permission);
+                            tracing::debug!(
+                                "[{}] BrewWorker: sent SIMPLEX_GRANTED uuid={} grant={} perm={}",
+                                self.log_label(),
+                                uuid,
+                                grant,
+                                permission
+                            );
                         }
                     }
                     BrewCommand::SendSimplexIdle { uuid, grant, permission } => {
                         let data = build_simplex_idle(&uuid, grant, permission);
                         if let Err(e) = self.transport.send_reliable(&data) {
-                            tracing::error!("BrewWorker: failed to send SIMPLEX_IDLE: {}", e);
+                            tracing::error!("[{}] BrewWorker: failed to send SIMPLEX_IDLE: {}", self.log_label(), e);
                         } else {
-                            tracing::debug!("Brew: sent SIMPLEX_IDLE uuid={} grant={} perm={}", uuid, grant, permission);
+                            tracing::debug!(
+                                "[{}] BrewWorker: sent SIMPLEX_IDLE uuid={} grant={} perm={}",
+                                self.log_label(),
+                                uuid,
+                                grant,
+                                permission
+                            );
                         }
                     }
                     BrewCommand::SendCallRelease { uuid, cause } => {
                         let data = build_call_release(&uuid, cause);
                         if let Err(e) = self.transport.send_reliable(&data) {
-                            tracing::error!("BrewWorker: failed to send CALL_RELEASE: {}", e);
+                            tracing::error!("[{}] BrewWorker: failed to send CALL_RELEASE: {}", self.log_label(), e);
                         } else {
-                            tracing::debug!("Brew: sent CALL_RELEASE uuid={} cause={}", uuid, cause);
+                            tracing::debug!("[{}] BrewWorker: sent CALL_RELEASE uuid={} cause={}", self.log_label(), uuid, cause);
                         }
                     }
                     BrewCommand::SendDtmf { uuid, length_bits, data } => {
                         let msg = build_dtmf_frame(&uuid, length_bits, &data);
                         if let Err(e) = self.transport.send_reliable(&msg) {
-                            tracing::error!("BrewWorker: failed to send DTMF: {}", e);
+                            tracing::error!("[{}] BrewWorker: failed to send DTMF: {}", self.log_label(), e);
                         } else {
-                            tracing::debug!("Brew: sent DTMF uuid={} bits={}", uuid, length_bits);
+                            tracing::debug!("[{}] BrewWorker: sent DTMF uuid={} bits={}", self.log_label(), uuid, length_bits);
                         }
                     }
                     BrewCommand::SendRssiUpdate { issi, rssi_dbfs } => {
                         let msg = build_service_rssi(issi, rssi_dbfs);
                         if let Err(e) = self.transport.send_reliable(&msg) {
-                            tracing::error!("BrewWorker: failed to send RSSI update for ISSI {}: {}", issi, e);
+                            tracing::error!(
+                                "[{}] BrewWorker: failed to send RSSI update for ISSI {}: {}",
+                                self.log_label(),
+                                issi,
+                                e
+                            );
                         } else {
-                            tracing::debug!("BrewWorker: sent RSSI issi={} rssi={:.1}dBFS", issi, rssi_dbfs);
+                            tracing::debug!(
+                                "[{}] BrewWorker: sent RSSI issi={} rssi={:.1}dBFS",
+                                self.log_label(),
+                                issi,
+                                rssi_dbfs
+                            );
                         }
                     }
                     BrewCommand::Disconnect => {
@@ -567,7 +646,7 @@ impl<T: NetworkTransport> BrewWorker<T> {
                 BrewMessage::CallControl(cc) => self.handle_call_control(cc),
                 BrewMessage::Frame(frame) => self.handle_frame(frame),
                 BrewMessage::Subscriber(sub) => {
-                    tracing::debug!("BrewWorker: subscriber event type={}", sub.msg_type);
+                    tracing::debug!("[{}] BrewWorker: subscriber event type={}", self.log_label(), sub.msg_type);
                     // TODO FIXME we could check whether this call is indeed a brew ssi here
                     let _ = self.event_sender.send(BrewEvent::SubscriberEvent {
                         msg_type: sub.msg_type,
@@ -576,7 +655,12 @@ impl<T: NetworkTransport> BrewWorker<T> {
                     });
                 }
                 BrewMessage::Error(err) => {
-                    tracing::warn!("BrewWorker: server error type={}: {} bytes", err.error_type, err.data.len());
+                    tracing::warn!(
+                        "[{}] BrewWorker: server error type={}: {} bytes",
+                        self.log_label(),
+                        err.error_type,
+                        err.data.len()
+                    );
                     // TODO FIXME we could check whether this call is indeed a brew ssi here
                     let _ = self.event_sender.send(BrewEvent::ServerError {
                         error_type: err.error_type,
@@ -584,11 +668,21 @@ impl<T: NetworkTransport> BrewWorker<T> {
                     });
                 }
                 BrewMessage::Service(svc) => {
-                    tracing::debug!("BrewWorker: service type={}: {}", svc.service_type, svc.json_data);
+                    tracing::debug!(
+                        "[{}] BrewWorker: service type={}: {}",
+                        self.log_label(),
+                        svc.service_type,
+                        svc.json_data
+                    );
                 }
             },
             Err(e) => {
-                tracing::warn!("BrewWorker: failed to parse message ({} bytes): {}", data.len(), e);
+                tracing::warn!(
+                    "[{}] BrewWorker: failed to parse message ({} bytes): {}",
+                    self.log_label(),
+                    data.len(),
+                    e
+                );
             }
         }
     }
@@ -599,7 +693,8 @@ impl<T: NetworkTransport> BrewWorker<T> {
             CALL_STATE_GROUP_TX => {
                 if let BrewCallPayload::GroupTransmission(gt) = cc.payload {
                     tracing::info!(
-                        "BrewWorker: GROUP_TX uuid={} src={} dst={} prio={} service={} mnemonic={}",
+                        "[{}] BrewWorker: GROUP_TX uuid={} src={} dst={} prio={} service={} mnemonic={}",
+                        self.log_label(),
                         cc.identifier,
                         gt.source,
                         gt.destination,
@@ -614,7 +709,11 @@ impl<T: NetworkTransport> BrewWorker<T> {
                     // Inbound admission (FH-FEAT-032 R3): a Brew-originated group call must NOT be
                     // gated by the outbound-only `whitelisted_ssis`; only `local_ssi_ranges` reject it.
                     if !net_brew::is_brew_inbound_allowed(&self.config, gt.destination) {
-                        tracing::warn!("BrewWorker: dropping GROUP_TX to inactive/local-only GSSI {}", gt.destination);
+                        tracing::warn!(
+                            "[{}] BrewWorker: dropping GROUP_TX to inactive/local-only GSSI {}",
+                            self.log_label(),
+                            gt.destination
+                        );
                         return;
                     };
                     let _ = self.event_sender.send(BrewEvent::GroupCallStart {
@@ -628,7 +727,12 @@ impl<T: NetworkTransport> BrewWorker<T> {
             }
             CALL_STATE_GROUP_IDLE => {
                 let cause = if let BrewCallPayload::Cause(c) = cc.payload { c } else { 0 };
-                tracing::info!("BrewWorker: GROUP_IDLE uuid={} cause={}", cc.identifier, cause);
+                tracing::info!(
+                    "[{}] BrewWorker: GROUP_IDLE uuid={} cause={}",
+                    self.log_label(),
+                    cc.identifier,
+                    cause
+                );
                 // TODO FIXME we could check whether this call is indeed a brew call here
                 let _ = self.event_sender.send(BrewEvent::GroupCallEnd {
                     uuid: cc.identifier,
@@ -639,7 +743,8 @@ impl<T: NetworkTransport> BrewWorker<T> {
             CALL_STATE_SETUP_REQUEST => {
                 if let BrewCallPayload::CircularCall(call) = cc.payload {
                     tracing::info!(
-                        "BrewWorker: SETUP_REQUEST uuid={} src={} dst={} number='{}' duplex={}",
+                        "[{}] BrewWorker: SETUP_REQUEST uuid={} src={} dst={} number='{}' duplex={}",
+                        self.log_label(),
                         cc.identifier,
                         call.source,
                         call.destination,
@@ -650,25 +755,31 @@ impl<T: NetworkTransport> BrewWorker<T> {
                 }
             }
             CALL_STATE_SETUP_ACCEPT => {
-                tracing::info!("BrewWorker: SETUP_ACCEPT uuid={}", cc.identifier);
+                tracing::info!("[{}] BrewWorker: SETUP_ACCEPT uuid={}", self.log_label(), cc.identifier);
                 let _ = self.event_sender.send(BrewEvent::CircuitSetupAccept { uuid: cc.identifier });
             }
             CALL_STATE_SETUP_REJECT => {
                 let cause = if let BrewCallPayload::Cause(c) = cc.payload { c } else { 0 };
-                tracing::info!("BrewWorker: SETUP_REJECT uuid={} cause={}", cc.identifier, cause);
+                tracing::info!(
+                    "[{}] BrewWorker: SETUP_REJECT uuid={} cause={}",
+                    self.log_label(),
+                    cc.identifier,
+                    cause
+                );
                 let _ = self.event_sender.send(BrewEvent::CircuitSetupReject {
                     uuid: cc.identifier,
                     cause,
                 });
             }
             CALL_STATE_CALL_ALERT => {
-                tracing::info!("BrewWorker: CALL_ALERT uuid={}", cc.identifier);
+                tracing::info!("[{}] BrewWorker: CALL_ALERT uuid={}", self.log_label(), cc.identifier);
                 let _ = self.event_sender.send(BrewEvent::CircuitCallAlert { uuid: cc.identifier });
             }
             CALL_STATE_CONNECT_REQUEST => {
                 if let BrewCallPayload::CircularCall(call) = cc.payload {
                     tracing::info!(
-                        "BrewWorker: CONNECT_REQUEST uuid={} src={} dst={} duplex={}",
+                        "[{}] BrewWorker: CONNECT_REQUEST uuid={} src={} dst={} duplex={}",
+                        self.log_label(),
                         cc.identifier,
                         call.source,
                         call.destination,
@@ -686,7 +797,8 @@ impl<T: NetworkTransport> BrewWorker<T> {
                     (0, 0)
                 };
                 tracing::info!(
-                    "BrewWorker: CONNECT_CONFIRM uuid={} grant={} perm={}",
+                    "[{}] BrewWorker: CONNECT_CONFIRM uuid={} grant={} perm={}",
+                    self.log_label(),
                     cc.identifier,
                     grant,
                     permission
@@ -704,7 +816,8 @@ impl<T: NetworkTransport> BrewWorker<T> {
                     (0, 0)
                 };
                 tracing::info!(
-                    "BrewWorker: SIMPLEX_GRANTED uuid={} grant={} perm={}",
+                    "[{}] BrewWorker: SIMPLEX_GRANTED uuid={} grant={} perm={}",
+                    self.log_label(),
                     cc.identifier,
                     grant,
                     permission
@@ -722,7 +835,8 @@ impl<T: NetworkTransport> BrewWorker<T> {
                     (0, 0)
                 };
                 tracing::info!(
-                    "BrewWorker: SIMPLEX_IDLE uuid={} grant={} perm={}",
+                    "[{}] BrewWorker: SIMPLEX_IDLE uuid={} grant={} perm={}",
+                    self.log_label(),
                     cc.identifier,
                     grant,
                     permission
@@ -735,7 +849,12 @@ impl<T: NetworkTransport> BrewWorker<T> {
             }
             CALL_STATE_CALL_RELEASE => {
                 let cause = if let BrewCallPayload::Cause(c) = cc.payload { c } else { 0 };
-                tracing::info!("BrewWorker: CALL_RELEASE uuid={} cause={}", cc.identifier, cause);
+                tracing::info!(
+                    "[{}] BrewWorker: CALL_RELEASE uuid={} cause={}",
+                    self.log_label(),
+                    cc.identifier,
+                    cause
+                );
                 // Send both events — entity will handle whichever is relevant
                 let _ = self.event_sender.send(BrewEvent::GroupCallEnd {
                     uuid: cc.identifier,
@@ -749,7 +868,8 @@ impl<T: NetworkTransport> BrewWorker<T> {
             CALL_STATE_SHORT_TRANSFER => {
                 if let BrewCallPayload::ShortTransfer { source, destination } = cc.payload {
                     tracing::info!(
-                        "BrewWorker: SHORT_TRANSFER uuid={} src={} dst={}",
+                        "[{}] BrewWorker: SHORT_TRANSFER uuid={} src={} dst={}",
+                        self.log_label(),
                         cc.identifier,
                         source,
                         destination
@@ -766,7 +886,12 @@ impl<T: NetworkTransport> BrewWorker<T> {
                 }
             }
             state => {
-                tracing::debug!("BrewWorker: unhandled call state {} uuid={}", state, cc.identifier);
+                tracing::debug!(
+                    "[{}] BrewWorker: unhandled call state {} uuid={}",
+                    self.log_label(),
+                    state,
+                    cc.identifier
+                );
             }
         }
     }
@@ -785,14 +910,18 @@ impl<T: NetworkTransport> BrewWorker<T> {
             }
             FRAME_TYPE_SDS_TRANSFER => {
                 if !self.brew_config.feature_sds_enabled {
-                    tracing::warn!("BrewWorker: ignoring incoming SDS_TRANSFER because SDS over Brew is disabled in config");
+                    tracing::warn!(
+                        "[{}] BrewWorker: ignoring incoming SDS_TRANSFER because SDS over Brew is disabled in config",
+                        self.log_label()
+                    );
                     return;
                 }
 
                 if frame.length_bits > 2047 {
                     // TODO FIXME we could split into multiple SDS messages here
                     tracing::warn!(
-                        "BrewWorker: ignoring SDS_TRANSFER with excessive length_bits={} ({} bytes)",
+                        "[{}] BrewWorker: ignoring SDS_TRANSFER with excessive length_bits={} ({} bytes)",
+                        self.log_label(),
                         frame.length_bits,
                         frame.data.len()
                     );
@@ -805,7 +934,8 @@ impl<T: NetworkTransport> BrewWorker<T> {
                 // over-claimed length would otherwise panic the base station (OOB).
                 if (frame.length_bits as usize).div_ceil(8) > frame.data.len() {
                     tracing::warn!(
-                        "BrewWorker: ignoring SDS_TRANSFER with length_bits={} exceeding payload of {} bytes",
+                        "[{}] BrewWorker: ignoring SDS_TRANSFER with length_bits={} exceeding payload of {} bytes",
+                        self.log_label(),
                         frame.length_bits,
                         frame.data.len()
                     );
@@ -815,7 +945,8 @@ impl<T: NetworkTransport> BrewWorker<T> {
                 // Match with pending SHORT_TRANSFER by UUID
                 if let Some(pending) = self.pending_sds.remove(&frame.identifier) {
                     tracing::info!(
-                        "BrewWorker: SDS_TRANSFER uuid={} src={} dst={} {} bytes",
+                        "[{}] BrewWorker: SDS_TRANSFER uuid={} src={} dst={} {} bytes",
+                        self.log_label(),
                         frame.identifier,
                         pending.source,
                         pending.destination,
@@ -830,7 +961,8 @@ impl<T: NetworkTransport> BrewWorker<T> {
                     });
                 } else {
                     tracing::warn!(
-                        "BrewWorker: SDS_TRANSFER uuid={} without matching SHORT_TRANSFER, {} bytes",
+                        "[{}] BrewWorker: SDS_TRANSFER uuid={} without matching SHORT_TRANSFER, {} bytes",
+                        self.log_label(),
                         frame.identifier,
                         frame.data.len()
                     );
@@ -838,14 +970,24 @@ impl<T: NetworkTransport> BrewWorker<T> {
             }
             FRAME_TYPE_SDS_REPORT => {
                 let status = if frame.data.is_empty() { 0 } else { frame.data[0] };
-                tracing::debug!("BrewWorker: SDS_REPORT uuid={} status={}", frame.identifier, status);
+                tracing::debug!(
+                    "[{}] BrewWorker: SDS_REPORT uuid={} status={}",
+                    self.log_label(),
+                    frame.identifier,
+                    status
+                );
                 let _ = self.event_sender.send(BrewEvent::SdsReport {
                     uuid: frame.identifier,
                     status,
                 });
             }
             ft => {
-                tracing::debug!("BrewWorker: unhandled frame type {} uuid={}", ft, frame.identifier);
+                tracing::debug!(
+                    "[{}] BrewWorker: unhandled frame type {} uuid={}",
+                    self.log_label(),
+                    ft,
+                    frame.identifier
+                );
             }
         }
     }

--- a/crates/tetra-entities/src/net_brew/worker.rs
+++ b/crates/tetra-entities/src/net_brew/worker.rs
@@ -217,8 +217,13 @@ pub struct BrewWorker<T: NetworkTransport> {
 }
 
 impl<T: NetworkTransport> BrewWorker<T> {
-    pub fn new(config: SharedConfig, event_sender: Sender<BrewEvent>, command_receiver: Receiver<BrewCommand>, transport: T) -> Self {
-        let brew_config = config.config().brew.clone().unwrap(); // Never fails
+    pub fn new(
+        config: SharedConfig,
+        brew_config: CfgBrew,
+        event_sender: Sender<BrewEvent>,
+        command_receiver: Receiver<BrewCommand>,
+        transport: T,
+    ) -> Self {
         Self {
             config,
             brew_config,
@@ -425,7 +430,7 @@ impl<T: NetworkTransport> BrewWorker<T> {
                         data,
                         length_bits,
                     } => {
-                        if !net_brew::feature_sds_enabled(&self.config) {
+                        if !self.brew_config.feature_sds_enabled {
                             tracing::warn!("BrewWorker: ignoring SendSds command because SDS over Brew is disabled in config");
                             continue;
                         }
@@ -446,7 +451,7 @@ impl<T: NetworkTransport> BrewWorker<T> {
                         }
                     }
                     BrewCommand::SendSdsReport { uuid, status } => {
-                        if !net_brew::feature_sds_enabled(&self.config) {
+                        if !self.brew_config.feature_sds_enabled {
                             tracing::warn!("BrewWorker: ignoring SendSdsReport command because SDS over Brew is disabled in config");
                             continue;
                         }
@@ -779,7 +784,7 @@ impl<T: NetworkTransport> BrewWorker<T> {
                 });
             }
             FRAME_TYPE_SDS_TRANSFER => {
-                if !net_brew::feature_sds_enabled(&self.config) {
+                if !self.brew_config.feature_sds_enabled {
                     tracing::warn!("BrewWorker: ignoring incoming SDS_TRANSFER because SDS over Brew is disabled in config");
                     return;
                 }

--- a/crates/tetra-entities/src/net_brew/worker.rs
+++ b/crates/tetra-entities/src/net_brew/worker.rs
@@ -294,7 +294,7 @@ impl<T: NetworkTransport> BrewWorker<T> {
             if !groups.is_empty() {
                 let mut group_list: Vec<u32> = groups.iter().copied().collect();
                 group_list.sort_unstable();
-                let deaff_msg = build_subscriber_deaffiliate(*issi, &group_list);
+                let deaff_msg = build_subscriber_deaffiliate_with_type(*issi, &group_list, self.brew_config.subscriber_type_deaffiliate);
                 if let Err(e) = self.transport.send_reliable(&deaff_msg) {
                     tracing::error!("[{}] BrewWorker: failed to send deaffiliation: {}", self.log_label(), e);
                 } else {
@@ -307,7 +307,7 @@ impl<T: NetworkTransport> BrewWorker<T> {
                 }
             }
 
-            let dereg_msg = build_subscriber_deregister(*issi);
+            let dereg_msg = build_subscriber_deregister_with_type(*issi, self.brew_config.subscriber_type_deregister);
             if let Err(e) = self.transport.send_reliable(&dereg_msg) {
                 tracing::error!("[{}] BrewWorker: failed to send deregistration: {}", self.log_label(), e);
             } else {
@@ -323,10 +323,11 @@ impl<T: NetworkTransport> BrewWorker<T> {
             let now = Instant::now();
 
             // Expire stale pending SDS entries (SHORT_TRANSFER without matching SDS_TRANSFER)
+            let log_label = self.log_label().to_string();
             self.pending_sds.retain(|uuid, pending| {
                 let age = now.duration_since(pending.received_at);
                 if age > Duration::from_secs(30) {
-                    tracing::warn!("[{}] BrewWorker: expiring stale pending SDS uuid={}", self.log_label(), uuid);
+                    tracing::warn!("[{}] BrewWorker: expiring stale pending SDS uuid={}", log_label, uuid);
                     false
                 } else {
                     true
@@ -364,9 +365,9 @@ impl<T: NetworkTransport> BrewWorker<T> {
                         let already_registered = self.subscriber_groups.contains_key(&issi);
                         self.subscriber_groups.entry(issi).or_insert_with(HashSet::new);
                         let msg = if already_registered {
-                            build_subscriber_reregister(issi)
+                            build_subscriber_reregister_with_type(issi, self.brew_config.subscriber_type_reregister)
                         } else {
-                            build_subscriber_register(issi, &[])
+                            build_subscriber_register_with_type(issi, &[], self.brew_config.subscriber_type_register)
                         };
                         if let Err(e) = self.transport.send_reliable(&msg) {
                             tracing::error!("[{}] BrewWorker: failed to send registration: {}", self.log_label(), e);
@@ -381,7 +382,7 @@ impl<T: NetworkTransport> BrewWorker<T> {
                     }
                     BrewCommand::DeregisterSubscriber { issi } => {
                         self.subscriber_groups.remove(&issi);
-                        let msg = build_subscriber_deregister(issi);
+                        let msg = build_subscriber_deregister_with_type(issi, self.brew_config.subscriber_type_deregister);
                         if let Err(e) = self.transport.send_reliable(&msg) {
                             tracing::error!("[{}] BrewWorker: failed to send deregistration: {}", self.log_label(), e);
                         } else {
@@ -393,7 +394,7 @@ impl<T: NetworkTransport> BrewWorker<T> {
                         for gssi in &groups {
                             entry.insert(*gssi);
                         }
-                        let msg = build_subscriber_affiliate(issi, &groups);
+                        let msg = build_subscriber_affiliate_with_type(issi, &groups, self.brew_config.subscriber_type_affiliate);
                         if let Err(e) = self.transport.send_reliable(&msg) {
                             tracing::error!("[{}] BrewWorker: failed to send affiliation: {}", self.log_label(), e);
                         } else {
@@ -411,7 +412,7 @@ impl<T: NetworkTransport> BrewWorker<T> {
                                 entry.remove(gssi);
                             }
                         }
-                        let msg = build_subscriber_deaffiliate(issi, &groups);
+                        let msg = build_subscriber_deaffiliate_with_type(issi, &groups, self.brew_config.subscriber_type_deaffiliate);
                         if let Err(e) = self.transport.send_reliable(&msg) {
                             tracing::error!("[{}] BrewWorker: failed to send deaffiliation: {}", self.log_label(), e);
                         } else {

--- a/crates/tetra-entities/src/net_dashboard/html.rs
+++ b/crates/tetra-entities/src/net_dashboard/html.rs
@@ -5198,7 +5198,7 @@ async function wifiCall(url, body){
 function escAttr(s){ return String(s).replace(/&/g,'&amp;').replace(/'/g,"&#39;").replace(/"/g,'&quot;'); }
 
 // ── State + WS ────────────────────────────────────────────────────────────
-let ws=null,state={ms:{},calls:{},emergencies:{},lastHeard:[],sdsLog:[],dapnetLog:[],geoalarmEvents:[],geoalarmConfig:null,meshcomNodes:[],meshcomMessages:[],brewOnline:false,brewVer:0},sdsDest=0;
+let ws=null,state={ms:{},calls:{},emergencies:{},lastHeard:[],sdsLog:[],dapnetLog:[],geoalarmEvents:[],geoalarmConfig:null,meshcomNodes:[],meshcomMessages:[],brewOnline:false,brewVer:0,brewStatus:null,brewStatusLoadedAt:0},sdsDest=0;
 
 // ── RadioID callsigns (indicativ) ──────────────────────────────────────────────
 // issi -> {cs:"CALLSIGN", fl:"🇷🇴"} (found; fl is the country flag emoji from the prefix, or "")
@@ -5265,6 +5265,58 @@ function clearEmergency(issi){if(!confirm(t('confirm_clear_emergency',{issi})))r
 
 // ── Topbar status chips (BS / Brew / Emergency) — calm always-visible state.
 // Mirrors the footer LEDs + emergency state onto the .pill chips in the header.
+let brewStatusFetchInFlight=false;
+function configuredBrewServers(){
+  const servers=(state.brewStatus&&state.brewStatus.servers)||[];
+  return servers.filter(function(server){return server&&server.configured;});
+}
+function brewUiSummary(online,version){
+  const servers=configuredBrewServers();
+  if(servers.length>1){
+    const connected=servers.filter(function(server){return !!server.connected;}).length;
+    const total=servers.length;
+    const all=connected===total;
+    const any=connected>0;
+    return {
+      online:any,
+      cardClass:all?'is-info':(any?'is-warn':'is-danger'),
+      pillClass:all?'pill-info':(any?'pill-warn':'pill-idle'),
+      value:connected+'/'+total+' '+t('brew_online'),
+      detail:servers.map(function(server){
+        return (server.title||server.entity||'Brew')+': '+(server.connected?t('brew_online'):t('brew_offline'));
+      }).join(' · '),
+      hero:connected+'/'+total,
+      chip:'Brew '+connected+'/'+total,
+      badge:connected+'/'+total,
+    };
+  }
+  return {
+    online,
+    cardClass:online?'is-info':'is-danger',
+    pillClass:online?'pill-info':'pill-idle',
+    value:online?t('brew_online'):t('brew_offline'),
+    detail:online?`Brew v${version||0}`:'—',
+    hero:online?`v${version||0}`:t('brew_offline'),
+    chip:online?('Brew v'+(version||0)):'Brew',
+    badge:online?('v'+(version||0)):'',
+  };
+}
+async function refreshBrewServerStatus(force){
+  const now=Date.now();
+  if(brewStatusFetchInFlight)return;
+  if(!force&&state.brewStatusLoadedAt&&now-state.brewStatusLoadedAt<5000)return;
+  brewStatusFetchInFlight=true;
+  try{
+    const r=await fetch('/api/brew/status');
+    if(r.ok){
+      state.brewStatus=await r.json();
+      state.brewStatusLoadedAt=Date.now();
+      renderBrewStatus();
+    }
+  }catch{}finally{
+    brewStatusFetchInFlight=false;
+  }
+}
 function syncTopbarChips(){
   const led=document.getElementById('connLed');
   const bsOn=!!(led&&led.classList.contains('on'));
@@ -5276,44 +5328,55 @@ function syncTopbarChips(){
   }
   const brew=document.getElementById('chip-brew');
   if(brew){
-    brew.className='pill '+(state.brewOnline?'pill-info':'pill-idle');
+    const summary=brewUiSummary(state.brewOnline,state.brewVer);
+    brew.className='pill '+summary.pillClass;
     const span=brew.querySelector('span');
-    if(span)span.textContent=state.brewOnline?('Brew v'+(state.brewVer||0)):'Brew';
+    if(span)span.textContent=summary.chip;
   }
   const emg=document.getElementById('chip-emergency');
   if(emg)emg.style.display=Object.keys(state.emergencies||{}).length?'inline-flex':'none';
 }
 
-function setBrewStatus(online,version){
-  state.brewOnline=online;state.brewVer=version||0;
+function renderBrewStatus(){
+  const summary=brewUiSummary(state.brewOnline,state.brewVer);
   const led=document.getElementById('brewLed');
   const txt=document.getElementById('brewText');
   const vbadge=document.getElementById('brewVerBadge');
-  if(online){
+  if(summary.online){
     led.classList.add('on');
-    txt.textContent=t('brew_online');txt.style.color='var(--accent2)';
-    if(vbadge){
-      const v=version||0;
-      vbadge.textContent='v'+v;vbadge.style.display='inline-block';
-      if(v>=1){vbadge.style.background='rgba(0,212,168,0.15)';vbadge.style.color='var(--accent)';vbadge.style.border='1px solid rgba(0,212,168,0.4)';}
-      else{vbadge.style.background='rgba(255,178,36,0.15)';vbadge.style.color='var(--warn)';vbadge.style.border='1px solid rgba(255,178,36,0.4)';}
-    }
+    txt.textContent=summary.value;txt.style.color=summary.cardClass==='is-warn'?'var(--warn)':'var(--accent2)';
   } else {
-    led.classList.remove('on');txt.textContent=t('brew_offline');txt.style.color='';
-    if(vbadge)vbadge.style.display='none';
+    led.classList.remove('on');txt.textContent=summary.value;txt.style.color='';
+  }
+  if(vbadge){
+    if(summary.badge){
+      vbadge.textContent=summary.badge;vbadge.style.display='inline-block';
+      const warn=summary.cardClass==='is-warn';
+      const ok=summary.cardClass==='is-info';
+      vbadge.style.background=ok?'rgba(0,212,168,0.15)':(warn?'rgba(255,178,36,0.15)':'rgba(255,76,76,0.15)');
+      vbadge.style.color=ok?'var(--accent)':(warn?'var(--warn)':'var(--danger)');
+      vbadge.style.border=ok?'1px solid rgba(0,212,168,0.4)':(warn?'1px solid rgba(255,178,36,0.4)':'1px solid rgba(255,76,76,0.4)');
+    } else {
+      vbadge.style.display='none';
+    }
   }
   // Update stat card — state via ONE class (kills inline color split).
   const bv=document.getElementById('stat-brew-val');
   const bs=document.getElementById('stat-brew-sub');
   const bcard=document.getElementById('stat-brew-card');
-  if(bv){bv.textContent=online?t('brew_online'):t('brew_offline');}
-  if(bcard){bcard.classList.remove('is-info','is-danger');bcard.classList.add(online?'is-info':'is-danger');}
-  if(bs)bs.textContent=online?`Brew v${version||0}`:'—';
+  if(bv){bv.textContent=summary.value;}
+  if(bcard){bcard.classList.remove('is-info','is-warn','is-danger');bcard.classList.add(summary.cardClass);}
+  if(bs)bs.textContent=summary.detail;
   const hb=document.getElementById('stations-hero-brew');
-  if(hb)hb.textContent=online?`v${version||0}`:t('brew_offline');
+  if(hb)hb.textContent=summary.hero;
   // System panel
-  updateSysBtsPanel(document.getElementById('connLed').classList.contains('on'),online,version||0);
+  updateSysBtsPanel(document.getElementById('connLed').classList.contains('on'),state.brewOnline,state.brewVer||0);
   syncTopbarChips();
+}
+function setBrewStatus(online,version){
+  state.brewOnline=online;state.brewVer=version||0;
+  renderBrewStatus();
+  refreshBrewServerStatus(false);
 }
 
 function connect(){
@@ -5325,10 +5388,12 @@ function connect(){
     updateSysBtsPanel(true,state.brewOnline,state.brewVer);
     syncTopbarChips();
     ws.send(JSON.stringify({type:'subscribe'}));
+    refreshBrewServerStatus(true);
   };
   ws.onclose=()=>{
     document.getElementById('connLed').classList.remove('on');
     const ct=document.getElementById('connText');ct.textContent=t('offline');ct.style.color='var(--danger)';
+    state.brewStatus=null;state.brewStatusLoadedAt=0;
     setBrewStatus(false,0);
     updateSysBtsPanel(false,false,0);
     syncTopbarChips();
@@ -7465,12 +7530,11 @@ function updateSysHero(){
   const tempV=document.getElementById('sysHeroTemp');
   const btsCard=document.getElementById('sysBtsCard');
   const btsOnline=btsCard&&btsCard.classList.contains('is-ok');
-  const brewCard=document.getElementById('sysBrewCard');
-  const brewOnline=brewCard&&brewCard.classList.contains('is-info');
+  const brewSummary=brewUiSummary(state.brewOnline,state.brewVer);
   if(dot) dot.className='hero-dot '+(btsOnline?'is-ok':'is-danger');
   if(sub){
     const host=(sysData&&sysData.hostname)||document.getElementById('sysHostname').textContent||'—';
-    sub.textContent=(btsOnline?t('online'):t('offline'))+' · '+(brewOnline?t('brew_online'):t('brew_offline'))+' · '+host;
+    sub.textContent=(btsOnline?t('online'):t('offline'))+' · '+brewSummary.value+' · '+host;
   }
   if(tempV){
     const tc=document.getElementById('sysCpuTemp');
@@ -7515,6 +7579,7 @@ async function activateProfile(name){
 }
 
 function updateSysBtsPanel(online,brewOnline,brewVer){
+  const summary=brewUiSummary(brewOnline,brewVer);
   const ipEl=document.getElementById('sysBtsIp');
   const stEl=document.getElementById('sysBtsStatus');
   const bsEl=document.getElementById('sysBrewStatus');
@@ -7524,9 +7589,9 @@ function updateSysBtsPanel(online,brewOnline,brewVer){
   if(ipEl)ipEl.textContent=online?location.hostname:'—';
   if(stEl)stEl.textContent=online?t('online'):t('offline');
   if(btsCard)btsCard.className='stat-card '+(online?'is-ok':'is-danger');
-  if(bsEl)bsEl.textContent=brewOnline?t('brew_online'):t('brew_offline');
-  if(brewCard)brewCard.className='stat-card '+(brewOnline?'is-info':'is-danger');
-  if(bdEl){bdEl.textContent=brewOnline?`Brew v${brewVer||0}`:'—';}
+  if(bsEl)bsEl.textContent=summary.value;
+  if(brewCard)brewCard.className='stat-card '+summary.cardClass;
+  if(bdEl){bdEl.textContent=summary.detail;}
   updateSysHero();
 }
 
@@ -8048,6 +8113,7 @@ function healthDomainSvg(d){
 function healthDomainAccent(d){ return (HEALTH_SVG[d]||{}).accent || ''; }
 // Inline SVGs for the integration cards (replace ☎ 📟 ◎).
 const INTEGRATION_SVG = {
+  brew:'<path d="M4.93 4.93a14 14 0 0 0 0 14.14M19.07 4.93a14 14 0 0 1 0 14.14M8.46 8.46a7 7 0 0 0 0 7.08M15.54 8.46a7 7 0 0 1 0 7.08"/><circle cx="12" cy="12" r="1.5"/>',
   asterisk:'<path d="M22 16.92v3a2 2 0 0 1-2.18 2 19.79 19.79 0 0 1-8.63-3.07 19.5 19.5 0 0 1-6-6 19.79 19.79 0 0 1-3.07-8.67A2 2 0 0 1 4.11 2h3a2 2 0 0 1 2 1.72c.13.96.36 1.9.7 2.81a2 2 0 0 1-.45 2.11L8.09 9.91a16 16 0 0 0 6 6l1.27-1.27a2 2 0 0 1 2.11-.45c.9.34 1.85.57 2.81.7A2 2 0 0 1 22 16.92z"/>',
   dapnet:'<rect x="5" y="2" width="14" height="20" rx="2"/><path d="M9 6h6M9 10h6M9 14h3"/>',
   geoalarm:'<path d="M12 21s-7-5.5-7-11a7 7 0 0 1 14 0c0 5.5-7 11-7 11z"/><circle cx="12" cy="10" r="2.5"/>',
@@ -8107,8 +8173,8 @@ function renderHealthTab(h){
   });
 }
 
-let healthIntegrationState={asterisk:null,dapnet:null,geoalarm:null,meshcom:null,lastLoad:0};
-// title, iconKey (asterisk|dapnet|geoalarm), accent (blue|purple|''), level, detail, extra.
+let healthIntegrationState={brew:null,asterisk:null,dapnet:null,geoalarm:null,meshcom:null,lastLoad:0};
+// title, iconKey (brew|asterisk|dapnet|geoalarm), accent (blue|purple|''), level, detail, extra.
 function integrationHealthCard(title,iconKey,accent,level,detail,extra){
   const lvlCls = healthLevelClass(level);
   const icoCls = level==='ok' ? accent : lvlCls;
@@ -8125,6 +8191,21 @@ function integrationHealthCard(title,iconKey,accent,level,detail,extra){
       + (extra?'<div class="h-det">'+escHtml(extra)+'</div>':'')
     + '</div>';
   return card;
+}
+function classifyBrewHealth(server){
+  if(!server||!server.configured)return {level:'ok',detail:'not configured',extra:'No config section for this Brew server.'};
+  const allow=(server.local_issi_allowlist||[]).filter(function(v){return v!==null&&v!==undefined;});
+  const block=(server.local_issi_blocklist||[]).filter(function(v){return v!==null&&v!==undefined;});
+  let level=server.connected?'ok':'degraded';
+  const detail=(server.connected?'connected':'disconnected')+' · '+(server.endpoint||'—');
+  const parts=[server.feature_sds_enabled?'SDS on':'SDS off',server.feature_rssi_export?'RSSI on':'RSSI off'];
+  if(allow.length)parts.push('ISSI allow '+allow.join(', '));
+  if(block.length)parts.push('ISSI block '+block.join(', '));
+  if(!allow.length&&server.entity==='brew2'){
+    parts.push('missing local_issi_allowlist');
+    level='degraded';
+  }
+  return {level,detail,extra:parts.join(' · ')};
 }
 function classifyAsteriskHealth(data){
   const c=(data&&data.config)||{},rt=(data&&data.runtime)||{};
@@ -8200,6 +8281,19 @@ function renderHealthIntegrations(){
   const grid=document.getElementById('health-integrations-grid');
   if(!grid)return;
   grid.innerHTML='';
+  if(healthIntegrationState.brew){
+    const servers=(healthIntegrationState.brew.servers||[]).filter(function(server){return server.configured;});
+    if(servers.length){
+      servers.forEach(function(server){
+        const b=classifyBrewHealth(server);
+        grid.appendChild(integrationHealthCard(server.title||server.entity||'Brew','brew','blue',b.level,b.detail,b.extra));
+      });
+    } else {
+      grid.appendChild(integrationHealthCard('Brew','brew','blue','ok','not configured','No Brew backhaul section is active.'));
+    }
+  } else {
+    grid.appendChild(integrationHealthCard('Brew','brew','blue','degraded','status unavailable','Wait for the next refresh.'));
+  }
   if(healthIntegrationState.asterisk){
     const a=classifyAsteriskHealth(healthIntegrationState.asterisk);
     grid.appendChild(integrationHealthCard('Asterisk SIP','asterisk','',a.level,a.detail,a.extra));
@@ -8228,12 +8322,14 @@ function renderHealthIntegrations(){
 async function loadHealthIntegrations(){
   healthIntegrationState.lastLoad=Date.now();
   try{
-    const [ast,dap,geo,mesh]=await Promise.all([
+    const [brew,ast,dap,geo,mesh]=await Promise.all([
+      fetch('/api/brew/status').then(r=>r.ok?r.json():null).catch(()=>null),
       fetch('/api/asterisk/status').then(r=>r.ok?r.json():null).catch(()=>null),
       fetch('/api/dapnet').then(r=>r.ok?r.json():null).catch(()=>null),
       fetch('/api/geoalarm').then(r=>r.ok?r.json():null).catch(()=>null),
       fetch('/api/meshcom').then(r=>r.ok?r.json():null).catch(()=>null)
     ]);
+    healthIntegrationState.brew=brew;
     healthIntegrationState.asterisk=ast;
     healthIntegrationState.dapnet=dap;
     healthIntegrationState.geoalarm=geo;
@@ -8756,6 +8852,8 @@ async function boot(){
   loadSystemInfo();
   loadBtsInfoLegacy();  // TETRA BTS Details card on the default (Radios) page
   loadDualCarrier();    // Dual-Carrier ON/OFF toggle state
+  refreshBrewServerStatus(true);
+  setInterval(()=>refreshBrewServerStatus(true),10000);
   wifiProbeAvailable(); // toggles the WiFi nav item
   checkUpdate();
 }

--- a/crates/tetra-entities/src/net_dashboard/server.rs
+++ b/crates/tetra-entities/src/net_dashboard/server.rs
@@ -9,6 +9,9 @@ use tungstenite::{
     handshake::server::{Request, Response},
 };
 
+use tetra_config::bluestation::CfgBrew;
+use tetra_core::tetra_entities::TetraEntity;
+
 use crate::net_control::commands::ControlCommand;
 use crate::net_dashboard::html::DASHBOARD_HTML;
 use crate::net_dashboard::state::{CallEntry, DashboardState, DashboardStateInner, MsEntry};
@@ -1896,6 +1899,10 @@ fn handle_connection(
         let mut s = stream;
         drain_http_headers(&mut s);
         serve_asterisk_status(s, &shared_config);
+    } else if req_line.contains("GET /api/brew/status") {
+        let mut s = stream;
+        drain_http_headers(&mut s);
+        serve_brew_status(s, &shared_config);
     } else if req_line.contains("GET /api/snom-notify") {
         let mut s = stream;
         drain_http_headers(&mut s);
@@ -4086,6 +4093,85 @@ fn serve_asterisk_status(stream: TcpStream, shared_config: &Option<tetra_config:
         }),
     };
     http_json_response(stream, 200, &body.to_string());
+}
+
+/// GET /api/brew/status — effective config and runtime status for both backhauls.
+fn serve_brew_status(stream: TcpStream, shared_config: &Option<tetra_config::bluestation::SharedConfig>) {
+    let body = match shared_config {
+        Some(cfg) => {
+            let c = cfg.config();
+            let state = cfg.state_read();
+            let servers = vec![
+                brew_status_json(
+                    "brew",
+                    "Brew",
+                    TetraEntity::Brew,
+                    c.brew.as_ref(),
+                    *state.brew_entity_connected.get(&TetraEntity::Brew).unwrap_or(&false),
+                ),
+                brew_status_json(
+                    "brew2",
+                    "Brew2",
+                    TetraEntity::Brew2,
+                    c.brew2.as_ref(),
+                    *state.brew_entity_connected.get(&TetraEntity::Brew2).unwrap_or(&false),
+                ),
+            ];
+            let configured_count = servers
+                .iter()
+                .filter(|server| server.get("configured").and_then(|value| value.as_bool()).unwrap_or(false))
+                .count();
+            let connected_count = servers
+                .iter()
+                .filter(|server| server.get("connected").and_then(|value| value.as_bool()).unwrap_or(false))
+                .count();
+            serde_json::json!({
+                "servers": servers,
+                "configured_count": configured_count,
+                "connected_count": connected_count,
+                "aggregate_connected": state.network_connected,
+            })
+        }
+        None => serde_json::json!({
+            "servers": [
+                { "entity": "brew", "title": "Brew", "configured": false, "connected": false },
+                { "entity": "brew2", "title": "Brew2", "configured": false, "connected": false },
+            ],
+            "configured_count": 0,
+            "connected_count": 0,
+            "aggregate_connected": false,
+        }),
+    };
+    http_json_response(stream, 200, &body.to_string());
+}
+
+fn brew_status_json(entity_key: &str, title: &str, entity: TetraEntity, brew: Option<&CfgBrew>, connected: bool) -> serde_json::Value {
+    match brew {
+        Some(brew) => {
+            let scheme = if brew.tls { "wss" } else { "ws" };
+            serde_json::json!({
+                "entity": entity_key,
+                "title": title,
+                "entity_debug": format!("{:?}", entity),
+                "configured": true,
+                "connected": connected,
+                "endpoint": format!("{}://{}:{}", scheme, brew.host, brew.port),
+                "feature_sds_enabled": brew.feature_sds_enabled,
+                "feature_rssi_export": brew.feature_rssi_export,
+                "whitelisted_ssis": brew.whitelisted_ssis.clone().unwrap_or_default(),
+                "pbx_gateway_issis": brew.pbx_gateway_issis.clone().unwrap_or_default(),
+                "local_issi_allowlist": brew.effective_local_issi_allowlist().unwrap_or_default(),
+                "local_issi_blocklist": brew.local_issi_blocklist.clone(),
+            })
+        }
+        None => serde_json::json!({
+            "entity": entity_key,
+            "title": title,
+            "entity_debug": format!("{:?}", entity),
+            "configured": false,
+            "connected": false,
+        }),
+    }
 }
 
 /// GET /api/snom-notify — return effective Snom XML NOTIFY settings.

--- a/crates/tetra-entities/src/umac/umac_bs.rs
+++ b/crates/tetra-entities/src/umac/umac_bs.rs
@@ -305,7 +305,7 @@ impl UmacBs {
     /// Otherwise, value from config is used.
     fn get_system_wide_services_state(config: &SharedConfig) -> bool {
         let cfg = config.config();
-        if cfg.brew.is_some() {
+        if cfg.brew.is_some() || cfg.brew2.is_some() {
             config.state_read().network_connected
         } else {
             cfg.cell.system_wide_services
@@ -1658,20 +1658,24 @@ impl UmacBs {
                     });
                 }
 
-                // Forward UL voice to Brew (User plane) if loaded
-                if self.config.config().brew.is_some() {
+                // Fan UL voice out to every configured Brew entity. Each entity accepts only
+                // calls and subscribers assigned to it, preventing cross-server media loops.
+                if self.config.config().brew.is_some() || self.config.config().brew2.is_some() {
                     if self.scheduler_for(carrier_num).circuit_is_active(Direction::Ul, ts) {
-                        let msg = SapMsg {
-                            sap: Sap::TmdSap,
-                            src: TetraEntity::Umac,
-                            dest: TetraEntity::Brew,
-                            msg: SapMsgInner::TmdCircuitDataInd(tetra_saps::tmd::TmdCircuitDataInd {
-                                carrier_num,
-                                ts,
-                                data: data.clone(),
-                            }),
-                        };
-                        queue.push_back(msg);
+                        for dest in crate::net_brew::BREW_ENTITIES {
+                            if crate::net_brew::is_active_for_entity(&self.config, dest) {
+                                queue.push_back(SapMsg {
+                                    sap: Sap::TmdSap,
+                                    src: TetraEntity::Umac,
+                                    dest,
+                                    msg: SapMsgInner::TmdCircuitDataInd(tetra_saps::tmd::TmdCircuitDataInd {
+                                        carrier_num,
+                                        ts,
+                                        data: data.clone(),
+                                    }),
+                                });
+                            }
+                        }
                     } else {
                         tracing::trace!("rx_tmd_prim: no active UL circuit on ts={}, dropping UL voice to Brew", ts);
                     }

--- a/crates/tetra-entities/tests/common/default_stack.rs
+++ b/crates/tetra-entities/tests/common/default_stack.rs
@@ -21,6 +21,7 @@ pub fn default_test_config_bs() -> StackConfig {
         net: net_info,
         cell: cell_info,
         brew: None,
+        brew2: None,
         asterisk: CfgAsterisk::default(),
         dapnet: CfgDapnet::default(),
         geoalarm: CfgGeoalarm::default(),

--- a/crates/tetra-entities/tests/test_cmce_bs.rs
+++ b/crates/tetra-entities/tests/test_cmce_bs.rs
@@ -1191,6 +1191,13 @@ fn test_network_group_speaker_change_uses_remote_floor_grant() {
         whitelisted_ssis: None,
         feature_rssi_export: false,
         pbx_gateway_issis: None,
+        local_issi_allowlist: None,
+        local_issi_blocklist: Vec::new(),
+        subscriber_type_deregister: 0,
+        subscriber_type_register: 1,
+        subscriber_type_reregister: 2,
+        subscriber_type_affiliate: 8,
+        subscriber_type_deaffiliate: 9,
     });
     let mut test = ComponentTest::from_config(config, Some(TdmaTime { h: 0, m: 1, f: 1, t: 1 }));
     test.populate_entities(

--- a/crates/tetra-entities/tests/test_cmce_bs.rs
+++ b/crates/tetra-entities/tests/test_cmce_bs.rs
@@ -30,6 +30,31 @@ const TEST_GSSI: u32 = 91;
 const TEST_ISSI: u32 = 1000001;
 const SECONDARY_CARRIER: u16 = 1522;
 
+fn brew_test_config() -> tetra_config::bluestation::StackConfig {
+    let mut config = ComponentTest::get_default_test_config(StackMode::Bs);
+    config.brew = Some(CfgBrew {
+        host: "test.local".into(),
+        port: 3000,
+        tls: false,
+        username: None,
+        password: None,
+        reconnect_delay: Duration::from_secs(1),
+        jitter_initial_latency_frames: 0,
+        feature_sds_enabled: true,
+        feature_rssi_export: false,
+        whitelisted_ssis: None,
+        pbx_gateway_issis: None,
+        local_issi_allowlist: None,
+        local_issi_blocklist: Vec::new(),
+        subscriber_type_deregister: 0,
+        subscriber_type_register: 1,
+        subscriber_type_reregister: 2,
+        subscriber_type_affiliate: 8,
+        subscriber_type_deaffiliate: 9,
+    });
+    config
+}
+
 /// Helper: register a subscriber on a GSSI so CMCE accepts calls for that group.
 fn register_subscriber(test: &mut ComponentTest, issi: u32, gssi: u32) {
     let register = SapMsg {
@@ -413,7 +438,7 @@ fn connected_duplex_individual_call(calling_issi: u32, called_issi: u32) -> (Com
 
 fn connected_brew_originated_simplex_call(remote_issi: u32, local_issi: u32) -> (ComponentTest, u16, uuid::Uuid) {
     let dltime = TdmaTime { h: 0, m: 1, f: 1, t: 1 };
-    let mut test = ComponentTest::new(StackMode::Bs, Some(dltime));
+    let mut test = ComponentTest::from_config(brew_test_config(), Some(dltime));
 
     let components = vec![TetraEntity::Cmce];
     let sinks = vec![TetraEntity::Mle, TetraEntity::Umac, TetraEntity::Brew];
@@ -570,8 +595,7 @@ fn test_local_echo_999_duplex_call_is_capped_to_finite_timeout() {
     test.run_stack(Some(1));
     let msgs = test.dump_sinks();
 
-    let (mut connect_sdu, _) =
-        find_lcmc_req(&msgs, calling_issi, CmcePduTypeDl::DConnect).expect("local echo must answer the caller");
+    let (mut connect_sdu, _) = find_lcmc_req(&msgs, calling_issi, CmcePduTypeDl::DConnect).expect("local echo must answer the caller");
     let d_connect = DConnect::from_bitbuf(&mut connect_sdu).expect("local echo D-CONNECT must parse");
     assert!(d_connect.simplex_duplex_selection, "this test exercises the duplex path");
     assert_eq!(
@@ -832,7 +856,7 @@ fn test_brew_originated_simplex_connect_confirm_makes_local_ms_listener() {
     debug::setup_logging_verbose();
 
     let dltime = TdmaTime { h: 0, m: 1, f: 1, t: 1 };
-    let mut test = ComponentTest::new(StackMode::Bs, Some(dltime));
+    let mut test = ComponentTest::from_config(brew_test_config(), Some(dltime));
 
     let components = vec![TetraEntity::Cmce];
     let sinks = vec![TetraEntity::Mle, TetraEntity::Umac, TetraEntity::Brew];
@@ -949,7 +973,7 @@ fn test_brew_connect_confirm_mcch_fallback_uses_linkless_delivery() {
     debug::setup_logging_verbose();
 
     let dltime = TdmaTime { h: 0, m: 1, f: 1, t: 1 };
-    let mut test = ComponentTest::new(StackMode::Bs, Some(dltime));
+    let mut test = ComponentTest::from_config(brew_test_config(), Some(dltime));
 
     let components = vec![TetraEntity::Cmce];
     let sinks = vec![TetraEntity::Mle, TetraEntity::Umac, TetraEntity::Brew];
@@ -2180,8 +2204,8 @@ mod ss_dgna_tests {
         debug::setup_logging_verbose();
         let (test, msgs) = run_dgna(false);
 
-        let (addr_ssi, facility) = find_d_facility(&msgs)
-            .unwrap_or_else(|| panic!("expected a D-FACILITY after DGNA deassign, got {} msgs", msgs.len()));
+        let (addr_ssi, facility) =
+            find_d_facility(&msgs).unwrap_or_else(|| panic!("expected a D-FACILITY after DGNA deassign, got {} msgs", msgs.len()));
         assert_eq!(addr_ssi, DGNA_ISSI);
 
         let body = facility.facility.expect("D-FACILITY must carry an SS-DGNA body");
@@ -2237,7 +2261,10 @@ mod ss_dgna_tests {
         debug::setup_logging_verbose();
 
         let mut test = ComponentTest::new(StackMode::Bs, Some(TdmaTime::default()));
-        test.populate_entities(vec![TetraEntity::Cmce], vec![TetraEntity::Mle, TetraEntity::Umac, TetraEntity::Brew]);
+        test.populate_entities(
+            vec![TetraEntity::Cmce],
+            vec![TetraEntity::Mle, TetraEntity::Umac, TetraEntity::Brew],
+        );
 
         // Build a U-FACILITY{ASSIGN ACK} as the affected MS would send back.
         let ack = AssignAck {

--- a/crates/tetra-entities/tests/test_sds_bs.rs
+++ b/crates/tetra-entities/tests/test_sds_bs.rs
@@ -198,6 +198,13 @@ fn test_sds_brew_forward() {
         feature_rssi_export: false,
         whitelisted_ssis: None,
         pbx_gateway_issis: None,
+        local_issi_allowlist: None,
+        local_issi_blocklist: Vec::new(),
+        subscriber_type_deregister: 0,
+        subscriber_type_register: 1,
+        subscriber_type_reregister: 2,
+        subscriber_type_affiliate: 8,
+        subscriber_type_deaffiliate: 9,
     });
     let mut test = ComponentTest::from_config(config, Some(dltime));
 
@@ -391,6 +398,13 @@ fn test_brew_inbound_allowed_bypasses_whitelist_but_honors_local_ranges() {
         feature_rssi_export: false,
         whitelisted_ssis: Some(vec![91]), // only GSSI 91 is whitelisted for OUTBOUND forwarding
         pbx_gateway_issis: None,
+        local_issi_allowlist: None,
+        local_issi_blocklist: Vec::new(),
+        subscriber_type_deregister: 0,
+        subscriber_type_register: 1,
+        subscriber_type_reregister: 2,
+        subscriber_type_affiliate: 8,
+        subscriber_type_deaffiliate: 9,
     });
     let test = ComponentTest::from_config(config, None);
 
@@ -496,6 +510,13 @@ fn test_u_status_brew_forward() {
         feature_rssi_export: false,
         whitelisted_ssis: None,
         pbx_gateway_issis: None,
+        local_issi_allowlist: None,
+        local_issi_blocklist: Vec::new(),
+        subscriber_type_deregister: 0,
+        subscriber_type_register: 1,
+        subscriber_type_reregister: 2,
+        subscriber_type_affiliate: 8,
+        subscriber_type_deaffiliate: 9,
     });
     let mut test = ComponentTest::from_config(config, Some(dltime));
 
@@ -1008,6 +1029,13 @@ fn brew_test_config() -> tetra_config::bluestation::StackConfig {
         feature_rssi_export: false,
         whitelisted_ssis: None,
         pbx_gateway_issis: None,
+        local_issi_allowlist: None,
+        local_issi_blocklist: Vec::new(),
+        subscriber_type_deregister: 0,
+        subscriber_type_register: 1,
+        subscriber_type_reregister: 2,
+        subscriber_type_affiliate: 8,
+        subscriber_type_deaffiliate: 9,
     });
     config
 }

--- a/example_config/config.toml
+++ b/example_config/config.toml
@@ -685,8 +685,18 @@ voice_service = true
 # is configured too, both [brew] and [brew2] MUST set a non-empty local_issi_allowlist,
 # and the two lists must not overlap. This prevents the same radio from registering
 # or forwarding traffic through both Brew servers.
-# local_issi_allowlist = [2632585, 2635411]
+# Include the source ISSI used by dashboard/integration SDS (normally 9999) on
+# exactly one server when those messages should leave through Brew.
+# local_issi_allowlist = [2632585, 2635411, 9999]
 # local_issi_blocklist = []
+#
+# Subscriber message type mapping. These TetraPack defaults can be overridden
+# independently for Brew servers that use another mapping.
+# subscriber_type_deregister = 0
+# subscriber_type_register = 1
+# subscriber_type_reregister = 2
+# subscriber_type_affiliate = 8
+# subscriber_type_deaffiliate = 9
 #
 # OPTIONAL: second Brew server. Same keys as [brew]. Use non-overlapping
 # local_issi_allowlist entries so every local ISSI belongs to exactly one server.
@@ -703,6 +713,11 @@ voice_service = true
 # pbx_gateway_issis = []
 # local_issi_allowlist = [2636000, 2636001]
 # local_issi_blocklist = []
+# subscriber_type_deregister = 0
+# subscriber_type_register = 1
+# subscriber_type_reregister = 2
+# subscriber_type_affiliate = 8
+# subscriber_type_deaffiliate = 9
 
 ###############################################################################
 

--- a/example_config/config.toml
+++ b/example_config/config.toml
@@ -679,6 +679,30 @@ voice_service = true
 # Optional PBX gateway ISSIs that should always be considered Brew-routable
 # (useful for phone/PBX interconnect IDs that do not follow normal Tetrapack ISSI rules)
 # pbx_gateway_issis = [16777184, 16777186]
+#
+# OPTIONAL: local ISSI partition for multi-Brew setups.
+# With only one Brew server this can stay commented for legacy behaviour. If [brew2]
+# is configured too, both [brew] and [brew2] MUST set a non-empty local_issi_allowlist,
+# and the two lists must not overlap. This prevents the same radio from registering
+# or forwarding traffic through both Brew servers.
+# local_issi_allowlist = [2632585, 2635411]
+# local_issi_blocklist = []
+#
+# OPTIONAL: second Brew server. Same keys as [brew]. Use non-overlapping
+# local_issi_allowlist entries so every local ISSI belongs to exactly one server.
+# [brew2]
+# host = "second.brew.example"
+# port = 9000
+# tls = true
+# username = 123456701
+# password = "012345"
+# reconnect_delay_secs = 15
+# feature_sds_enabled = true
+# feature_rssi_export = false
+# whitelisted_ssis = [92]
+# pbx_gateway_issis = []
+# local_issi_allowlist = [2636000, 2636001]
+# local_issi_blocklist = []
 
 ###############################################################################
 


### PR DESCRIPTION
## Summary

- add an optional `[brew2]` backhaul with independent connection, routing and subscriber state
- partition local ISSIs per server with required non-overlapping allowlists; blocklists take precedence and common whitelist/blacklist aliases remain supported
- prevent cross-server loops for registration, subscriber state, voice, SDS, RSSI and call lifecycle traffic
- support per-server Brew subscriber message type mappings and reconnect/resync handling
- expose both backhauls separately in dashboard health, topbar and system status (`1/2`, `2/2`)
- route dashboard/integration SDS through the Brew server owning its configured source ISSI
- document configuration, loop protection and the reserved source ISSI assignment

## Validation

- `DOCS_RS=1 cargo test -p tetra-config`
- `DOCS_RS=1 cargo test -p tetra-entities`
- `DOCS_RS=1 cargo check -p bluestation-bs --no-default-features`
- embedded dashboard JavaScript syntax validation
- `git diff --check`

Target branch: `beta`.
