### PR TITLE
Integrate EchoLink core, UI and routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,17 @@ cargo build --release
 ./target/release/bluestation-bs config.toml
 ```
 
+For voice bridges, install the native codec dependencies first and select the
+required feature:
+
+```bash
+# EchoLink voice
+cargo build --release --features echolink
+
+# Asterisk and EchoLink voice together
+cargo build --release --features asterisk,echolink
+```
+
 ### As a systemd service
 
 ```bash
@@ -492,7 +503,8 @@ sure AMI is enabled and `res_pjsip_notify.so` loads.
 
 EchoLink uses the public directory servers for login/status and UDP 5198/5199
 for QSO audio/control. GSM-FR audio requires `libgsm1-dev` at build time and the
-TETRA ACELP codec for TETRA audio conversion.
+TETRA ACELP codec for TETRA audio conversion. Build the station with
+`cargo build --release --features echolink`.
 
 ```toml
 [echolink]
@@ -518,14 +530,19 @@ allowed_node_ids = []
 auto_connect = ""
 reconnect_interval_secs = 30
 max_session_secs = 3600
+telegram_session_alerts = false
+telegram_session_prefix = "EchoLink"
 
 default_tetra_source_issi = 9999
-default_tetra_dest_issi = 2632585
-default_tetra_dest_is_group = false
+default_tetra_dest_issi = 26225
+default_tetra_dest_is_group = true
 ```
 
 The EchoLink dashboard page shows directory status, station count, QSO status,
-current route, last TX/error, and the downloaded directory list.
+current route, last TX/error, and the downloaded directory list. Empty remote
+allowlists accept all stations; when either list is populated, the remote
+callsign or node ID must match. Incoming audio is routed as a simplex/P2MP group
+call and uses the normal call ownership and teardown path for loop protection.
 
 ### MeshCom external UDP bridge
 
@@ -658,20 +675,21 @@ The dashboard shows a persistent red warning banner with the parse error so you 
 FlowStation can bridge TETRA to external paging and telephony networks and push
 alerts out to desk phones, dashboards, and Telegram. DAPNET, Snom display
 notifications, GeoAlarm, and the TPG2200 trigger are all part of the **default
-build** — just fill in their config sections. Asterisk SIP/RTP telephony is
-**feature-gated** (see below).
+build** — just fill in their config sections. Asterisk SIP/RTP and EchoLink
+voice are **feature-gated** (see below).
 
-> **Asterisk is not in the default build.** To use the SIP/RTP bridge the device
-> binary must be built with `cargo build --release --features asterisk`, and the
+> **Voice bridges are not in the default build.** Build Asterisk SIP/RTP with
+> `--features asterisk`, EchoLink audio with `--features echolink`, or both with
+> `--features asterisk,echolink`. The
 > native [`tetra-codec`](https://github.com/outerplane/tetra-codec) (outerplane)
 > ACELP library must be installed so FlowStation can convert between TETRA ACELP
-> and PCM audio. The default `cargo build --release` does **not** include Asterisk;
-> DAPNET, Snom notify, GeoAlarm, the TPG2200 trigger, and the dashboard all work
-> without it.
+> and PCM audio; EchoLink additionally needs `libgsm1-dev`. The default build
+> keeps EchoLink config, directory status, and dashboard support available but
+> does not compile QSO control or native voice transcoding.
 
-### TETRA ACELP codec (Asterisk only)
+### TETRA ACELP codec (voice bridges)
 
-The Asterisk audio bridge needs a TETRA ACELP codec implementation. One tested
+The Asterisk and EchoLink audio bridges need a TETRA ACELP codec implementation. One tested
 implementation is `outerplane/tetra-codec`:
 
 ```bash

--- a/bins/bluestation-bs/Cargo.toml
+++ b/bins/bluestation-bs/Cargo.toml
@@ -13,6 +13,7 @@ path = "src/main.rs"
 # device binary. Off by default so the standard build needs no codec.
 default = []
 asterisk = ["tetra-entities/asterisk"]
+echolink = ["tetra-entities/echolink"]
 
 [dependencies]
 tetra-core = { workspace = true }

--- a/bins/bluestation-bs/src/main.rs
+++ b/bins/bluestation-bs/src/main.rs
@@ -18,6 +18,7 @@ use tetra_entities::net_brew::entity::BrewEntity;
 use tetra_entities::net_brew::new_websocket_transport;
 use tetra_entities::net_dapnet::spawn_dapnet_worker;
 use tetra_entities::net_dashboard::DashboardServer;
+use tetra_entities::net_echolink::{EcholinkEntity, echolink_channel};
 use tetra_entities::net_geoalarm::{GeoAlarmSink, spawn_geoalarm_worker};
 use tetra_entities::net_meshcom::spawn_meshcom_worker;
 use tetra_entities::net_snom::{snom_notify_channel, spawn_snom_notify_worker};
@@ -163,6 +164,8 @@ fn start_control_worker(cfg: SharedConfig, command_dispatchers: HashMap<TetraEnt
 fn build_bs_stack(
     cfg: &mut SharedConfig,
     config_path: &str,
+    echolink_cmd_rx: tetra_entities::net_echolink::EcholinkCmdReceiver,
+    echolink_telegram_sink: Option<TelegramAlertSink>,
 ) -> (
     MessageRouter,
     Option<TelemetrySource>,
@@ -307,6 +310,17 @@ fn build_bs_stack(
         }
     }
 
+    router.register_entity(Box::new(EcholinkEntity::new(
+        cfg.clone(),
+        echolink_cmd_rx,
+        echolink_telegram_sink,
+    )));
+    if cfg.effective_echolink().enabled {
+        eprintln!(" -> EchoLink integration enabled");
+        #[cfg(not(feature = "echolink"))]
+        eprintln!("    audio codecs not compiled in; rebuild with --features echolink");
+    }
+
     // Init network time
     router.set_dl_time(TdmaTime::default());
 
@@ -381,7 +395,15 @@ fn main() {
         );
     }
 
-    let (mut router, tsource, cdispatchers, dapnet_telemetry_sink) = build_bs_stack(&mut cfg, &args.config);
+    let (echolink_cmd_tx, echolink_cmd_rx) = echolink_channel();
+    let (telegram_alert_sink, mut telegram_alert_source) = if cfg.config().telegram.is_some() {
+        let (sink, source) = telegram_alert_channel();
+        (Some(sink), Some(source))
+    } else {
+        (None, None)
+    };
+    let (mut router, tsource, cdispatchers, dapnet_telemetry_sink) =
+        build_bs_stack(&mut cfg, &args.config, echolink_cmd_rx, telegram_alert_sink.clone());
     let dapnet_cmd_tx = cdispatchers.get(&TetraEntity::Cmce).map(|dispatcher| dispatcher.clone_sender());
     let mut dapnet_telegram_sink: Option<TelegramAlertSink> = None;
     #[allow(unused_assignments)]
@@ -412,7 +434,7 @@ fn main() {
         // exists; it idles when alerts are disabled and reads settings live via
         // effective_telegram(), so toggling from the dashboard takes effect without a restart.
         let alert_sink = if has_telegram {
-            let (sink, alert_source) = telegram_alert_channel();
+            let alert_source = telegram_alert_source.take().expect("telegram source created with telegram config");
             let alert_cfg = cfg.clone();
             let snom_for_alerts = snom_notify_sink.clone();
             thread::Builder::new()
@@ -421,7 +443,7 @@ fn main() {
                     TelegramAlerter::new(alert_cfg, alert_source).with_snom_sink(snom_for_alerts).run();
                 })
                 .expect("failed to spawn telegram-alerter thread");
-            Some(sink)
+            telegram_alert_sink.clone()
         } else {
             None
         };
@@ -463,6 +485,7 @@ fn main() {
 
             // Propagate SharedConfig so the dashboard can read live SDS queue state.
             dashboard.set_shared_config(cfg.clone());
+            dashboard.set_echolink_cmd_sender(echolink_cmd_tx.clone());
 
             // Create a control link so dashboard can send commands to CMCE
             let dash_cmd_tx = {

--- a/crates/tetra-config/src/bluestation/config.rs
+++ b/crates/tetra-config/src/bluestation/config.rs
@@ -3,8 +3,8 @@ use std::sync::{Arc, RwLock};
 use tetra_core::freqs::FreqInfo;
 
 use crate::bluestation::{
-    CfgAsterisk, CfgCellInfo, CfgControl, CfgDapnet, CfgEmergency, CfgGeoalarm, CfgHealth, CfgMeshcom, CfgNetInfo, CfgPhyIo, CfgRecovery,
-    CfgSecurity, CfgSnomNotify, CfgTpg2200Action, CfgWxService, PhyBackend, StackState,
+    CfgAsterisk, CfgCellInfo, CfgControl, CfgDapnet, CfgEcholink, CfgEmergency, CfgGeoalarm, CfgHealth, CfgMeshcom, CfgNetInfo, CfgPhyIo,
+    CfgRecovery, CfgSecurity, CfgSnomNotify, CfgTpg2200Action, CfgWxService, PhyBackend, StackState,
 };
 
 use super::sec_brew::CfgBrew;
@@ -80,6 +80,9 @@ pub struct StackConfig {
 
     /// DAPNET inbound-message forwarding configuration.
     pub dapnet: CfgDapnet,
+
+    /// EchoLink directory and audio bridge configuration.
+    pub echolink: CfgEcholink,
 
     /// Geo-fence alarm configuration for TETRA/MeshCom positions.
     pub geoalarm: CfgGeoalarm,
@@ -483,6 +486,43 @@ impl SharedConfig {
                 tpg2200_max_text_chars: o.tpg2200_max_text_chars.clamp(8, 160),
                 sip_title_prefix: o.sip_title_prefix.clone(),
                 telegram_prefix: o.telegram_prefix.clone(),
+            }
+        } else {
+            base
+        }
+    }
+
+    /// Effective EchoLink settings: dashboard runtime override when present, otherwise TOML.
+    pub fn effective_echolink(&self) -> crate::bluestation::CfgEcholink {
+        let base = self.cfg.echolink.clone();
+        if let Some(o) = self.state_read().echolink_override.as_ref() {
+            crate::bluestation::CfgEcholink {
+                enabled: o.enabled,
+                callsign: o.callsign.clone(),
+                password: crate::bluestation::SecretField::from(o.password.clone()),
+                location: o.location.clone(),
+                status_text: o.status_text.clone(),
+                directory_servers: o.directory_servers.clone(),
+                directory_port: o.directory_port,
+                bind_addr: o.bind_addr.clone(),
+                audio_port: o.audio_port,
+                control_port: o.control_port,
+                inbound_enabled: o.inbound_enabled,
+                outbound_enabled: o.outbound_enabled,
+                outbound_prefix: o.outbound_prefix.clone(),
+                strip_outbound_prefix: o.strip_outbound_prefix,
+                service_numbers: o.service_numbers.clone(),
+                default_tetra_source_issi: o.default_tetra_source_issi,
+                default_tetra_dest_issi: o.default_tetra_dest_issi,
+                default_tetra_dest_is_group: o.default_tetra_dest_is_group,
+                routes: o.routes.clone(),
+                allowed_callsigns: o.allowed_callsigns.clone(),
+                allowed_node_ids: o.allowed_node_ids.clone(),
+                auto_connect: o.auto_connect.clone(),
+                reconnect_interval_secs: o.reconnect_interval_secs.max(1),
+                max_session_secs: o.max_session_secs.max(1),
+                telegram_session_alerts: o.telegram_session_alerts,
+                telegram_session_prefix: o.telegram_session_prefix.clone(),
             }
         } else {
             base

--- a/crates/tetra-config/src/bluestation/mod.rs
+++ b/crates/tetra-config/src/bluestation/mod.rs
@@ -25,6 +25,9 @@ pub use sec_asterisk::*;
 pub mod sec_dapnet;
 pub use sec_dapnet::*;
 
+pub mod sec_echolink;
+pub use sec_echolink::*;
+
 pub mod sec_geoalarm;
 pub use sec_geoalarm::*;
 

--- a/crates/tetra-config/src/bluestation/parsing.rs
+++ b/crates/tetra-config/src/bluestation/parsing.rs
@@ -14,6 +14,7 @@ use super::sec_asterisk::{CfgAsteriskDto, apply_asterisk_patch};
 use super::sec_brew::{CfgBrewDto, apply_brew_patch};
 use super::sec_dapnet::{CfgDapnetDto, apply_dapnet_patch};
 use super::sec_dashboard::{CfgDashboardDto, apply_dashboard_patch};
+use super::sec_echolink::{CfgEcholinkDto, apply_echolink_patch};
 use super::sec_emergency::{CfgEmergencyDto, apply_emergency_patch};
 use super::sec_geoalarm::{CfgGeoalarmDto, apply_geoalarm_patch};
 use super::sec_health::{CfgHealthDto, apply_health_patch};
@@ -137,6 +138,13 @@ pub fn from_toml_str(toml_str: &str) -> Result<StackConfig, Box<dyn std::error::
         return Err(format!("Unrecognized fields in dapnet config: {:?}", sorted_keys(&dapnet.extra)).into());
     }
 
+    // Optional echolink section
+    if let Some(ref echolink) = root.echolink
+        && !echolink.extra.is_empty()
+    {
+        return Err(format!("Unrecognized fields in echolink config: {:?}", sorted_keys(&echolink.extra)).into());
+    }
+
     // Optional geoalarm section
     if let Some(ref geoalarm) = root.geoalarm
         && !geoalarm.extra.is_empty()
@@ -239,6 +247,7 @@ pub fn from_toml_str(toml_str: &str) -> Result<StackConfig, Box<dyn std::error::
         brew: None,
         asterisk: apply_asterisk_patch(root.asterisk.unwrap_or_default())?,
         dapnet: apply_dapnet_patch(root.dapnet.unwrap_or_default())?,
+        echolink: apply_echolink_patch(root.echolink.unwrap_or_default())?,
         geoalarm: apply_geoalarm_patch(root.geoalarm.unwrap_or_default())?,
         meshcom: apply_meshcom_patch(root.meshcom.unwrap_or_default())?,
         tpg2200_action: apply_tpg2200_action_patch(root.tpg2200_action.unwrap_or_default())?,
@@ -316,6 +325,7 @@ struct TomlConfigRoot {
     brew: Option<CfgBrewDto>,
     asterisk: Option<CfgAsteriskDto>,
     dapnet: Option<CfgDapnetDto>,
+    echolink: Option<CfgEcholinkDto>,
     geoalarm: Option<CfgGeoalarmDto>,
     meshcom: Option<CfgMeshcomDto>,
     tpg2200_action: Option<CfgTpg2200ActionDto>,

--- a/crates/tetra-config/src/bluestation/sec_echolink.rs
+++ b/crates/tetra-config/src/bluestation/sec_echolink.rs
@@ -1,0 +1,283 @@
+use serde::Deserialize;
+use std::collections::{BTreeMap, HashMap};
+use toml::Value;
+
+use crate::bluestation::SecretField;
+
+/// EchoLink bridge configuration.
+///
+/// Disabled by default. This section provides the stable FlowStation-side integration surface:
+/// credentials, local EchoLink ports, and deterministic TETRA routing. The voice QSO engine can
+/// use the same config once the GSM-FR EchoLink audio bridge is enabled.
+#[derive(Debug, Clone)]
+pub struct CfgEcholink {
+    pub enabled: bool,
+    pub callsign: String,
+    pub password: SecretField,
+    pub location: String,
+    pub status_text: String,
+    pub directory_servers: Vec<String>,
+    pub directory_port: u16,
+    pub bind_addr: String,
+    pub audio_port: u16,
+    pub control_port: u16,
+    pub inbound_enabled: bool,
+    pub outbound_enabled: bool,
+    pub outbound_prefix: String,
+    pub strip_outbound_prefix: bool,
+    pub service_numbers: Vec<String>,
+    pub default_tetra_source_issi: u32,
+    pub default_tetra_dest_issi: u32,
+    pub default_tetra_dest_is_group: bool,
+    pub routes: BTreeMap<String, String>,
+    pub allowed_callsigns: Vec<String>,
+    pub allowed_node_ids: Vec<u32>,
+    pub auto_connect: String,
+    pub reconnect_interval_secs: u64,
+    pub max_session_secs: u64,
+    pub telegram_session_alerts: bool,
+    pub telegram_session_prefix: String,
+}
+
+impl Default for CfgEcholink {
+    fn default() -> Self {
+        apply_echolink_patch(CfgEcholinkDto::default()).expect("default echolink config must be valid")
+    }
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct CfgEcholinkDto {
+    #[serde(default)]
+    pub enabled: bool,
+    #[serde(default)]
+    pub callsign: String,
+    #[serde(default)]
+    pub password: String,
+    #[serde(default = "default_location")]
+    pub location: String,
+    #[serde(default = "default_status_text")]
+    pub status_text: String,
+    #[serde(default = "default_directory_servers")]
+    pub directory_servers: Vec<String>,
+    #[serde(default = "default_directory_port")]
+    pub directory_port: u16,
+    #[serde(default = "default_bind_addr")]
+    pub bind_addr: String,
+    #[serde(default = "default_audio_port")]
+    pub audio_port: u16,
+    #[serde(default = "default_control_port")]
+    pub control_port: u16,
+    #[serde(default = "default_true")]
+    pub inbound_enabled: bool,
+    #[serde(default = "default_true")]
+    pub outbound_enabled: bool,
+    #[serde(default = "default_outbound_prefix")]
+    pub outbound_prefix: String,
+    #[serde(default = "default_strip_outbound_prefix")]
+    pub strip_outbound_prefix: bool,
+    #[serde(default)]
+    pub service_numbers: Vec<String>,
+    #[serde(default = "default_tetra_source_issi")]
+    pub default_tetra_source_issi: u32,
+    #[serde(default)]
+    pub default_tetra_dest_issi: u32,
+    #[serde(default)]
+    pub default_tetra_dest_is_group: bool,
+    #[serde(default)]
+    pub routes: HashMap<String, String>,
+    #[serde(default)]
+    pub allowed_callsigns: Vec<String>,
+    #[serde(default)]
+    pub allowed_node_ids: Vec<u32>,
+    #[serde(default)]
+    pub auto_connect: String,
+    #[serde(default = "default_reconnect_interval_secs")]
+    pub reconnect_interval_secs: u64,
+    #[serde(default = "default_max_session_secs")]
+    pub max_session_secs: u64,
+    #[serde(default)]
+    pub telegram_session_alerts: bool,
+    #[serde(default = "default_telegram_session_prefix")]
+    pub telegram_session_prefix: String,
+
+    #[serde(flatten)]
+    pub extra: HashMap<String, Value>,
+}
+
+impl Default for CfgEcholinkDto {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            callsign: String::new(),
+            password: String::new(),
+            location: default_location(),
+            status_text: default_status_text(),
+            directory_servers: default_directory_servers(),
+            directory_port: default_directory_port(),
+            bind_addr: default_bind_addr(),
+            audio_port: default_audio_port(),
+            control_port: default_control_port(),
+            inbound_enabled: true,
+            outbound_enabled: true,
+            outbound_prefix: default_outbound_prefix(),
+            strip_outbound_prefix: default_strip_outbound_prefix(),
+            service_numbers: Vec::new(),
+            default_tetra_source_issi: default_tetra_source_issi(),
+            default_tetra_dest_issi: 0,
+            default_tetra_dest_is_group: false,
+            routes: HashMap::new(),
+            allowed_callsigns: Vec::new(),
+            allowed_node_ids: Vec::new(),
+            auto_connect: String::new(),
+            reconnect_interval_secs: default_reconnect_interval_secs(),
+            max_session_secs: default_max_session_secs(),
+            telegram_session_alerts: false,
+            telegram_session_prefix: default_telegram_session_prefix(),
+            extra: HashMap::new(),
+        }
+    }
+}
+
+fn default_true() -> bool {
+    true
+}
+
+fn default_location() -> String {
+    "FlowStation".to_string()
+}
+
+fn default_status_text() -> String {
+    "FlowStation EchoLink bridge".to_string()
+}
+
+fn default_directory_servers() -> Vec<String> {
+    vec!["servers.echolink.org".to_string(), "backup.echolink.org".to_string()]
+}
+
+fn default_directory_port() -> u16 {
+    5200
+}
+
+fn default_bind_addr() -> String {
+    "0.0.0.0".to_string()
+}
+
+fn default_audio_port() -> u16 {
+    5198
+}
+
+fn default_control_port() -> u16 {
+    5199
+}
+
+fn default_outbound_prefix() -> String {
+    "92".to_string()
+}
+
+fn default_strip_outbound_prefix() -> bool {
+    true
+}
+
+fn default_tetra_source_issi() -> u32 {
+    9999
+}
+
+fn default_reconnect_interval_secs() -> u64 {
+    30
+}
+
+fn default_max_session_secs() -> u64 {
+    3600
+}
+
+fn default_telegram_session_prefix() -> String {
+    "EchoLink".to_string()
+}
+
+pub fn apply_echolink_patch(src: CfgEcholinkDto) -> Result<CfgEcholink, String> {
+    if src.enabled {
+        if src.callsign.trim().is_empty() {
+            return Err("echolink: callsign cannot be empty when enabled".to_string());
+        }
+        if src.password.trim().is_empty() {
+            return Err("echolink: password cannot be empty when enabled".to_string());
+        }
+        if src.directory_port == 0 {
+            return Err("echolink: directory_port cannot be 0".to_string());
+        }
+        if src.audio_port == 0 || src.control_port == 0 || src.audio_port == src.control_port {
+            return Err("echolink: audio_port/control_port must be distinct non-zero ports".to_string());
+        }
+        if src.directory_servers.iter().all(|s| s.trim().is_empty()) {
+            return Err("echolink: at least one directory server is required when enabled".to_string());
+        }
+    }
+
+    let routes = normalize_routes(src.routes)?;
+    let service_numbers = normalize_string_list(src.service_numbers, false);
+    let allowed_callsigns = normalize_string_list(src.allowed_callsigns, true);
+    let allowed_node_ids = src.allowed_node_ids.into_iter().filter(|id| *id > 0).collect();
+
+    Ok(CfgEcholink {
+        enabled: src.enabled,
+        callsign: normalize_callsign(&src.callsign),
+        password: SecretField::from(src.password),
+        location: src.location,
+        status_text: src.status_text,
+        directory_servers: normalize_string_list(src.directory_servers, false),
+        directory_port: src.directory_port,
+        bind_addr: src.bind_addr,
+        audio_port: src.audio_port,
+        control_port: src.control_port,
+        inbound_enabled: src.inbound_enabled,
+        outbound_enabled: src.outbound_enabled,
+        outbound_prefix: src.outbound_prefix,
+        strip_outbound_prefix: src.strip_outbound_prefix,
+        service_numbers,
+        default_tetra_source_issi: src.default_tetra_source_issi.max(1),
+        default_tetra_dest_issi: src.default_tetra_dest_issi,
+        default_tetra_dest_is_group: src.default_tetra_dest_is_group,
+        routes,
+        allowed_callsigns,
+        allowed_node_ids,
+        auto_connect: normalize_echolink_target(&src.auto_connect),
+        reconnect_interval_secs: src.reconnect_interval_secs.max(1),
+        max_session_secs: src.max_session_secs.max(1),
+        telegram_session_alerts: src.telegram_session_alerts,
+        telegram_session_prefix: non_empty_or(src.telegram_session_prefix, "EchoLink"),
+    })
+}
+
+pub fn normalize_echolink_target(target: &str) -> String {
+    target.trim().to_ascii_uppercase()
+}
+
+fn normalize_callsign(callsign: &str) -> String {
+    callsign.trim().to_ascii_uppercase()
+}
+
+fn normalize_string_list(values: Vec<String>, callsigns: bool) -> Vec<String> {
+    values
+        .into_iter()
+        .map(|s| if callsigns { normalize_callsign(&s) } else { s.trim().to_string() })
+        .filter(|s| !s.is_empty())
+        .collect()
+}
+
+fn non_empty_or(value: String, fallback: &str) -> String {
+    let value = value.trim().to_string();
+    if value.is_empty() { fallback.to_string() } else { value }
+}
+
+fn normalize_routes(routes: HashMap<String, String>) -> Result<BTreeMap<String, String>, String> {
+    let mut out = BTreeMap::new();
+    for (dial, target) in routes {
+        let dial = dial.trim().to_string();
+        let target = normalize_echolink_target(&target);
+        if dial.is_empty() || target.is_empty() {
+            return Err("echolink.routes: dial keys and targets cannot be empty".to_string());
+        }
+        out.insert(dial, target);
+    }
+    Ok(out)
+}

--- a/crates/tetra-config/src/bluestation/state.rs
+++ b/crates/tetra-config/src/bluestation/state.rs
@@ -214,6 +214,37 @@ pub struct DapnetRuntimeOverride {
     pub rwth_messages_limit: usize,
 }
 
+/// Runtime override for EchoLink settings edited from the dashboard.
+#[derive(Debug, Clone, Default)]
+pub struct EcholinkRuntimeOverride {
+    pub enabled: bool,
+    pub callsign: String,
+    pub password: String,
+    pub location: String,
+    pub status_text: String,
+    pub directory_servers: Vec<String>,
+    pub directory_port: u16,
+    pub bind_addr: String,
+    pub audio_port: u16,
+    pub control_port: u16,
+    pub inbound_enabled: bool,
+    pub outbound_enabled: bool,
+    pub outbound_prefix: String,
+    pub strip_outbound_prefix: bool,
+    pub service_numbers: Vec<String>,
+    pub default_tetra_source_issi: u32,
+    pub default_tetra_dest_issi: u32,
+    pub default_tetra_dest_is_group: bool,
+    pub routes: std::collections::BTreeMap<String, String>,
+    pub allowed_callsigns: Vec<String>,
+    pub allowed_node_ids: Vec<u32>,
+    pub auto_connect: String,
+    pub reconnect_interval_secs: u64,
+    pub max_session_secs: u64,
+    pub telegram_session_alerts: bool,
+    pub telegram_session_prefix: String,
+}
+
 /// Runtime override for GeoAlarm settings, edited from the dashboard.
 ///
 /// Mirrors `[geoalarm]`. When present, it takes precedence over the config file so radius,
@@ -427,6 +458,50 @@ impl Default for GeoalarmRuntimeStatus {
 }
 
 #[derive(Debug, Clone)]
+pub struct EcholinkDirectoryStationStatus {
+    pub callsign: String,
+    pub id: u32,
+    pub ip: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct EcholinkRuntimeStatus {
+    pub configured: bool,
+    pub enabled: bool,
+    pub directory_status: String,
+    pub qso_status: String,
+    pub bind: String,
+    pub callsign: String,
+    pub connected_target: Option<String>,
+    pub routed_tetra_dest: Option<String>,
+    pub last_session_event: Option<String>,
+    pub last_rx: Option<String>,
+    pub last_tx: Option<String>,
+    pub last_error: Option<String>,
+    pub directory_stations: Vec<EcholinkDirectoryStationStatus>,
+}
+
+impl Default for EcholinkRuntimeStatus {
+    fn default() -> Self {
+        Self {
+            configured: false,
+            enabled: false,
+            directory_status: "disabled".to_string(),
+            qso_status: "idle".to_string(),
+            bind: String::new(),
+            callsign: String::new(),
+            connected_target: None,
+            routed_tetra_dest: None,
+            last_session_event: None,
+            last_rx: None,
+            last_tx: None,
+            last_error: None,
+            directory_stations: Vec::new(),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
 pub struct MeshcomNodeStatus {
     pub src: String,
     pub last_seen: String,
@@ -505,6 +580,8 @@ pub struct StackState {
     pub telegram_override: Option<TelegramRuntimeOverride>,
     /// Runtime override for DAPNET settings (dashboard editing). See DapnetRuntimeOverride.
     pub dapnet_override: Option<DapnetRuntimeOverride>,
+    /// Runtime override for EchoLink settings (dashboard editing). See EcholinkRuntimeOverride.
+    pub echolink_override: Option<EcholinkRuntimeOverride>,
     /// Runtime override for GeoAlarm settings (dashboard editing). See GeoalarmRuntimeOverride.
     pub geoalarm_override: Option<GeoalarmRuntimeOverride>,
     /// Runtime override for MeshCom settings (dashboard editing). See MeshcomRuntimeOverride.
@@ -517,6 +594,8 @@ pub struct StackState {
     pub asterisk_status: AsteriskRuntimeStatus,
     /// Runtime DAPNET receiver/forwarding status for `/api/dapnet` and the Health tab.
     pub dapnet_status: DapnetRuntimeStatus,
+    /// Runtime EchoLink bridge status for `/api/echolink` and the Health tab.
+    pub echolink_status: EcholinkRuntimeStatus,
     /// Runtime GeoAlarm status for `/api/geoalarm`.
     pub geoalarm_status: GeoalarmRuntimeStatus,
     /// Runtime MeshCom UDP bridge status for `/api/meshcom` and the Health tab.
@@ -637,12 +716,14 @@ impl Default for StackState {
             wx_override: None,
             telegram_override: None,
             dapnet_override: None,
+            echolink_override: None,
             geoalarm_override: None,
             meshcom_override: None,
             snom_notify_override: None,
             tpg2200_action_next_incident: None,
             asterisk_status: AsteriskRuntimeStatus::default(),
             dapnet_status: DapnetRuntimeStatus::default(),
+            echolink_status: EcholinkRuntimeStatus::default(),
             geoalarm_status: GeoalarmRuntimeStatus::default(),
             meshcom_status: MeshcomRuntimeStatus::default(),
             active_call_ts: std::collections::HashMap::new(),

--- a/crates/tetra-core/src/tetra_entities.rs
+++ b/crates/tetra-core/src/tetra_entities.rs
@@ -29,4 +29,7 @@ pub enum TetraEntity {
 
     /// Asterisk SIP/RTP bridge
     Asterisk,
+
+    /// EchoLink UDP/GSM bridge
+    Echolink,
 }

--- a/crates/tetra-entities/Cargo.toml
+++ b/crates/tetra-entities/Cargo.toml
@@ -9,6 +9,8 @@ edition.workspace = true
 # link the TETRA codec.
 default = []
 asterisk = []
+# EchoLink GSM-FR/TETRA audio bridge. Requires libgsm and libtetra-codec.
+echolink = []
 
 [dependencies]
 tetra-core = { workspace = true }

--- a/crates/tetra-entities/src/cmce/subentities/cc_bs/lifecycle.rs
+++ b/crates/tetra-entities/src/cmce/subentities/cc_bs/lifecycle.rs
@@ -157,8 +157,8 @@ impl CcBsSubentity {
         }
     }
 
-    pub(super) fn notify_network_call_end(&self, queue: &mut MessageQueue, brew_uuid: uuid::Uuid) {
-        Self::push_control(queue, TetraEntity::Brew, CallControl::NetworkCallEnd { brew_uuid });
+    pub(super) fn notify_network_call_end(&self, queue: &mut MessageQueue, network_entity: TetraEntity, brew_uuid: uuid::Uuid) {
+        Self::push_control(queue, network_entity, CallControl::NetworkCallEnd { brew_uuid });
     }
 
     pub(super) fn notify_network_circuit_release(

--- a/crates/tetra-entities/src/cmce/subentities/cc_bs/pdu.rs
+++ b/crates/tetra-entities/src/cmce/subentities/cc_bs/pdu.rs
@@ -304,6 +304,16 @@ impl CcBsSubentity {
         self.group_listeners.get(&gssi).copied().unwrap_or(0) > 0
     }
 
+    pub(in crate::cmce::subentities::cc_bs) fn is_echolink_inbound_group_destination(&self, gssi: u32) -> bool {
+        let cfg = self.config.effective_echolink();
+        cfg.enabled && cfg.inbound_enabled && cfg.default_tetra_dest_is_group && cfg.default_tetra_dest_issi == gssi
+    }
+
+    pub(in crate::cmce::subentities::cc_bs) fn is_echolink_outbound_group_destination(&self, gssi: u32) -> bool {
+        let cfg = self.config.effective_echolink();
+        cfg.enabled && cfg.outbound_enabled && cfg.default_tetra_dest_is_group && cfg.default_tetra_dest_issi == gssi
+    }
+
     pub(super) fn inc_group_listener(&mut self, gssi: u32) {
         let entry = self.group_listeners.entry(gssi).or_insert(0);
         *entry += 1;
@@ -393,10 +403,8 @@ impl CcBsSubentity {
 
         for (call_id, origin) in to_drop {
             tracing::info!("CMCE: dropping call_id={} gssi={} (no listeners)", call_id, gssi);
-            if let CallOrigin::Network { brew_uuid } = origin {
-                if brew::is_brew_gssi_routable(&self.config, gssi) {
-                    self.notify_network_call_end(queue, brew_uuid);
-                };
+            if let CallOrigin::Network { network_entity, brew_uuid } = origin {
+                self.notify_network_call_end(queue, network_entity, brew_uuid);
             };
             self.release_group_call(queue, call_id, DisconnectCause::SwmiRequestedDisconnection);
         }
@@ -718,6 +726,46 @@ impl CcBsSubentity {
         };
 
         cfg.route_outbound_raw(&raw)
+    }
+
+    pub(super) fn echolink_route_target(&self, network_call: &NetworkCircuitCall) -> Option<String> {
+        let cfg = self.config.effective_echolink();
+        if !cfg.enabled || !cfg.outbound_enabled {
+            return None;
+        }
+
+        let raw = if !network_call.number.trim().is_empty() {
+            network_call.number.trim().to_string()
+        } else if network_call.destination != 0 {
+            network_call.destination.to_string()
+        } else {
+            return None;
+        };
+
+        let mut routed = raw.as_str();
+        let prefix_matched = !cfg.outbound_prefix.is_empty() && raw.starts_with(&cfg.outbound_prefix);
+        if prefix_matched && cfg.strip_outbound_prefix {
+            routed = &raw[cfg.outbound_prefix.len()..];
+        }
+
+        let routed = routed.trim();
+        if routed.is_empty() {
+            return None;
+        }
+        if let Some(target) = cfg.routes.get(routed) {
+            return Some(target.clone());
+        }
+        if cfg.service_numbers.iter().any(|number| number == routed) {
+            return if cfg.auto_connect.trim().is_empty() {
+                Some(routed.to_string())
+            } else {
+                Some(cfg.auto_connect.clone())
+            };
+        }
+        if cfg.service_numbers.is_empty() && prefix_matched {
+            return Some(routed.to_string());
+        }
+        None
     }
 
     pub(super) fn signal_umac_circuit_open(

--- a/crates/tetra-entities/src/cmce/subentities/cc_bs/procedures/group.rs
+++ b/crates/tetra-entities/src/cmce/subentities/cc_bs/procedures/group.rs
@@ -296,6 +296,7 @@ impl CcBsSubentity {
         &mut self,
         queue: &mut MessageQueue,
         call_id: u16,
+        network_entity: TetraEntity,
         brew_uuid: uuid::Uuid,
         source_issi: u32,
     ) -> Result<(), GroupTransitionError> {
@@ -309,11 +310,14 @@ impl CcBsSubentity {
 
         call.grant_floor(source_issi, None);
         call.brew_uuid = Some(brew_uuid);
-        if let CallOrigin::Network { brew_uuid: old_uuid } = call.origin
-            && old_uuid != brew_uuid
+        if let CallOrigin::Network {
+            network_entity: old_entity,
+            brew_uuid: old_uuid,
+        } = &call.origin
+            && (*old_uuid != brew_uuid || *old_entity != network_entity)
         {
             tracing::warn!("CMCE FSM: network call start changed brew_uuid call_id={}", call_id);
-            call.origin = CallOrigin::Network { brew_uuid };
+            call.origin = CallOrigin::Network { network_entity, brew_uuid };
         }
 
         let ts = call.ts;
@@ -328,7 +332,7 @@ impl CcBsSubentity {
         queue.push_back(SapMsg {
             sap: Sap::Control,
             src: TetraEntity::Cmce,
-            dest: TetraEntity::Brew,
+            dest: network_entity,
             msg: SapMsgInner::CmceCallControl(CallControl::NetworkCallReady {
                 brew_uuid,
                 call_id,

--- a/crates/tetra-entities/src/cmce/subentities/cc_bs/procedures/isi.rs
+++ b/crates/tetra-entities/src/cmce/subentities/cc_bs/procedures/isi.rs
@@ -26,7 +26,14 @@ impl CcBsSubentity {
         }
     }
 
-    /// Handle network-initiated circuit setup request (Brew/Asterisk -> local called MS).
+    fn network_group_call_allowed(&self, network_entity: TetraEntity, dest_gssi: u32) -> bool {
+        match network_entity {
+            TetraEntity::Echolink => self.is_echolink_inbound_group_destination(dest_gssi),
+            _ => brew::is_brew_inbound_allowed(&self.config, dest_gssi),
+        }
+    }
+
+    /// Handle network-initiated circuit setup request (Brew/Asterisk/EchoLink -> local called MS).
     pub(in crate::cmce::subentities::cc_bs) fn fsm_on_network_circuit_setup_request(
         &mut self,
         queue: &mut MessageQueue,
@@ -140,18 +147,27 @@ impl CcBsSubentity {
         let call_timeout = CallTimeout::try_from(call.timeout as u64).unwrap_or(CallTimeout::T5m);
         let setup_timeout = self.network_setup_timeout(network_entity);
         let circuit_mode = CircuitModeType::try_from(call.mode as u64).unwrap_or(CircuitModeType::TchS);
-        let external_subscriber_number = Self::encode_external_subscriber_number(&call.number);
-        let calling_party_extension = call.number.trim().parse::<u32>().ok().filter(|value| *value <= 0x00ff_ffff);
+        let external_number = if call.number.trim().is_empty() && call.source_issi != 0 {
+            call.source_issi.to_string()
+        } else {
+            call.number.clone()
+        };
+        let external_subscriber_number = Self::encode_external_subscriber_number(&external_number);
 
         // Asterisk SIP callers often have no real TETRA ISSI; derive a display SSI from the
         // dialled external number so the local MS sees a sensible calling party. Brew keeps its
         // original behaviour (always uses source_issi, even when 0).
         let calling_party_address_ssi = if call.source_issi != 0 {
             Some(call.source_issi)
-        } else if network_entity == TetraEntity::Asterisk {
-            Self::external_number_as_ssi(&call.number)
+        } else if matches!(network_entity, TetraEntity::Asterisk | TetraEntity::Echolink) {
+            Self::external_number_as_ssi(&external_number)
         } else {
-            Some(call.source_issi)
+            None
+        };
+        let calling_party_extension = if calling_party_address_ssi.is_none() {
+            external_number.trim().parse::<u32>().ok().filter(|value| *value <= 0x00ff_ffff)
+        } else {
+            None
         };
 
         tracing::info!(
@@ -713,6 +729,7 @@ impl CcBsSubentity {
     pub(in crate::cmce::subentities::cc_bs) fn fsm_on_network_call_start(
         &mut self,
         queue: &mut MessageQueue,
+        network_entity: TetraEntity,
         brew_uuid: uuid::Uuid,
         source_issi: u32,
         dest_gssi: u32,
@@ -722,17 +739,17 @@ impl CcBsSubentity {
         // inbound predicate which — unlike is_brew_gssi_routable — must NOT apply the
         // outbound whitelist (see brew_routable::is_brew_inbound_allowed). A GSSI that
         // is not admissible is dropped gracefully instead of crashing the base station.
-        if !brew::is_brew_inbound_allowed(&self.config, dest_gssi) {
+        if !self.network_group_call_allowed(network_entity, dest_gssi) {
             tracing::info!(
                 "CMCE: ignoring network call start uuid={} gssi={} (inbound not allowed)",
                 brew_uuid,
                 dest_gssi
             );
-            self.notify_network_call_end(queue, brew_uuid);
+            self.notify_network_call_end(queue, network_entity, brew_uuid);
             return;
         }
 
-        if !self.has_listener(dest_gssi) {
+        if !self.has_listener(dest_gssi) && network_entity != TetraEntity::Echolink {
             tracing::info!(
                 "CMCE: ignoring network call start uuid={} gssi={} (no listeners)",
                 brew_uuid,
@@ -740,8 +757,14 @@ impl CcBsSubentity {
             );
             self.drop_group_calls_if_unlistened(queue, dest_gssi);
 
-            self.notify_network_call_end(queue, brew_uuid);
+            self.notify_network_call_end(queue, network_entity, brew_uuid);
             return;
+        } else if !self.has_listener(dest_gssi) {
+            tracing::info!(
+                "CMCE: accepting EchoLink network call uuid={} gssi={} without registry listeners",
+                brew_uuid,
+                dest_gssi
+            );
         }
 
         // Speaker change for an existing GSSI call
@@ -758,7 +781,7 @@ impl CcBsSubentity {
                 old_speaker
             );
 
-            if let Err(err) = self.fsm_group_on_network_call_start(queue, call_id, brew_uuid, source_issi) {
+            if let Err(err) = self.fsm_group_on_network_call_start(queue, call_id, network_entity, brew_uuid, source_issi) {
                 match err {
                     GroupTransitionError::UnknownCall(_) => {
                         tracing::warn!(
@@ -914,6 +937,7 @@ impl CcBsSubentity {
         self.active_calls.insert(
             call_id,
             ActiveCall::new_network(
+                network_entity,
                 brew_uuid,
                 dest_gssi,
                 source_issi,
@@ -939,7 +963,7 @@ impl CcBsSubentity {
         queue.push_back(SapMsg {
             sap: Sap::Control,
             src: TetraEntity::Cmce,
-            dest: TetraEntity::Brew,
+            dest: network_entity,
             msg: SapMsgInner::CmceCallControl(CallControl::NetworkCallReady {
                 brew_uuid,
                 call_id,

--- a/crates/tetra-entities/src/cmce/subentities/cc_bs/procedures/setup.rs
+++ b/crates/tetra-entities/src/cmce/subentities/cc_bs/procedures/setup.rs
@@ -312,13 +312,19 @@ impl CcBsSubentity {
         let dest_gssi = dest_gssi as u32;
         let dest_addr = TetraAddress::new(dest_gssi, SsiType::Gssi);
 
-        if !self.has_listener(dest_gssi) {
+        if !self.has_listener(dest_gssi) && !self.is_echolink_outbound_group_destination(dest_gssi) {
             tracing::info!(
                 "CMCE: rejecting U-SETUP from issi={} to gssi={} (no listeners)",
                 calling_party.ssi,
                 dest_gssi
             );
             return;
+        } else if !self.has_listener(dest_gssi) {
+            tracing::info!(
+                "CMCE: accepting U-SETUP from issi={} to EchoLink gssi={} without registry listeners",
+                calling_party.ssi,
+                dest_gssi
+            );
         }
 
         if is_emergency_priority(pdu.call_priority) {
@@ -558,9 +564,13 @@ impl CcBsSubentity {
         let asterisk_can_route = self.config.config().asterisk.enabled;
         #[cfg(not(feature = "asterisk"))]
         let asterisk_can_route = false;
-        if !is_issi_address && !brew::is_active(&self.config) && !asterisk_can_route {
+        if !is_issi_address
+            && !brew::is_active(&self.config)
+            && !asterisk_can_route
+            && !self.config.effective_echolink().enabled
+        {
             tracing::warn!(
-                "U-SETUP P2P with non-ISSI called_party_type_identifier={} (rejecting, Brew/Asterisk disabled)",
+                "U-SETUP P2P with non-ISSI called_party_type_identifier={} (rejecting, no network bridge enabled)",
                 pdu.called_party_type_identifier
             );
             self.reject_setup_request(
@@ -568,7 +578,7 @@ impl CcBsSubentity {
                 message,
                 calling_party,
                 DisconnectCause::RequestedServiceNotAvailable,
-                "non-ISSI destination requires Brew or Asterisk",
+                "non-ISSI destination requires Brew, Asterisk or EchoLink",
             );
             return;
         }
@@ -893,35 +903,48 @@ impl CcBsSubentity {
         let SapMsgInner::LcmcMleUnitdataInd(prim) = &message.msg else {
             panic!()
         };
-        #[cfg_attr(not(feature = "asterisk"), allow(unused_mut))]
         let mut network_call = Self::build_network_circuit_call_from_u_setup(pdu, calling_party.ssi);
 
-        // Decide whether this dialed (non-ISSI) number routes to the Asterisk SIP/RTP bridge
-        // instead of Brew. Asterisk takes precedence; otherwise the call falls through to Brew.
-        // Without the asterisk feature there is no SIP bridge, so every call falls through to Brew.
         #[cfg(feature = "asterisk")]
-        let network_entity = {
-            let asterisk_number = self.asterisk_route_number(&network_call);
-            let entity = if asterisk_number.is_some() {
-                TetraEntity::Asterisk
-            } else {
-                TetraEntity::Brew
-            };
-            if let Some(number) = asterisk_number {
-                tracing::info!(
-                    "CMCE: routing U-SETUP src={} dialed='{}' to Asterisk SIP number='{}'",
-                    calling_party.ssi,
-                    network_call.number,
-                    number
-                );
-                network_call.number = number;
-                network_call.destination = 0;
-                network_call.duplex = 1;
-            }
-            entity
-        };
+        let asterisk_number = self.asterisk_route_number(&network_call);
         #[cfg(not(feature = "asterisk"))]
-        let network_entity = TetraEntity::Brew;
+        let asterisk_number: Option<String> = None;
+
+        let echolink_target = if asterisk_number.is_none() {
+            self.echolink_route_target(&network_call)
+        } else {
+            None
+        };
+        let network_entity = if asterisk_number.is_some() {
+            TetraEntity::Asterisk
+        } else if echolink_target.is_some() {
+            TetraEntity::Echolink
+        } else {
+            TetraEntity::Brew
+        };
+
+        if let Some(number) = asterisk_number {
+            tracing::info!(
+                "CMCE: routing U-SETUP src={} dialed='{}' to Asterisk SIP number='{}'",
+                calling_party.ssi,
+                network_call.number,
+                number
+            );
+            network_call.number = number;
+            network_call.destination = 0;
+            network_call.duplex = 1;
+        } else if let Some(target) = echolink_target {
+            tracing::info!(
+                "CMCE: routing U-SETUP src={} dialed='{}' to EchoLink target='{}'",
+                calling_party.ssi,
+                network_call.number,
+                target
+            );
+            network_call.number = target;
+            network_call.destination = 0;
+            network_call.duplex = 0;
+            network_call.communication = CommunicationType::P2Mp.into_raw() as u8;
+        }
 
         if network_entity == TetraEntity::Brew && !brew::is_active(&self.config) {
             tracing::info!(
@@ -986,7 +1009,7 @@ impl CcBsSubentity {
         }
 
         let has_external_called_party = Self::has_external_called_party(pdu, &network_call);
-        let destination_routable = network_entity == TetraEntity::Asterisk
+        let destination_routable = matches!(network_entity, TetraEntity::Asterisk | TetraEntity::Echolink)
             || network_call.destination == 0
             || brew::is_brew_issi_routable(&self.config, network_call.destination);
 
@@ -1016,13 +1039,18 @@ impl CcBsSubentity {
             network_call.destination = 0;
         }
 
-        // Allocate one bearer for the local MS.
+        // EchoLink is always a simplex P2MP bridge, even when reached from an individual dial.
+        let is_echolink = network_entity == TetraEntity::Echolink;
         let circuit_calling = {
             let mut state = self.config.state_write();
             match self.circuits.allocate_circuit_with_allocator(
                 Direction::Both,
-                pdu.basic_service_information.communication_type,
-                pdu.simplex_duplex_selection,
+                if is_echolink {
+                    CommunicationType::P2Mp
+                } else {
+                    pdu.basic_service_information.communication_type
+                },
+                if is_echolink { false } else { pdu.simplex_duplex_selection },
                 &mut state.timeslot_alloc,
                 TimeslotOwner::Cmce,
             ) {
@@ -1094,14 +1122,14 @@ impl CcBsSubentity {
                 called_ts: ts,
                 calling_usage: usage,
                 called_usage: usage,
-                simplex_duplex: pdu.simplex_duplex_selection,
+                simplex_duplex: if is_echolink { false } else { pdu.simplex_duplex_selection },
                 priority: pdu.call_priority,
                 state: IndividualCallState::CallSetupPending,
                 formal_state: CcFormalState::Idle.after(CcFormalEvent::SetupRequest),
                 setup_timer_started: Some(self.dltime),
                 setup_timeout: Some(CallTimeoutSetupPhase::T60s),
                 active_timer_started: None,
-                call_timeout: Self::p2p_call_timeout(pdu.simplex_duplex_selection),
+                call_timeout: Self::p2p_call_timeout(if is_echolink { false } else { pdu.simplex_duplex_selection }),
                 called_over_brew: true,
                 calling_over_brew: false,
                 network_entity,

--- a/crates/tetra-entities/src/cmce/subentities/cc_bs/routes/isi.rs
+++ b/crates/tetra-entities/src/cmce/subentities/cc_bs/routes/isi.rs
@@ -134,12 +134,13 @@ impl CcBsSubentity {
     pub(super) fn rx_network_call_start(
         &mut self,
         queue: &mut MessageQueue,
+        network_entity: TetraEntity,
         brew_uuid: uuid::Uuid,
         source_issi: u32,
         dest_gssi: u32,
         priority: u8,
     ) {
-        self.fsm_on_network_call_start(queue, brew_uuid, source_issi, dest_gssi, priority);
+        self.fsm_on_network_call_start(queue, network_entity, brew_uuid, source_issi, dest_gssi, priority);
     }
 
     /// Handle network call end request

--- a/crates/tetra-entities/src/cmce/subentities/cc_bs/routes/ra.rs
+++ b/crates/tetra-entities/src/cmce/subentities/cc_bs/routes/ra.rs
@@ -2,9 +2,9 @@ use super::*;
 
 impl CcBsSubentity {
     pub fn rx_call_control(&mut self, queue: &mut MessageQueue, message: SapMsg) {
-        // The originating network entity (Brew or Asterisk). Inbound network-initiated setup
+        // The originating network entity (Brew, Asterisk, or EchoLink). Inbound network-initiated setup
         // requests carry no prior call record, so we route replies back to the sender.
-        let src_entity = message.src;
+        let network_entity = message.src;
         let SapMsgInner::CmceCallControl(call_control) = message.msg else {
             tracing::warn!("CMCE CC control ingress received non-call-control message");
             return;
@@ -17,7 +17,7 @@ impl CcBsSubentity {
                 dest_gssi,
                 priority,
             } => {
-                self.rx_network_call_start(queue, brew_uuid, source_issi, dest_gssi, priority);
+                self.rx_network_call_start(queue, network_entity, brew_uuid, source_issi, dest_gssi, priority);
             }
             CallControl::NetworkCallEnd { brew_uuid } => {
                 self.rx_network_call_end(queue, brew_uuid);
@@ -26,7 +26,7 @@ impl CcBsSubentity {
                 self.handle_ul_inactivity_timeout_slot(queue, carrier_num, ts);
             }
             CallControl::NetworkCircuitSetupRequest { brew_uuid, call } => {
-                self.rx_network_circuit_setup_request(queue, src_entity, brew_uuid, call);
+                self.rx_network_circuit_setup_request(queue, network_entity, brew_uuid, call);
             }
             CallControl::NetworkCircuitSetupAccept { brew_uuid } => {
                 self.rx_network_circuit_setup_accept(brew_uuid);

--- a/crates/tetra-entities/src/cmce/subentities/cc_bs/state/mod.rs
+++ b/crates/tetra-entities/src/cmce/subentities/cc_bs/state/mod.rs
@@ -63,6 +63,7 @@ pub(super) enum CallOrigin {
     },
     /// Network-initiated call from TetraPack/Brew
     Network {
+        network_entity: TetraEntity,
         brew_uuid: uuid::Uuid, // For Brew tracking
     },
 }
@@ -212,6 +213,7 @@ impl ActiveCall {
 
     #[allow(clippy::too_many_arguments)]
     pub(super) fn new_network(
+        network_entity: TetraEntity,
         brew_uuid: uuid::Uuid,
         dest_gssi: u32,
         source_issi: u32,
@@ -223,7 +225,7 @@ impl ActiveCall {
         priority: u8,
     ) -> Self {
         Self {
-            origin: CallOrigin::Network { brew_uuid },
+            origin: CallOrigin::Network { network_entity, brew_uuid },
             dest_gssi,
             source_issi,
             created_at,
@@ -411,10 +413,9 @@ pub(super) struct IndividualCall {
     pub(super) called_over_brew: bool,
     /// True when the calling party lives behind Brew/TetraPack.
     pub(super) calling_over_brew: bool,
-    /// Network entity bridging this call (Brew or Asterisk). Call-control messages and
+    /// Network entity bridging this call (Brew, Asterisk, or EchoLink). Call-control messages and
     /// floor/DTMF signalling for the network leg are routed to this entity rather than
-    /// hardcoding `TetraEntity::Brew`, so Brew calls reach Brew and Asterisk calls reach
-    /// the SIP/RTP bridge.
+    /// hardcoding `TetraEntity::Brew`.
     pub(super) network_entity: TetraEntity,
     /// Brew UUID when this call is bridged to TetraPack.
     pub(super) brew_uuid: Option<uuid::Uuid>,

--- a/crates/tetra-entities/src/lib.rs
+++ b/crates/tetra-entities/src/lib.rs
@@ -19,6 +19,7 @@ pub mod net_brew;
 pub mod net_control;
 pub mod net_dapnet;
 pub mod net_dashboard;
+pub mod net_echolink;
 pub mod net_geoalarm;
 pub mod net_meshcom;
 pub mod net_snom;

--- a/crates/tetra-entities/src/net_dashboard/echolink.rs
+++ b/crates/tetra-entities/src/net_dashboard/echolink.rs
@@ -1,0 +1,189 @@
+//! Dashboard-side persistence and helpers for EchoLink settings.
+
+use tetra_config::bluestation::EcholinkRuntimeOverride;
+
+pub fn mask_secret(secret: &str) -> String {
+    crate::net_dashboard::dapnet::mask_secret(secret)
+}
+
+fn toml_escape(s: &str) -> String {
+    s.replace('\\', "\\\\").replace('"', "\\\"")
+}
+
+fn string_array_toml(values: &[String]) -> String {
+    values
+        .iter()
+        .map(|v| format!("\"{}\"", toml_escape(v)))
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+fn u32_array_toml(values: &[u32]) -> String {
+    values.iter().map(|v| v.to_string()).collect::<Vec<_>>().join(", ")
+}
+
+fn routes_toml(routes: &std::collections::BTreeMap<String, String>) -> String {
+    routes
+        .iter()
+        .map(|(dial, target)| format!("\"{}\" = \"{}\"", toml_escape(dial), toml_escape(target)))
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+/// Rewrite (or insert) the `[echolink]` section in the TOML file. A `.echolink.bak` backup is made.
+pub fn write_echolink_to_toml(config_path: &str, ov: &EcholinkRuntimeOverride) -> std::io::Result<()> {
+    let original = std::fs::read_to_string(config_path)?;
+    let section = format!(
+        "[echolink]\n\
+         enabled = {}\n\
+         callsign = \"{}\"\n\
+         password = \"{}\"\n\
+         location = \"{}\"\n\
+         status_text = \"{}\"\n\
+         directory_servers = [{}]\n\
+         directory_port = {}\n\
+         bind_addr = \"{}\"\n\
+         audio_port = {}\n\
+         control_port = {}\n\n\
+         inbound_enabled = {}\n\
+         outbound_enabled = {}\n\
+         outbound_prefix = \"{}\"\n\
+         strip_outbound_prefix = {}\n\
+         service_numbers = [{}]\n\n\
+         default_tetra_source_issi = {}\n\
+         default_tetra_dest_issi = {}\n\
+         default_tetra_dest_is_group = {}\n\
+         routes = {{{}}}\n\
+         allowed_callsigns = [{}]\n\
+         allowed_node_ids = [{}]\n\
+         auto_connect = \"{}\"\n\
+         reconnect_interval_secs = {}\n\
+         max_session_secs = {}\n\
+         telegram_session_alerts = {}\n\
+         telegram_session_prefix = \"{}\"",
+        ov.enabled,
+        toml_escape(&ov.callsign),
+        toml_escape(&ov.password),
+        toml_escape(&ov.location),
+        toml_escape(&ov.status_text),
+        string_array_toml(&ov.directory_servers),
+        ov.directory_port,
+        toml_escape(&ov.bind_addr),
+        ov.audio_port,
+        ov.control_port,
+        ov.inbound_enabled,
+        ov.outbound_enabled,
+        toml_escape(&ov.outbound_prefix),
+        ov.strip_outbound_prefix,
+        string_array_toml(&ov.service_numbers),
+        ov.default_tetra_source_issi,
+        ov.default_tetra_dest_issi,
+        ov.default_tetra_dest_is_group,
+        routes_toml(&ov.routes),
+        string_array_toml(&ov.allowed_callsigns),
+        u32_array_toml(&ov.allowed_node_ids),
+        toml_escape(&ov.auto_connect),
+        ov.reconnect_interval_secs.max(1),
+        ov.max_session_secs.max(1),
+        ov.telegram_session_alerts,
+        toml_escape(&ov.telegram_session_prefix),
+    );
+
+    let lines: Vec<&str> = original.lines().collect();
+    let mut out: Vec<String> = Vec::with_capacity(lines.len() + 24);
+    let mut i = 0;
+    let mut replaced = false;
+
+    while i < lines.len() {
+        let trimmed = lines[i].trim_start();
+        if trimmed.starts_with("[echolink]") {
+            out.push(section.clone());
+            replaced = true;
+            i += 1;
+            while i < lines.len() {
+                let t = lines[i].trim_start();
+                if t.starts_with('[') && t.contains(']') {
+                    break;
+                }
+                i += 1;
+            }
+            continue;
+        }
+        out.push(lines[i].to_string());
+        i += 1;
+    }
+
+    if !replaced {
+        if !out.is_empty() && !out.last().map(|l| l.is_empty()).unwrap_or(true) {
+            out.push(String::new());
+        }
+        out.push(section);
+    }
+
+    let mut new_content = out.join("\n");
+    if original.ends_with('\n') {
+        new_content.push('\n');
+    }
+
+    let backup = format!("{config_path}.echolink.bak");
+    let _ = std::fs::copy(config_path, &backup);
+    std::fs::write(config_path, new_content)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::BTreeMap;
+
+    fn settings() -> EcholinkRuntimeOverride {
+        EcholinkRuntimeOverride {
+            enabled: true,
+            callsign: "DJ2TH-L".to_string(),
+            password: "secret".to_string(),
+            location: "FlowStation".to_string(),
+            status_text: "Ready".to_string(),
+            directory_servers: vec!["servers.echolink.org".to_string()],
+            directory_port: 5200,
+            bind_addr: "0.0.0.0".to_string(),
+            audio_port: 5198,
+            control_port: 5199,
+            inbound_enabled: true,
+            outbound_enabled: true,
+            outbound_prefix: "92".to_string(),
+            strip_outbound_prefix: true,
+            service_numbers: vec!["700".to_string()],
+            default_tetra_source_issi: 9999,
+            default_tetra_dest_issi: 26225,
+            default_tetra_dest_is_group: true,
+            routes: BTreeMap::from([("700".to_string(), "ECHOTEST".to_string())]),
+            allowed_callsigns: vec!["ECHOTEST".to_string()],
+            allowed_node_ids: vec![9999],
+            auto_connect: String::new(),
+            reconnect_interval_secs: 30,
+            max_session_secs: 3600,
+            telegram_session_alerts: true,
+            telegram_session_prefix: "EchoLink".to_string(),
+        }
+    }
+
+    #[test]
+    fn write_toml_replaces_existing_section_without_touching_neighbors() {
+        let path = std::env::temp_dir().join(format!("flowstation-echolink-{}.toml", uuid::Uuid::new_v4()));
+        std::fs::write(
+            &path,
+            "[cell]\nmcc = 262\n\n[echolink]\nenabled = false\n\n[health]\nenabled = true\n",
+        )
+        .unwrap();
+
+        write_echolink_to_toml(path.to_str().unwrap(), &settings()).unwrap();
+        let written = std::fs::read_to_string(&path).unwrap();
+
+        assert_eq!(written.matches("[echolink]").count(), 1);
+        assert!(written.contains("callsign = \"DJ2TH-L\""));
+        assert!(written.contains("routes = {\"700\" = \"ECHOTEST\"}"));
+        assert!(written.contains("[health]\nenabled = true"));
+
+        let _ = std::fs::remove_file(format!("{}.echolink.bak", path.display()));
+        let _ = std::fs::remove_file(path);
+    }
+}

--- a/crates/tetra-entities/src/net_dashboard/html.rs
+++ b/crates/tetra-entities/src/net_dashboard/html.rs
@@ -2267,6 +2267,10 @@ tbody tr:hover td{background:color-mix(in srgb,var(--bg3) 70%, transparent);}
       <span class="nav-icon" data-icon="dapnet"></span>
       <span class="nav-label" data-i18n="dapnet">DAPNET</span>
     </div>
+    <div class="nav-item" onclick="showPage('echolink',this)" id="nav-echolink">
+      <span class="nav-icon" data-icon="dapnet"></span>
+      <span class="nav-label" data-i18n="echolink">EchoLink</span>
+    </div>
     <div class="nav-item" onclick="showPage('geoalarm',this)" id="nav-geoalarm">
       <span class="nav-icon" data-icon="geoalarm"></span>
       <span class="nav-label" data-i18n="geoalarm">GeoAlarm</span>
@@ -3194,6 +3198,163 @@ tbody tr:hover td{background:color-mix(in srgb,var(--bg3) 70%, transparent);}
             <textarea id="dap-out-text" class="form-input" rows="3" maxlength="80" placeholder="Message text"></textarea>
           </div>
           <div class="config-msg" id="dap-send-msg"></div>
+        </div>
+      </div>
+    </div>
+
+    <!-- ── ECHOLINK ── -->
+    <div class="page" id="page-echolink">
+      <div class="section-label" data-i18n="integrations">Integrations</div>
+      <div class="hero">
+        <span class="hero-dot is-idle" id="el-hero-dot"></span>
+        <div class="hero-main">
+          <div class="hero-title" data-i18n="echolink_title">EchoLink</div>
+          <div class="hero-sub" id="el-bind">—</div>
+        </div>
+        <div class="hero-metrics">
+          <span class="pill pill-idle" id="el-directory">—</span>
+        </div>
+      </div>
+
+      <div class="card">
+        <div class="card-head">
+          <div class="card-title" data-i18n="echolink_title">EchoLink</div>
+          <div class="card-actions">
+            <button class="btn btn-sm" onclick="loadEcholink()"><span class="btn-icon" data-icon="restart"></span><span data-i18n="refresh">Refresh</span></button>
+            <button class="btn btn-primary" onclick="saveEcholink()"><span class="btn-icon" data-icon="save"></span><span data-i18n="save">Save</span></button>
+          </div>
+        </div>
+        <div class="card-body">
+          <div class="stat-grid" style="margin-bottom:14px">
+            <div class="stat-card">
+              <div class="stat-label">QSO</div>
+              <div class="stat-value" id="el-qso">—</div>
+              <div class="stat-sub" id="el-target">—</div>
+            </div>
+            <div class="stat-card blue">
+              <div class="stat-label">TETRA route</div>
+              <div class="stat-value blue" id="el-route">—</div>
+              <div class="stat-sub" id="el-status-callsign">—</div>
+            </div>
+          </div>
+          <div class="info-grid" style="margin-bottom:14px">
+            <div class="info-row"><div class="info-key">Last event</div><div class="info-val" id="el-last-rx">—</div></div>
+            <div class="info-row"><div class="info-key">Last TX</div><div class="info-val" id="el-last-tx">—</div></div>
+            <div class="info-row"><div class="info-key">Last error</div><div class="info-val" id="el-last-error">—</div></div>
+          </div>
+
+          <label class="sw-row">
+            <span class="sw-text">Enable EchoLink integration</span>
+            <span class="sw"><input type="checkbox" id="el-enabled"><i></i></span>
+          </label>
+          <div class="h-form" style="margin-top:14px">
+            <label class="h-flabel">Callsign</label>
+            <input type="text" id="el-callsign" class="form-input" autocomplete="off" spellcheck="false" style="text-transform:uppercase" placeholder="DJ2TH-L">
+            <label class="h-flabel">Password</label>
+            <input type="password" id="el-password" class="form-input" autocomplete="new-password" spellcheck="false" oninput="echolinkPasswordDirty=true">
+            <label class="h-flabel">Location</label>
+            <input type="text" id="el-location" class="form-input" placeholder="FlowStation">
+            <label class="h-flabel">Status text</label>
+            <input type="text" id="el-status-text" class="form-input" placeholder="FlowStation EchoLink bridge">
+            <label class="h-flabel top">Directory servers</label>
+            <textarea id="el-directory-servers" class="form-input" rows="2" placeholder="servers.echolink.org&#10;backup.echolink.org"></textarea>
+            <label class="h-flabel">Directory port</label>
+            <input type="number" id="el-directory-port" class="form-input" min="1" max="65535" placeholder="5200">
+            <label class="h-flabel">Bind address</label>
+            <input type="text" id="el-bind-addr" class="form-input" placeholder="0.0.0.0">
+            <label class="h-flabel">Audio / control ports</label>
+            <div style="display:grid;grid-template-columns:1fr 1fr;gap:8px">
+              <input type="number" id="el-audio-port" class="form-input" min="1" max="65535" placeholder="5198">
+              <input type="number" id="el-control-port" class="form-input" min="1" max="65535" placeholder="5199">
+            </div>
+          </div>
+          <div class="config-msg" id="el-msg"></div>
+        </div>
+      </div>
+
+      <div class="card">
+        <div class="card-head">
+          <div class="card-title">EchoLink Routing</div>
+          <div class="card-actions">
+            <button class="btn btn-primary" onclick="saveEcholink()"><span class="btn-icon" data-icon="save"></span><span data-i18n="save">Save</span></button>
+          </div>
+        </div>
+        <div class="card-body">
+          <div class="h-form wide">
+            <div>
+              <label class="sw-row"><span class="sw-text">Inbound EchoLink → TETRA</span><span class="sw"><input type="checkbox" id="el-inbound"><i></i></span></label>
+              <div class="h-form-pair" style="margin-top:10px">
+                <label class="h-flabel">Source ISSI</label>
+                <input type="number" id="el-source-issi" class="form-input" min="1" max="16777215" placeholder="9999">
+                <label class="h-flabel">Default destination</label>
+                <input type="number" id="el-dest-issi" class="form-input" min="0" max="16777215" placeholder="GSSI">
+                <label class="h-flabel">Group destination</label>
+                <label class="h-finline"><span class="sw"><input type="checkbox" id="el-dest-group"><i></i></span><span class="h-flabel-sm">simplex/P2MP inbound</span></label>
+              </div>
+            </div>
+            <div>
+              <label class="sw-row"><span class="sw-text">Outbound TETRA → EchoLink</span><span class="sw"><input type="checkbox" id="el-outbound"><i></i></span></label>
+              <div class="h-form-pair" style="margin-top:10px">
+                <label class="h-flabel">Outbound prefix</label>
+                <input type="text" id="el-out-prefix" class="form-input" placeholder="92">
+                <label class="h-flabel">Strip prefix</label>
+                <label class="h-finline"><span class="sw"><input type="checkbox" id="el-strip-prefix"><i></i></span><span class="h-flabel-sm">before lookup</span></label>
+                <label class="h-flabel top">Service numbers</label>
+                <textarea id="el-service-numbers" class="form-input" rows="2" placeholder="700"></textarea>
+                <label class="h-flabel top">Dial → EchoLink target</label>
+                <textarea id="el-routes" class="form-input" rows="3" placeholder="700=ECHOTEST&#10;701=DB0ABC-L"></textarea>
+              </div>
+            </div>
+            <div>
+              <div class="h-form-pair">
+                <label class="h-flabel top">Allowed callsigns</label>
+                <textarea id="el-allowed-calls" class="form-input" rows="3" placeholder="ECHOTEST&#10;DB0ABC-L"></textarea>
+                <label class="h-flabel top">Allowed node IDs</label>
+                <textarea id="el-allowed-nodes" class="form-input" rows="3" placeholder="9999"></textarea>
+                <label class="h-flabel">Auto connect</label>
+                <input type="text" id="el-auto-connect" class="form-input" placeholder="ECHOTEST">
+                <label class="h-flabel">Reconnect / max session</label>
+                <div style="display:grid;grid-template-columns:1fr 1fr;gap:8px">
+                  <input type="number" id="el-reconnect" class="form-input" min="1" placeholder="30">
+                  <input type="number" id="el-max-session" class="form-input" min="1" placeholder="3600">
+                </div>
+                <label class="h-flabel">Telegram session alerts</label>
+                <label class="h-finline"><span class="sw"><input type="checkbox" id="el-telegram-session-alerts"><i></i></span><span class="h-flabel-sm">connect and disconnect</span></label>
+                <label class="h-flabel">Telegram prefix</label>
+                <input type="text" id="el-telegram-session-prefix" class="form-input" placeholder="EchoLink">
+              </div>
+            </div>
+          </div>
+          <div style="display:flex;gap:10px;align-items:center;flex-wrap:wrap;margin-top:14px">
+            <input type="text" id="el-connect-target" class="form-input" style="max-width:260px" placeholder="ECHOTEST or node ID">
+            <button class="btn btn-primary" onclick="echolinkConnect()">Connect</button>
+            <button class="btn btn-danger" onclick="echolinkDisconnect()">Disconnect</button>
+          </div>
+          <div class="help-text" style="margin-top:10px">EchoLink uses UDP 5198/5199 with GSM-FR audio. TETRA service numbers and prefixes route to EchoLink as simplex calls; inbound QSOs route to the configured GSSI as simplex/P2MP group calls.</div>
+        </div>
+      </div>
+
+      <div class="card">
+        <div class="card-head">
+          <div class="card-title">EchoLink Directory</div>
+          <div class="card-actions">
+            <input type="text" id="el-directory-filter" class="form-input" style="width:220px" placeholder="Search callsign, node ID or IP" oninput="echolinkDirectoryPageIndex=0;renderEcholinkDirectory()">
+            <button class="btn btn-sm" onclick="loadEcholinkDirectory()"><span class="btn-icon" data-icon="restart"></span><span data-i18n="refresh">Refresh</span></button>
+          </div>
+        </div>
+        <div class="card-body">
+          <div class="help-text" id="el-directory-summary">Directory not loaded yet.</div>
+          <div class="table-wrap" style="margin-top:10px">
+            <table>
+              <thead><tr><th>Callsign</th><th>Node ID</th><th>IP</th><th>Action</th></tr></thead>
+              <tbody id="el-directory-tbody"></tbody>
+            </table>
+          </div>
+          <div class="log-controls">
+            <button class="btn btn-sm" onclick="echolinkDirectoryPrevPage()">‹ Prev</button>
+            <span class="sds-empty" id="el-directory-page">Page 0 / 0 · 0</span>
+            <button class="btn btn-sm" onclick="echolinkDirectoryNextPage()">Next ›</button>
+          </div>
         </div>
       </div>
     </div>
@@ -4863,6 +5024,7 @@ function showPage(name,el){
   if(name==='health'){loadHealthIntegrations();}
   if(name==='asterisk'){loadAsteriskStatus();loadSnomNotify();}
   if(name==='dapnet'){loadDapnet();loadDapnetLog();}
+  if(name==='echolink'){loadEcholink();}
   if(name==='geoalarm'){loadGeoalarm();}
   if(name==='meshcom'){loadMeshcom();}
   if(name==='maps'){refreshMapsData();}
@@ -5198,7 +5360,7 @@ async function wifiCall(url, body){
 function escAttr(s){ return String(s).replace(/&/g,'&amp;').replace(/'/g,"&#39;").replace(/"/g,'&quot;'); }
 
 // ── State + WS ────────────────────────────────────────────────────────────
-let ws=null,state={ms:{},calls:{},emergencies:{},lastHeard:[],sdsLog:[],dapnetLog:[],geoalarmEvents:[],geoalarmConfig:null,meshcomNodes:[],meshcomMessages:[],brewOnline:false,brewVer:0},sdsDest=0;
+let ws=null,state={ms:{},calls:{},emergencies:{},lastHeard:[],sdsLog:[],dapnetLog:[],echolinkDirectory:[],echolinkDirectoryStatus:'unknown',geoalarmEvents:[],geoalarmConfig:null,meshcomNodes:[],meshcomMessages:[],brewOnline:false,brewVer:0},sdsDest=0;
 
 // ── RadioID callsigns (indicativ) ──────────────────────────────────────────────
 // issi -> {cs:"CALLSIGN", fl:"🇷🇴"} (found; fl is the country flag emoji from the prefix, or "")
@@ -6054,7 +6216,7 @@ function _p2(n){return String(n).padStart(2,'0');}
 // live rows arriving over the WS; rows fetched from /api/sds-log already carry a server stamp.
 function nowStamp(){const d=new Date();return `${d.getFullYear()}-${_p2(d.getMonth()+1)}-${_p2(d.getDate())} ${_p2(d.getHours())}:${_p2(d.getMinutes())}:${_p2(d.getSeconds())}`;}
 const LOG_PAGE_SIZE=50;
-let sdsLogPageIndex=0,dapnetLogPageIndex=0,geoalarmPageIndex=0,meshNodePageIndex=0,meshMsgPageIndex=0;
+let sdsLogPageIndex=0,dapnetLogPageIndex=0,echolinkDirectoryPageIndex=0,geoalarmPageIndex=0,meshNodePageIndex=0,meshMsgPageIndex=0;
 function setLogPager(id,page,total){
   const el=document.getElementById(id);if(!el)return;
   if(!total){el.textContent='Page 0 / 0 · 0';return;}
@@ -6357,6 +6519,200 @@ async function sendDapnetMessage(){
     if(d.ok){setDapSendMsg('✓ Sent',true);document.getElementById('dap-out-text').value='';loadDapnetLog();}
     else setDapSendMsg('✗ '+(d.error||'Send failed'),false);
   }catch{setDapSendMsg(t('conn_error'),false);}
+}
+
+let echolinkPasswordDirty=false;
+function echolinkRoutesText(routes){
+  if(!routes)return'';
+  if(Array.isArray(routes))return routes.join('\n');
+  return Object.keys(routes).sort().map(k=>`${k}=${routes[k]}`).join('\n');
+}
+function echolinkRoutesBody(id){
+  const out={};
+  for(const raw of (document.getElementById(id)?.value||'').split(/\r?\n/)){
+    const line=raw.trim();
+    if(!line)continue;
+    const idx=line.indexOf('=');
+    if(idx<1){setElMsg('Route must use dial=target format',false);return null;}
+    const k=line.slice(0,idx).trim(),v=line.slice(idx+1).trim();
+    if(!k||!v){setElMsg('Route must use dial=target format',false);return null;}
+    out[k]=v.toUpperCase();
+  }
+  return out;
+}
+function echolinkListText(values){return (values||[]).join('\n');}
+function echolinkListBody(id){
+  return (document.getElementById(id)?.value||'')
+    .split(/[\s,]+/)
+    .map(v=>v.trim())
+    .filter(Boolean);
+}
+function echolinkU32ListBody(id){
+  const out=[];
+  for(const raw of echolinkListBody(id)){
+    const n=Number(raw);
+    if(!Number.isInteger(n)||n<1){setElMsg('Node IDs must be positive numbers',false);return null;}
+    out.push(n);
+  }
+  return out;
+}
+function echolinkDirectoryFiltered(){
+  const q=(document.getElementById('el-directory-filter')?.value||'').trim().toUpperCase();
+  const rows=(state.echolinkDirectory||[]).slice().sort((a,b)=>String(a.callsign||'').localeCompare(String(b.callsign||'')));
+  if(!q)return rows;
+  return rows.filter(s=>
+    String(s.callsign||'').toUpperCase().includes(q) ||
+    String(s.id||'').includes(q) ||
+    String(s.ip||'').includes(q)
+  );
+}
+function echolinkDirectoryRow(s){
+  const call=String(s.callsign||'').toUpperCase();
+  return `<tr>
+    <td><span class="badge badge-blue" style="font-size:10px">${escHtml(call||'—')}</span></td>
+    <td class="sds-time">${escHtml(s.id??'')}</td>
+    <td class="sds-time">${escHtml(s.ip||'')}</td>
+    <td><button class="btn btn-sm" onclick="echolinkUseDirectoryTarget('${escAttr(call)}')">Use</button></td>
+  </tr>`;
+}
+function renderEcholinkDirectory(){
+  const tb=document.getElementById('el-directory-tbody');if(!tb)return;
+  const rows=echolinkDirectoryFiltered();
+  echolinkDirectoryPageIndex=clampLogPage(echolinkDirectoryPageIndex,rows.length);
+  setLogPager('el-directory-page',echolinkDirectoryPageIndex,rows.length);
+  const summary=document.getElementById('el-directory-summary');
+  if(summary){
+    const total=(state.echolinkDirectory||[]).length;
+    const status=state.echolinkDirectoryStatus||'Directory';
+    summary.textContent=total?`${status} · ${rows.length} shown · ${total} total`:'Directory not loaded yet.';
+  }
+  if(!rows.length){tb.innerHTML=`<tr><td colspan="4" class="sds-empty" style="text-align:center;padding:24px">No directory entries</td></tr>`;return;}
+  const start=echolinkDirectoryPageIndex*LOG_PAGE_SIZE;
+  tb.innerHTML=rows.slice(start,start+LOG_PAGE_SIZE).map(echolinkDirectoryRow).join('');
+}
+function echolinkDirectoryPrevPage(){echolinkDirectoryPageIndex--;renderEcholinkDirectory();}
+function echolinkDirectoryNextPage(){echolinkDirectoryPageIndex++;renderEcholinkDirectory();}
+function echolinkUseDirectoryTarget(target){
+  dapSet('el-connect-target',target);
+  setElMsg(`Target selected: ${target}`,true);
+}
+async function loadEcholinkDirectory(){
+  try{
+    const r=await fetch('/api/echolink/directory');
+    if(!r.ok)return;
+    const d=await r.json();
+    state.echolinkDirectory=d.stations||[];
+    state.echolinkDirectoryStatus=d.directory_status||'unknown';
+    echolinkDirectoryPageIndex=0;
+    renderEcholinkDirectory();
+  }catch{}
+}
+async function loadEcholink(){
+  try{
+    const r=await fetch('/api/echolink');
+    if(!r.ok){setElMsg(t('conn_error'),false);return;}
+    const d=await r.json(),rt=d.runtime||{};
+    dapCheck('el-enabled',d.enabled);
+    dapSet('el-callsign',d.callsign||'');
+    dapSet('el-password',d.password_set?(d.password_masked||''):'');
+    echolinkPasswordDirty=false;
+    dapSet('el-location',d.location||'FlowStation');
+    dapSet('el-status-text',d.status_text||'FlowStation EchoLink bridge');
+    dapSet('el-directory-servers',echolinkListText(d.directory_servers));
+    dapSet('el-directory-port',d.directory_port||5200);
+    dapSet('el-bind-addr',d.bind_addr||'0.0.0.0');
+    dapSet('el-audio-port',d.audio_port||5198);
+    dapSet('el-control-port',d.control_port||5199);
+    dapCheck('el-inbound',d.inbound_enabled);
+    dapCheck('el-outbound',d.outbound_enabled);
+    dapSet('el-out-prefix',d.outbound_prefix||'92');
+    dapCheck('el-strip-prefix',d.strip_outbound_prefix);
+    dapSet('el-service-numbers',echolinkListText(d.service_numbers));
+    dapSet('el-source-issi',d.default_tetra_source_issi||9999);
+    dapSet('el-dest-issi',d.default_tetra_dest_issi||0);
+    dapCheck('el-dest-group',d.default_tetra_dest_is_group);
+    dapSet('el-routes',echolinkRoutesText(d.routes));
+    dapSet('el-allowed-calls',echolinkListText(d.allowed_callsigns));
+    dapSet('el-allowed-nodes',echolinkListText(d.allowed_node_ids));
+    dapSet('el-auto-connect',d.auto_connect||'');
+    dapSet('el-reconnect',d.reconnect_interval_secs||30);
+    dapSet('el-max-session',d.max_session_secs||3600);
+    dapCheck('el-telegram-session-alerts',d.telegram_session_alerts);
+    dapSet('el-telegram-session-prefix',d.telegram_session_prefix||'EchoLink');
+    dapSet('el-directory',rt.directory_status||'—');
+    dapSet('el-qso',rt.qso_status||'—');
+    dapSet('el-bind',rt.bind||'—');
+    dapSet('el-target',rt.connected_target||'idle');
+    dapSet('el-status-callsign',rt.callsign||d.callsign||'—');
+    dapSet('el-route',rt.routed_tetra_dest||'not routed');
+    dapSet('el-last-rx',rt.last_session_event||'—');
+    dapSet('el-last-tx',rt.last_tx||'—');
+    dapSet('el-last-error',rt.last_error||'—');
+    const active=!!d.enabled&&!rt.last_error;
+    const dot=document.getElementById('el-hero-dot');
+    const pill=document.getElementById('el-directory');
+    if(dot)dot.className='hero-dot '+(active?'is-ok':(d.enabled?'is-warn':'is-idle'));
+    if(pill)pill.className='pill '+(active?'pill-ok':(d.enabled?'pill-warn':'pill-idle'));
+    setElMsg('',true);
+    loadEcholinkDirectory();
+  }catch{setElMsg(t('conn_error'),false);}
+}
+async function saveEcholink(){
+  const routes=echolinkRoutesBody('el-routes');
+  if(routes===null)return;
+  const allowedNodes=echolinkU32ListBody('el-allowed-nodes');
+  if(allowedNodes===null)return;
+  const body={
+    enabled:document.getElementById('el-enabled').checked,
+    callsign:dapVal('el-callsign').toUpperCase(),
+    location:dapVal('el-location')||'FlowStation',
+    status_text:dapVal('el-status-text')||'FlowStation EchoLink bridge',
+    directory_servers:echolinkListBody('el-directory-servers'),
+    directory_port:dapNum('el-directory-port',5200,1,65535),
+    bind_addr:dapVal('el-bind-addr')||'0.0.0.0',
+    audio_port:dapNum('el-audio-port',5198,1,65535),
+    control_port:dapNum('el-control-port',5199,1,65535),
+    inbound_enabled:document.getElementById('el-inbound').checked,
+    outbound_enabled:document.getElementById('el-outbound').checked,
+    outbound_prefix:dapVal('el-out-prefix')||'92',
+    strip_outbound_prefix:document.getElementById('el-strip-prefix').checked,
+    service_numbers:echolinkListBody('el-service-numbers'),
+    default_tetra_source_issi:dapNum('el-source-issi',9999,1,16777215),
+    default_tetra_dest_issi:dapNum('el-dest-issi',0,0,16777215),
+    default_tetra_dest_is_group:document.getElementById('el-dest-group').checked,
+    routes,
+    allowed_callsigns:echolinkListBody('el-allowed-calls').map(v=>v.toUpperCase()),
+    allowed_node_ids:allowedNodes,
+    auto_connect:dapVal('el-auto-connect').toUpperCase(),
+    reconnect_interval_secs:dapNum('el-reconnect',30,1,86400),
+    max_session_secs:dapNum('el-max-session',3600,1,86400),
+    telegram_session_alerts:document.getElementById('el-telegram-session-alerts').checked,
+    telegram_session_prefix:dapVal('el-telegram-session-prefix')||'EchoLink'
+  };
+  if(echolinkPasswordDirty)body.password=dapVal('el-password');
+  try{
+    const r=await fetch('/api/echolink',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify(body)});
+    if(r.ok){setElMsg('✓ Saved',true);loadEcholink();}
+    else setElMsg(t('save_fail')+': '+await r.text(),false);
+  }catch{setElMsg(t('conn_error'),false);}
+}
+async function echolinkConnect(){
+  const target=dapVal('el-connect-target').toUpperCase();
+  if(!target){setElMsg('Set EchoLink target first',false);return;}
+  try{
+    const r=await fetch('/api/echolink/connect',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({target})});
+    const d=await r.json();
+    if(d.ok){setElMsg('✓ Connect requested',true);setTimeout(loadEcholink,500);}
+    else setElMsg('✗ '+(d.error||'Connect failed'),false);
+  }catch{setElMsg(t('conn_error'),false);}
+}
+async function echolinkDisconnect(){
+  try{
+    const r=await fetch('/api/echolink/disconnect',{method:'POST'});
+    const d=await r.json();
+    if(d.ok){setElMsg('✓ Disconnect requested',true);setTimeout(loadEcholink,500);}
+    else setElMsg('✗ '+(d.error||'Disconnect failed'),false);
+  }catch{setElMsg(t('conn_error'),false);}
 }
 
 // ── Shared map-link + paths helpers (also used by GeoAlarm) ────────────────
@@ -6765,6 +7121,7 @@ async function sendMeshcomMessage(){
 }
 function setMeshMsg(txt,ok){const el=document.getElementById('mesh-msg');if(!el)return;el.textContent=txt;el.style.color=ok?'var(--accent)':'var(--danger)';if(txt)setTimeout(()=>{if(el.textContent===txt)el.textContent='';},5000);}
 function setMeshSendMsg(txt,ok){const el=document.getElementById('mesh-send-msg');if(!el)return;el.textContent=txt;el.style.color=ok?'var(--accent)':'var(--danger)';if(txt)setTimeout(()=>{if(el.textContent===txt)el.textContent='';},5000);}
+function setElMsg(txt,ok){const el=document.getElementById('el-msg');if(!el)return;el.textContent=txt;el.style.color=ok?'var(--accent)':'var(--danger)';if(txt)setTimeout(()=>{if(el.textContent===txt)el.textContent='';},5000);}
 function setDapMsg(txt,ok){const el=document.getElementById('dap-msg');if(!el)return;el.textContent=txt;el.style.color=ok?'var(--accent)':'var(--danger)';if(txt)setTimeout(()=>{if(el.textContent===txt)el.textContent='';},5000);}
 function setDapSendMsg(txt,ok){const el=document.getElementById('dap-send-msg');if(!el)return;el.textContent=txt;el.style.color=ok?'var(--accent)':'var(--danger)';if(txt)setTimeout(()=>{if(el.textContent===txt)el.textContent='';},5000);}
 
@@ -8050,6 +8407,7 @@ function healthDomainAccent(d){ return (HEALTH_SVG[d]||{}).accent || ''; }
 const INTEGRATION_SVG = {
   asterisk:'<path d="M22 16.92v3a2 2 0 0 1-2.18 2 19.79 19.79 0 0 1-8.63-3.07 19.5 19.5 0 0 1-6-6 19.79 19.79 0 0 1-3.07-8.67A2 2 0 0 1 4.11 2h3a2 2 0 0 1 2 1.72c.13.96.36 1.9.7 2.81a2 2 0 0 1-.45 2.11L8.09 9.91a16 16 0 0 0 6 6l1.27-1.27a2 2 0 0 1 2.11-.45c.9.34 1.85.57 2.81.7A2 2 0 0 1 22 16.92z"/>',
   dapnet:'<rect x="5" y="2" width="14" height="20" rx="2"/><path d="M9 6h6M9 10h6M9 14h3"/>',
+  echolink:'<path d="M10 13a5 5 0 0 0 7.07 0l2.12-2.12a5 5 0 0 0-7.07-7.07L11 4.93"/><path d="M14 11a5 5 0 0 0-7.07 0L4.81 13.12a5 5 0 0 0 7.07 7.07L13 19.07"/>',
   geoalarm:'<path d="M12 21s-7-5.5-7-11a7 7 0 0 1 14 0c0 5.5-7 11-7 11z"/><circle cx="12" cy="10" r="2.5"/>',
 };
 function integrationSvg(key){
@@ -8107,8 +8465,8 @@ function renderHealthTab(h){
   });
 }
 
-let healthIntegrationState={asterisk:null,dapnet:null,geoalarm:null,meshcom:null,lastLoad:0};
-// title, iconKey (asterisk|dapnet|geoalarm), accent (blue|purple|''), level, detail, extra.
+let healthIntegrationState={asterisk:null,dapnet:null,echolink:null,geoalarm:null,meshcom:null,lastLoad:0};
+// title, iconKey (asterisk|dapnet|echolink|geoalarm), accent (blue|purple|''), level, detail, extra.
 function integrationHealthCard(title,iconKey,accent,level,detail,extra){
   const lvlCls = healthLevelClass(level);
   const icoCls = level==='ok' ? accent : lvlCls;
@@ -8165,6 +8523,22 @@ function classifyDapnetHealth(data){
   const extra=notes.length?notes.join(' · '):('Host '+(rt.endpoint||((data.rwth_core_host||'—')+':'+(data.rwth_core_port||'—')))+' · seen '+(rt.seen_messages??0)+(rt.last_rx?' · last RX '+rt.last_rx:''));
   return {level,detail,extra};
 }
+function classifyEcholinkHealth(data){
+  if(!data||!data.enabled)return {level:'ok',detail:'disabled',extra:'EchoLink bridge is not active.'};
+  const rt=data.runtime||{};
+  const status=String(rt.directory_status||'').toLowerCase();
+  const err=rt.last_error||'';
+  let level='ok';
+  const notes=[];
+  if(!data.callsign)notes.push('callsign missing');
+  if(!data.password_set)notes.push('password missing');
+  if(err)notes.push('Last error: '+err);
+  if(status&&/(error|failed)/.test(status))notes.push('Directory '+rt.directory_status);
+  if(notes.length)level='degraded';
+  const detail=(rt.directory_status||'configured')+' · '+(rt.qso_status||'idle');
+  const extra=notes.length?notes.join(' · '):('Bind '+(rt.bind||'—')+' · route '+(rt.routed_tetra_dest||'not routed'));
+  return {level,detail,extra};
+}
 function classifyGeoalarmHealth(data){
   if(!data||!data.enabled)return {level:'ok',detail:'disabled',extra:'GeoAlarm is not active.'};
   const rt=data.runtime||{};
@@ -8212,6 +8586,12 @@ function renderHealthIntegrations(){
   } else {
     grid.appendChild(integrationHealthCard('DAPNET','dapnet','blue','degraded','status unavailable','Open the DAPNET page or wait for the next refresh.'));
   }
+  if(healthIntegrationState.echolink){
+    const e=classifyEcholinkHealth(healthIntegrationState.echolink);
+    grid.appendChild(integrationHealthCard('EchoLink','echolink','blue',e.level,e.detail,e.extra));
+  } else {
+    grid.appendChild(integrationHealthCard('EchoLink','echolink','blue','degraded','status unavailable','Open the EchoLink page or wait for the next refresh.'));
+  }
   if(healthIntegrationState.geoalarm){
     const g=classifyGeoalarmHealth(healthIntegrationState.geoalarm);
     grid.appendChild(integrationHealthCard('GeoAlarm','geoalarm','purple',g.level,g.detail,g.extra));
@@ -8228,14 +8608,16 @@ function renderHealthIntegrations(){
 async function loadHealthIntegrations(){
   healthIntegrationState.lastLoad=Date.now();
   try{
-    const [ast,dap,geo,mesh]=await Promise.all([
+    const [ast,dap,el,geo,mesh]=await Promise.all([
       fetch('/api/asterisk/status').then(r=>r.ok?r.json():null).catch(()=>null),
       fetch('/api/dapnet').then(r=>r.ok?r.json():null).catch(()=>null),
+      fetch('/api/echolink').then(r=>r.ok?r.json():null).catch(()=>null),
       fetch('/api/geoalarm').then(r=>r.ok?r.json():null).catch(()=>null),
       fetch('/api/meshcom').then(r=>r.ok?r.json():null).catch(()=>null)
     ]);
     healthIntegrationState.asterisk=ast;
     healthIntegrationState.dapnet=dap;
+    healthIntegrationState.echolink=el;
     healthIntegrationState.geoalarm=geo;
     healthIntegrationState.meshcom=mesh;
   }catch{}

--- a/crates/tetra-entities/src/net_dashboard/mod.rs
+++ b/crates/tetra-entities/src/net_dashboard/mod.rs
@@ -1,6 +1,7 @@
 pub mod callsign;
 pub mod dapnet;
 pub mod dual_carrier;
+pub mod echolink;
 pub mod geoalarm;
 pub mod html;
 pub mod meshcom;

--- a/crates/tetra-entities/src/net_dashboard/server.rs
+++ b/crates/tetra-entities/src/net_dashboard/server.rs
@@ -12,6 +12,7 @@ use tungstenite::{
 use crate::net_control::commands::ControlCommand;
 use crate::net_dashboard::html::DASHBOARD_HTML;
 use crate::net_dashboard::state::{CallEntry, DashboardState, DashboardStateInner, MsEntry};
+use crate::net_echolink::{EcholinkCmdSender, EcholinkCommand};
 use crate::net_telemetry::TelemetryEvent;
 use crate::tpg2200::build_tpg2200_callout_payload;
 
@@ -621,6 +622,7 @@ pub struct DashboardServer {
     /// Shared stack config — used to read live_sds_queue from StackState.
     shared_config: Option<tetra_config::bluestation::SharedConfig>,
     cmd_tx: Option<CmdSender>,
+    echolink_cmd_tx: Option<EcholinkCmdSender>,
     update_state: SharedUpdateState,
     /// Optional override for the OTA update source directory.
     /// If None, the update routine auto-detects.
@@ -652,6 +654,7 @@ impl DashboardServer {
             config_path,
             shared_config: None,
             cmd_tx: None,
+            echolink_cmd_tx: None,
             update_state: Arc::new(Mutex::new(UpdateState::new())),
             source_dir_override: None,
             auth: None,
@@ -664,6 +667,10 @@ impl DashboardServer {
 
     pub fn set_cmd_sender(&mut self, tx: CmdSender) {
         self.cmd_tx = Some(tx);
+    }
+
+    pub fn set_echolink_cmd_sender(&mut self, tx: EcholinkCmdSender) {
+        self.echolink_cmd_tx = Some(tx);
     }
 
     /// Provide the SharedConfig so the dashboard can read live SDS queue state.
@@ -701,6 +708,7 @@ impl DashboardServer {
         let clients = Arc::clone(&self.clients);
         let config_path = self.config_path.clone();
         let cmd_tx: Arc<Mutex<Option<CmdSender>>> = Arc::new(Mutex::new(self.cmd_tx.take()));
+        let echolink_cmd_tx: Arc<Mutex<Option<EcholinkCmdSender>>> = Arc::new(Mutex::new(self.echolink_cmd_tx.take()));
         let update_state = Arc::clone(&self.update_state);
         let source_dir_override = self.source_dir_override.clone();
         let auth = self.auth.clone();
@@ -742,6 +750,7 @@ impl DashboardServer {
                     let clients = Arc::clone(&clients);
                     let config_path = config_path.clone();
                     let cmd_tx = Arc::clone(&cmd_tx);
+                    let echolink_cmd_tx = Arc::clone(&echolink_cmd_tx);
                     let update_state = Arc::clone(&update_state);
                     let source_dir_override = source_dir_override.clone();
                     let auth = auth.clone();
@@ -757,6 +766,7 @@ impl DashboardServer {
                                 clients,
                                 config_path,
                                 cmd_tx,
+                                echolink_cmd_tx,
                                 update_state,
                                 source_dir_override,
                                 auth,
@@ -1424,6 +1434,7 @@ fn handle_connection(
     clients: WsClients,
     config_path: String,
     cmd_tx: Arc<Mutex<Option<CmdSender>>>,
+    echolink_cmd_tx: Arc<Mutex<Option<EcholinkCmdSender>>>,
     update_state: SharedUpdateState,
     source_dir_override: Option<String>,
     auth: Option<(String, String)>,
@@ -2005,6 +2016,23 @@ fn handle_connection(
     } else if req_line.contains("POST /api/dapnet") {
         let (inner, body_str) = read_post_body(stream);
         serve_dapnet_post(inner, &shared_config, &config_path, &body_str);
+    } else if req_line.contains("GET /api/echolink/directory") {
+        let mut s = stream;
+        drain_http_headers(&mut s);
+        serve_echolink_directory(s, &shared_config);
+    } else if req_line.contains("POST /api/echolink/connect") {
+        let (inner, body_str) = read_post_body(stream);
+        serve_echolink_connect(inner, &shared_config, &echolink_cmd_tx, &body_str);
+    } else if req_line.contains("POST /api/echolink/disconnect") {
+        let (inner, _) = read_post_body(stream);
+        serve_echolink_disconnect(inner, &echolink_cmd_tx);
+    } else if req_line.contains("GET /api/echolink") {
+        let mut s = stream;
+        drain_http_headers(&mut s);
+        serve_echolink_get(s, &shared_config);
+    } else if req_line.contains("POST /api/echolink") {
+        let (inner, body_str) = read_post_body(stream);
+        serve_echolink_post(inner, &shared_config, &config_path, &body_str);
     } else if req_line.contains("GET /api/geoalarm") {
         let mut s = stream;
         drain_http_headers(&mut s);
@@ -4611,6 +4639,307 @@ fn serve_dapnet_post(stream: TcpStream, shared_config: &Option<tetra_config::blu
         ov.forward_telegram
     );
     http_response(stream, 200, "OK");
+}
+
+/// GET /api/echolink — effective settings and live directory/QSO state.
+fn serve_echolink_get(stream: TcpStream, shared_config: &Option<tetra_config::bluestation::SharedConfig>) {
+    let (echolink, runtime) = match shared_config {
+        Some(cfg) => (cfg.effective_echolink(), cfg.state_read().echolink_status.clone()),
+        None => (
+            tetra_config::bluestation::CfgEcholink::default(),
+            tetra_config::bluestation::EcholinkRuntimeStatus::default(),
+        ),
+    };
+    let password = echolink.password.as_ref().to_string();
+    let body = serde_json::json!({
+        "enabled": echolink.enabled,
+        "callsign": echolink.callsign,
+        "password_masked": crate::net_dashboard::echolink::mask_secret(&password),
+        "password_set": !password.trim().is_empty(),
+        "location": echolink.location,
+        "status_text": echolink.status_text,
+        "directory_servers": echolink.directory_servers,
+        "directory_port": echolink.directory_port,
+        "bind_addr": echolink.bind_addr,
+        "audio_port": echolink.audio_port,
+        "control_port": echolink.control_port,
+        "inbound_enabled": echolink.inbound_enabled,
+        "outbound_enabled": echolink.outbound_enabled,
+        "outbound_prefix": echolink.outbound_prefix,
+        "strip_outbound_prefix": echolink.strip_outbound_prefix,
+        "service_numbers": echolink.service_numbers,
+        "default_tetra_source_issi": echolink.default_tetra_source_issi,
+        "default_tetra_dest_issi": echolink.default_tetra_dest_issi,
+        "default_tetra_dest_is_group": echolink.default_tetra_dest_is_group,
+        "routes": echolink.routes,
+        "allowed_callsigns": echolink.allowed_callsigns,
+        "allowed_node_ids": echolink.allowed_node_ids,
+        "auto_connect": echolink.auto_connect,
+        "reconnect_interval_secs": echolink.reconnect_interval_secs,
+        "max_session_secs": echolink.max_session_secs,
+        "telegram_session_alerts": echolink.telegram_session_alerts,
+        "telegram_session_prefix": echolink.telegram_session_prefix,
+        "runtime": {
+            "configured": runtime.configured,
+            "enabled": runtime.enabled,
+            "directory_status": runtime.directory_status,
+            "qso_status": runtime.qso_status,
+            "bind": runtime.bind,
+            "callsign": runtime.callsign,
+            "connected_target": runtime.connected_target,
+            "routed_tetra_dest": runtime.routed_tetra_dest,
+            "last_session_event": runtime.last_session_event,
+            "last_rx": runtime.last_rx,
+            "last_tx": runtime.last_tx,
+            "last_error": runtime.last_error,
+        }
+    });
+    http_json_response(stream, 200, &body.to_string());
+}
+
+fn serve_echolink_directory(stream: TcpStream, shared_config: &Option<tetra_config::bluestation::SharedConfig>) {
+    let runtime = shared_config
+        .as_ref()
+        .map(|cfg| cfg.state_read().echolink_status.clone())
+        .unwrap_or_default();
+    let stations = runtime
+        .directory_stations
+        .iter()
+        .map(|station| {
+            serde_json::json!({
+                "callsign": station.callsign,
+                "id": station.id,
+                "ip": station.ip,
+            })
+        })
+        .collect::<Vec<_>>();
+    let body = serde_json::json!({
+        "configured": runtime.configured,
+        "enabled": runtime.enabled,
+        "directory_status": runtime.directory_status,
+        "count": stations.len(),
+        "stations": stations,
+        "last_tx": runtime.last_tx,
+        "last_error": runtime.last_error,
+    });
+    http_json_response(stream, 200, &body.to_string());
+}
+
+/// POST /api/echolink — apply settings immediately and persist `[echolink]`.
+fn serve_echolink_post(
+    stream: TcpStream,
+    shared_config: &Option<tetra_config::bluestation::SharedConfig>,
+    config_path: &str,
+    body: &str,
+) {
+    use tetra_config::bluestation::{CfgEcholinkDto, EcholinkRuntimeOverride, apply_echolink_patch};
+
+    let json: serde_json::Value = match serde_json::from_str(body.trim()) {
+        Ok(value) => value,
+        Err(err) => {
+            http_response(stream, 400, &format!("Invalid JSON: {err}"));
+            return;
+        }
+    };
+    let Some(cfg) = shared_config else {
+        http_response(stream, 503, "Config not available");
+        return;
+    };
+    let cur = cfg.effective_echolink();
+    let dto = CfgEcholinkDto {
+        enabled: dapnet_as_bool(&json, "enabled", cur.enabled),
+        callsign: dapnet_as_string(&json, "callsign", &cur.callsign),
+        password: dapnet_resolve_secret(&json, "password", cur.password.as_ref()),
+        location: dapnet_as_string(&json, "location", &cur.location),
+        status_text: dapnet_as_string(&json, "status_text", &cur.status_text),
+        directory_servers: echolink_string_list(&json, "directory_servers", &cur.directory_servers),
+        directory_port: dapnet_as_u16(&json, "directory_port", cur.directory_port),
+        bind_addr: dapnet_as_string(&json, "bind_addr", &cur.bind_addr),
+        audio_port: dapnet_as_u16(&json, "audio_port", cur.audio_port),
+        control_port: dapnet_as_u16(&json, "control_port", cur.control_port),
+        inbound_enabled: dapnet_as_bool(&json, "inbound_enabled", cur.inbound_enabled),
+        outbound_enabled: dapnet_as_bool(&json, "outbound_enabled", cur.outbound_enabled),
+        outbound_prefix: dapnet_as_string(&json, "outbound_prefix", &cur.outbound_prefix),
+        strip_outbound_prefix: dapnet_as_bool(&json, "strip_outbound_prefix", cur.strip_outbound_prefix),
+        service_numbers: echolink_string_list(&json, "service_numbers", &cur.service_numbers),
+        default_tetra_source_issi: dapnet_as_u32(&json, "default_tetra_source_issi", cur.default_tetra_source_issi),
+        default_tetra_dest_issi: dapnet_as_u32(&json, "default_tetra_dest_issi", cur.default_tetra_dest_issi),
+        default_tetra_dest_is_group: dapnet_as_bool(&json, "default_tetra_dest_is_group", cur.default_tetra_dest_is_group),
+        routes: echolink_routes_from_json(&json, &cur.routes),
+        allowed_callsigns: echolink_string_list(&json, "allowed_callsigns", &cur.allowed_callsigns),
+        allowed_node_ids: echolink_u32_list(&json, "allowed_node_ids", &cur.allowed_node_ids),
+        auto_connect: dapnet_as_string(&json, "auto_connect", &cur.auto_connect),
+        reconnect_interval_secs: dapnet_as_u64(&json, "reconnect_interval_secs", cur.reconnect_interval_secs),
+        max_session_secs: dapnet_as_u64(&json, "max_session_secs", cur.max_session_secs),
+        telegram_session_alerts: dapnet_as_bool(&json, "telegram_session_alerts", cur.telegram_session_alerts),
+        telegram_session_prefix: dapnet_as_string(&json, "telegram_session_prefix", &cur.telegram_session_prefix),
+        extra: HashMap::new(),
+    };
+    let normalized = match apply_echolink_patch(dto) {
+        Ok(value) => value,
+        Err(err) => {
+            http_response(stream, 400, &err);
+            return;
+        }
+    };
+    let text_fields = [
+        normalized.callsign.as_str(),
+        normalized.password.as_ref(),
+        normalized.location.as_str(),
+        normalized.status_text.as_str(),
+        normalized.bind_addr.as_str(),
+        normalized.outbound_prefix.as_str(),
+        normalized.auto_connect.as_str(),
+        normalized.telegram_session_prefix.as_str(),
+    ];
+    let list_fields = normalized
+        .directory_servers
+        .iter()
+        .chain(&normalized.service_numbers)
+        .chain(&normalized.allowed_callsigns);
+    let route_fields = normalized.routes.iter().flat_map(|(dial, target)| [dial, target]);
+    if !text_fields.iter().all(|value| dapnet_text_acceptable(value))
+        || !list_fields.chain(route_fields).all(|value| dapnet_text_acceptable(value))
+    {
+        http_response(stream, 400, "Invalid EchoLink setting: control characters are not allowed");
+        return;
+    }
+
+    let ov = EcholinkRuntimeOverride {
+        enabled: normalized.enabled,
+        callsign: normalized.callsign,
+        password: normalized.password.as_ref().to_string(),
+        location: normalized.location,
+        status_text: normalized.status_text,
+        directory_servers: normalized.directory_servers,
+        directory_port: normalized.directory_port,
+        bind_addr: normalized.bind_addr,
+        audio_port: normalized.audio_port,
+        control_port: normalized.control_port,
+        inbound_enabled: normalized.inbound_enabled,
+        outbound_enabled: normalized.outbound_enabled,
+        outbound_prefix: normalized.outbound_prefix,
+        strip_outbound_prefix: normalized.strip_outbound_prefix,
+        service_numbers: normalized.service_numbers,
+        default_tetra_source_issi: normalized.default_tetra_source_issi,
+        default_tetra_dest_issi: normalized.default_tetra_dest_issi,
+        default_tetra_dest_is_group: normalized.default_tetra_dest_is_group,
+        routes: normalized.routes,
+        allowed_callsigns: normalized.allowed_callsigns,
+        allowed_node_ids: normalized.allowed_node_ids,
+        auto_connect: normalized.auto_connect,
+        reconnect_interval_secs: normalized.reconnect_interval_secs,
+        max_session_secs: normalized.max_session_secs,
+        telegram_session_alerts: normalized.telegram_session_alerts,
+        telegram_session_prefix: normalized.telegram_session_prefix,
+    };
+    cfg.state_write().echolink_override = Some(ov.clone());
+
+    if let Err(err) = crate::net_dashboard::echolink::write_echolink_to_toml(config_path, &ov) {
+        tracing::warn!("Dashboard: EchoLink applied at runtime but failed to persist: {}", err);
+        http_response(stream, 200, "Applied at runtime; failed to write config file (check permissions)");
+        return;
+    }
+    http_response(stream, 200, "OK");
+}
+
+fn serve_echolink_connect(
+    stream: TcpStream,
+    shared_config: &Option<tetra_config::bluestation::SharedConfig>,
+    cmd_tx: &Arc<Mutex<Option<EcholinkCmdSender>>>,
+    body: &str,
+) {
+    let json: serde_json::Value = serde_json::from_str(body.trim()).unwrap_or(serde_json::Value::Null);
+    let target = json
+        .get("target")
+        .and_then(|value| value.as_str())
+        .map(tetra_config::bluestation::normalize_echolink_target)
+        .unwrap_or_default();
+    if target.is_empty() {
+        http_json_response(stream, 400, "{\"ok\":false,\"error\":\"target is required\"}");
+        return;
+    }
+    if shared_config.as_ref().is_some_and(|cfg| !cfg.effective_echolink().enabled) {
+        http_json_response(stream, 200, "{\"ok\":false,\"error\":\"EchoLink is disabled\"}");
+        return;
+    }
+    let Some(tx) = cmd_tx.lock().ok().and_then(|guard| guard.clone()) else {
+        http_json_response(stream, 503, "{\"ok\":false,\"error\":\"EchoLink worker is unavailable\"}");
+        return;
+    };
+    match tx.send(EcholinkCommand::Connect { target }) {
+        Ok(()) => http_json_response(stream, 200, "{\"ok\":true}"),
+        Err(err) => http_json_response(stream, 503, &serde_json::json!({"ok":false,"error":err.to_string()}).to_string()),
+    }
+}
+
+fn serve_echolink_disconnect(stream: TcpStream, cmd_tx: &Arc<Mutex<Option<EcholinkCmdSender>>>) {
+    let Some(tx) = cmd_tx.lock().ok().and_then(|guard| guard.clone()) else {
+        http_json_response(stream, 503, "{\"ok\":false,\"error\":\"EchoLink worker is unavailable\"}");
+        return;
+    };
+    match tx.send(EcholinkCommand::Disconnect) {
+        Ok(()) => http_json_response(stream, 200, "{\"ok\":true}"),
+        Err(err) => http_json_response(stream, 503, &serde_json::json!({"ok":false,"error":err.to_string()}).to_string()),
+    }
+}
+
+fn echolink_string_list(json: &serde_json::Value, key: &str, default: &[String]) -> Vec<String> {
+    if let Some(values) = json.get(key).and_then(|value| value.as_array()) {
+        return values
+            .iter()
+            .filter_map(|value| value.as_str())
+            .map(|value| value.trim().to_string())
+            .filter(|value| !value.is_empty())
+            .collect();
+    }
+    if let Some(value) = json.get(key).and_then(|value| value.as_str()) {
+        return value
+            .split(|ch: char| ch == ',' || ch.is_whitespace())
+            .map(|part| part.trim().to_string())
+            .filter(|part| !part.is_empty())
+            .collect();
+    }
+    default.to_vec()
+}
+
+fn echolink_u32_list(json: &serde_json::Value, key: &str, default: &[u32]) -> Vec<u32> {
+    if let Some(values) = json.get(key).and_then(|value| value.as_array()) {
+        return values
+            .iter()
+            .filter_map(|value| {
+                value
+                    .as_u64()
+                    .filter(|number| *number <= u32::MAX as u64)
+                    .map(|number| number as u32)
+                    .or_else(|| value.as_str().and_then(|text| text.trim().parse::<u32>().ok()))
+            })
+            .filter(|number| *number > 0)
+            .collect();
+    }
+    default.to_vec()
+}
+
+fn echolink_routes_from_json(json: &serde_json::Value, default: &BTreeMap<String, String>) -> HashMap<String, String> {
+    let Some(value) = json.get("routes") else {
+        return default.iter().map(|(key, value)| (key.clone(), value.clone())).collect();
+    };
+    if let Some(object) = value.as_object() {
+        return object
+            .iter()
+            .filter_map(|(key, value)| value.as_str().map(|target| (key.trim().to_string(), target.trim().to_string())))
+            .filter(|(key, target)| !key.is_empty() && !target.is_empty())
+            .collect();
+    }
+    if let Some(text) = value.as_str() {
+        return text
+            .lines()
+            .filter_map(|line| line.split_once('='))
+            .map(|(dial, target)| (dial.trim().to_string(), target.trim().to_string()))
+            .filter(|(dial, target)| !dial.is_empty() && !target.is_empty())
+            .collect();
+    }
+    default.iter().map(|(key, value)| (key.clone(), value.clone())).collect()
 }
 
 /// GET /api/meshcom — return effective MeshCom settings and runtime status as JSON.

--- a/crates/tetra-entities/src/net_echolink/audio.rs
+++ b/crates/tetra-entities/src/net_echolink/audio.rs
@@ -1,0 +1,258 @@
+use std::os::raw::c_int;
+use std::ptr::NonNull;
+
+pub(crate) const ECHOLINK_GSM_FRAME_BYTES: usize = 33;
+pub(crate) const ECHOLINK_GSM_FRAMES_PER_PACKET: usize = 4;
+pub(crate) const ECHOLINK_GSM_PACKET_BYTES: usize = ECHOLINK_GSM_FRAME_BYTES * ECHOLINK_GSM_FRAMES_PER_PACKET;
+
+const PCM_SAMPLES_PER_GSM_FRAME: usize = 160;
+const PCM_SAMPLES_PER_ECHOLINK_PACKET: usize = PCM_SAMPLES_PER_GSM_FRAME * ECHOLINK_GSM_FRAMES_PER_PACKET;
+
+const TETRA_PCM_SAMPLES_PER_FRAME: usize = 240;
+const TETRA_PCM_SAMPLES_PER_BLOCK: usize = TETRA_PCM_SAMPLES_PER_FRAME * 2;
+const TETRA_CODED_BITS_PER_FRAME: usize = 137;
+const TETRA_CODED_BYTES_PER_FRAME: usize = (TETRA_CODED_BITS_PER_FRAME + 7) / 8;
+const TETRA_TMD_BITS_PER_BLOCK: usize = TETRA_CODED_BITS_PER_FRAME * 2;
+const TETRA_TMD_PACKED_BYTES: usize = (TETRA_TMD_BITS_PER_BLOCK + 7) / 8;
+
+#[repr(C)]
+struct RawTetraCodec {
+    _private: [u8; 0],
+}
+
+#[link(name = "tetra-codec")]
+unsafe extern "C" {
+    fn tetra_encoder_create() -> *mut RawTetraCodec;
+    fn tetra_decoder_create() -> *mut RawTetraCodec;
+    fn tetra_codec_destroy(st: *mut RawTetraCodec);
+    fn tetra_encode(st: *mut RawTetraCodec, pcm: *const i16, coded: *mut u8);
+    fn tetra_decode(st: *mut RawTetraCodec, coded: *const u8, pcm: *mut i16, bfi: i32);
+}
+
+#[repr(C)]
+struct RawGsm {
+    _private: [u8; 0],
+}
+
+#[link(name = "gsm")]
+unsafe extern "C" {
+    fn gsm_create() -> *mut RawGsm;
+    fn gsm_destroy(g: *mut RawGsm);
+    fn gsm_encode(g: *mut RawGsm, s: *const i16, c: *mut u8);
+    fn gsm_decode(g: *mut RawGsm, c: *const u8, s: *mut i16) -> c_int;
+}
+
+struct TetraCodecHandle {
+    ptr: NonNull<RawTetraCodec>,
+}
+
+unsafe impl Send for TetraCodecHandle {}
+
+impl TetraCodecHandle {
+    fn from_raw(ptr: *mut RawTetraCodec) -> Option<Self> {
+        NonNull::new(ptr).map(|ptr| Self { ptr })
+    }
+}
+
+impl Drop for TetraCodecHandle {
+    fn drop(&mut self) {
+        unsafe {
+            tetra_codec_destroy(self.ptr.as_ptr());
+        }
+    }
+}
+
+struct GsmHandle {
+    ptr: NonNull<RawGsm>,
+}
+
+unsafe impl Send for GsmHandle {}
+
+impl GsmHandle {
+    fn from_raw(ptr: *mut RawGsm) -> Option<Self> {
+        NonNull::new(ptr).map(|ptr| Self { ptr })
+    }
+}
+
+impl Drop for GsmHandle {
+    fn drop(&mut self) {
+        unsafe {
+            gsm_destroy(self.ptr.as_ptr());
+        }
+    }
+}
+
+pub(crate) struct EcholinkAudioTranscoder {
+    tetra_encoder: TetraCodecHandle,
+    tetra_decoder: TetraCodecHandle,
+    gsm: GsmHandle,
+    tetra_to_gsm_pcm: Vec<i16>,
+    gsm_to_tetra_pcm: Vec<i16>,
+}
+
+impl EcholinkAudioTranscoder {
+    pub(crate) fn new() -> Option<Self> {
+        let tetra_encoder = TetraCodecHandle::from_raw(unsafe { tetra_encoder_create() })?;
+        let tetra_decoder = TetraCodecHandle::from_raw(unsafe { tetra_decoder_create() })?;
+        let gsm = GsmHandle::from_raw(unsafe { gsm_create() })?;
+        Some(Self {
+            tetra_encoder,
+            tetra_decoder,
+            gsm,
+            tetra_to_gsm_pcm: Vec::with_capacity(PCM_SAMPLES_PER_ECHOLINK_PACKET * 2),
+            gsm_to_tetra_pcm: Vec::with_capacity(TETRA_PCM_SAMPLES_PER_BLOCK * 2),
+        })
+    }
+
+    pub(crate) fn decode_tmd_to_gsm_packets(&mut self, acelp: &[u8]) -> Option<Vec<Vec<u8>>> {
+        let coded = split_tmd_block_to_codec_frames(acelp)?;
+        for frame in &coded {
+            let mut pcm = [0i16; TETRA_PCM_SAMPLES_PER_FRAME];
+            unsafe {
+                tetra_decode(self.tetra_decoder.ptr.as_ptr(), frame.as_ptr(), pcm.as_mut_ptr(), 0);
+            }
+            self.tetra_to_gsm_pcm.extend_from_slice(&pcm);
+        }
+
+        let mut packets = Vec::new();
+        while self.tetra_to_gsm_pcm.len() >= PCM_SAMPLES_PER_ECHOLINK_PACKET {
+            let mut payload = vec![0u8; ECHOLINK_GSM_PACKET_BYTES];
+            for frame_idx in 0..ECHOLINK_GSM_FRAMES_PER_PACKET {
+                let pcm_offset = frame_idx * PCM_SAMPLES_PER_GSM_FRAME;
+                let gsm_offset = frame_idx * ECHOLINK_GSM_FRAME_BYTES;
+                unsafe {
+                    gsm_encode(
+                        self.gsm.ptr.as_ptr(),
+                        self.tetra_to_gsm_pcm[pcm_offset..].as_ptr(),
+                        payload[gsm_offset..].as_mut_ptr(),
+                    );
+                }
+            }
+            self.tetra_to_gsm_pcm.drain(..PCM_SAMPLES_PER_ECHOLINK_PACKET);
+            packets.push(payload);
+        }
+        Some(packets)
+    }
+
+    pub(crate) fn decode_gsm_payload_to_tmd(&mut self, payload: &[u8]) -> Vec<Vec<u8>> {
+        let complete_frames = payload.len() / ECHOLINK_GSM_FRAME_BYTES;
+        for frame_idx in 0..complete_frames {
+            let offset = frame_idx * ECHOLINK_GSM_FRAME_BYTES;
+            let mut pcm = [0i16; PCM_SAMPLES_PER_GSM_FRAME];
+            let rc = unsafe { gsm_decode(self.gsm.ptr.as_ptr(), payload[offset..].as_ptr(), pcm.as_mut_ptr()) };
+            if rc == 0 {
+                self.gsm_to_tetra_pcm.extend_from_slice(&pcm);
+            }
+        }
+
+        let mut out = Vec::new();
+        while self.gsm_to_tetra_pcm.len() >= TETRA_PCM_SAMPLES_PER_BLOCK {
+            let mut pcm_a = [0i16; TETRA_PCM_SAMPLES_PER_FRAME];
+            let mut pcm_b = [0i16; TETRA_PCM_SAMPLES_PER_FRAME];
+            pcm_a.copy_from_slice(&self.gsm_to_tetra_pcm[..TETRA_PCM_SAMPLES_PER_FRAME]);
+            pcm_b.copy_from_slice(&self.gsm_to_tetra_pcm[TETRA_PCM_SAMPLES_PER_FRAME..TETRA_PCM_SAMPLES_PER_BLOCK]);
+            self.gsm_to_tetra_pcm.drain(..TETRA_PCM_SAMPLES_PER_BLOCK);
+
+            let mut coded_a = [0u8; TETRA_CODED_BYTES_PER_FRAME];
+            let mut coded_b = [0u8; TETRA_CODED_BYTES_PER_FRAME];
+            unsafe {
+                tetra_encode(self.tetra_encoder.ptr.as_ptr(), pcm_a.as_ptr(), coded_a.as_mut_ptr());
+                tetra_encode(self.tetra_encoder.ptr.as_ptr(), pcm_b.as_ptr(), coded_b.as_mut_ptr());
+            }
+            out.push(join_codec_frames_to_tmd_block(&coded_a, &coded_b));
+        }
+        out
+    }
+}
+
+fn split_tmd_block_to_codec_frames(data: &[u8]) -> Option<[[u8; TETRA_CODED_BYTES_PER_FRAME]; 2]> {
+    let packed = if data.len() == TETRA_TMD_PACKED_BYTES + 1 {
+        Some(&data[1..])
+    } else if data.len() == TETRA_TMD_PACKED_BYTES {
+        Some(data)
+    } else {
+        None
+    };
+
+    let mut frames = [[0u8; TETRA_CODED_BYTES_PER_FRAME]; 2];
+    if let Some(packed) = packed {
+        for bit_idx in 0..TETRA_TMD_BITS_PER_BLOCK {
+            let bit = get_packed_bit(packed, bit_idx);
+            set_packed_bit(
+                &mut frames[bit_idx / TETRA_CODED_BITS_PER_FRAME],
+                bit_idx % TETRA_CODED_BITS_PER_FRAME,
+                bit,
+            );
+        }
+        return Some(frames);
+    }
+
+    if data.len() < TETRA_TMD_BITS_PER_BLOCK {
+        return None;
+    }
+    for bit_idx in 0..TETRA_TMD_BITS_PER_BLOCK {
+        set_packed_bit(
+            &mut frames[bit_idx / TETRA_CODED_BITS_PER_FRAME],
+            bit_idx % TETRA_CODED_BITS_PER_FRAME,
+            data[bit_idx] & 1,
+        );
+    }
+    Some(frames)
+}
+
+fn join_codec_frames_to_tmd_block(frame_a: &[u8; TETRA_CODED_BYTES_PER_FRAME], frame_b: &[u8; TETRA_CODED_BYTES_PER_FRAME]) -> Vec<u8> {
+    let mut out = vec![0u8; TETRA_TMD_PACKED_BYTES];
+    for bit_idx in 0..TETRA_TMD_BITS_PER_BLOCK {
+        let frame = if bit_idx < TETRA_CODED_BITS_PER_FRAME { frame_a } else { frame_b };
+        let frame_bit = bit_idx % TETRA_CODED_BITS_PER_FRAME;
+        set_packed_bit(&mut out, bit_idx, get_packed_bit(frame, frame_bit));
+    }
+    out
+}
+
+fn get_packed_bit(data: &[u8], bit_idx: usize) -> u8 {
+    (data[bit_idx / 8] >> (7 - (bit_idx % 8))) & 1
+}
+
+fn set_packed_bit(data: &mut [u8], bit_idx: usize, bit: u8) {
+    if bit & 1 != 0 {
+        data[bit_idx / 8] |= 1 << (7 - (bit_idx % 8));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn codec_frames_pack_to_tmd_block_and_split_back() {
+        let mut frame_a = [0u8; TETRA_CODED_BYTES_PER_FRAME];
+        let mut frame_b = [0u8; TETRA_CODED_BYTES_PER_FRAME];
+        for bit_idx in 0..TETRA_CODED_BITS_PER_FRAME {
+            set_packed_bit(&mut frame_a, bit_idx, (bit_idx % 2) as u8);
+            set_packed_bit(&mut frame_b, bit_idx, ((bit_idx + 1) % 3 == 0) as u8);
+        }
+
+        let packed = join_codec_frames_to_tmd_block(&frame_a, &frame_b);
+        assert_eq!(packed.len(), TETRA_TMD_PACKED_BYTES);
+        let split = split_tmd_block_to_codec_frames(&packed).expect("packed block must split");
+
+        assert_eq!(split[0], frame_a);
+        assert_eq!(split[1], frame_b);
+    }
+
+    #[test]
+    fn split_accepts_tmd_block_with_leading_marker_byte() {
+        let mut packed = vec![0xaa];
+        packed.extend(join_codec_frames_to_tmd_block(
+            &[0xffu8; TETRA_CODED_BYTES_PER_FRAME],
+            &[0u8; TETRA_CODED_BYTES_PER_FRAME],
+        ));
+
+        let split = split_tmd_block_to_codec_frames(&packed).expect("marked block must split");
+        for bit_idx in 0..TETRA_CODED_BITS_PER_FRAME {
+            assert_eq!(get_packed_bit(&split[0], bit_idx), 1);
+        }
+        assert!(split[1].iter().all(|bit| *bit == 0));
+    }
+}

--- a/crates/tetra-entities/src/net_echolink/audio_stub.rs
+++ b/crates/tetra-entities/src/net_echolink/audio_stub.rs
@@ -1,0 +1,19 @@
+pub(crate) const ECHOLINK_GSM_FRAME_BYTES: usize = 33;
+pub(crate) const ECHOLINK_GSM_PACKET_BYTES: usize = 132;
+
+/// Build-time fallback used when the native EchoLink codecs are not enabled.
+pub(crate) struct EcholinkAudioTranscoder;
+
+impl EcholinkAudioTranscoder {
+    pub(crate) fn new() -> Option<Self> {
+        None
+    }
+
+    pub(crate) fn decode_tmd_to_gsm_packets(&mut self, _acelp: &[u8]) -> Option<Vec<Vec<u8>>> {
+        None
+    }
+
+    pub(crate) fn decode_gsm_payload_to_tmd(&mut self, _payload: &[u8]) -> Vec<Vec<u8>> {
+        Vec::new()
+    }
+}

--- a/crates/tetra-entities/src/net_echolink/mod.rs
+++ b/crates/tetra-entities/src/net_echolink/mod.rs
@@ -1,0 +1,1782 @@
+//! EchoLink UDP/GSM bridge for simplex P2MP voice calls.
+
+#[cfg(feature = "echolink")]
+mod audio;
+#[cfg(not(feature = "echolink"))]
+#[path = "audio_stub.rs"]
+mod audio;
+
+use std::io::{Read, Write};
+use std::net::{IpAddr, SocketAddr, TcpStream, ToSocketAddrs, UdpSocket};
+use std::thread;
+use std::time::{Duration, Instant};
+
+use tetra_config::bluestation::{
+    CfgEcholink, EcholinkDirectoryStationStatus, EcholinkRuntimeStatus, SharedConfig, normalize_echolink_target,
+};
+use tetra_core::{Sap, TdmaTime, tetra_entities::TetraEntity};
+use tetra_pdus::cmce::enums::call_timeout::CallTimeout;
+use tetra_saps::{
+    SapMsg, SapMsgInner,
+    control::call_control::{CallControl, NetworkCircuitCall},
+    control::enums::communication_type::CommunicationType,
+    tmd::{TmdCircuitDataInd, TmdCircuitDataReq},
+};
+use uuid::Uuid;
+
+use crate::net_telegram::TelegramAlertSink;
+use crate::{MessageQueue, TetraEntityTrait};
+
+use self::audio::{ECHOLINK_GSM_FRAME_BYTES, ECHOLINK_GSM_PACKET_BYTES, EcholinkAudioTranscoder};
+
+const RTP_VERSION_ECHOLINK: u8 = 3;
+const RTCP_RR: u8 = 201;
+const RTCP_SDES: u8 = 202;
+const RTCP_BYE: u8 = 203;
+const RTCP_SDES_END: u8 = 0;
+const RTCP_SDES_CNAME: u8 = 1;
+const RTCP_SDES_NAME: u8 = 2;
+const RTCP_SDES_EMAIL: u8 = 3;
+const RTCP_SDES_PHONE: u8 = 4;
+const ECHOLINK_RTP_GSM_PT: u8 = 0x03;
+const ECHOLINK_RTP_HEADER: usize = 12;
+const CONNECT_TIMEOUT: Duration = Duration::from_secs(30);
+const KEEPALIVE_INTERVAL: Duration = Duration::from_secs(10);
+const AUDIO_RX_ACTIVITY_TIMEOUT: Duration = Duration::from_millis(350);
+const AUDIO_RX_SETUP_TIMEOUT: Duration = Duration::from_secs(1);
+const DIRECTORY_TIMEOUT: Duration = Duration::from_secs(3);
+const DIRECTORY_REFRESH_INTERVAL: Duration = Duration::from_secs(5 * 60);
+const DIRECTORY_DESCRIPTION_MAX_CHARS: usize = 27;
+
+#[derive(Debug, Clone)]
+pub enum EcholinkCommand {
+    Connect { target: String },
+    Disconnect,
+}
+
+#[derive(Debug)]
+enum EcholinkDirectoryEvent {
+    Online {
+        generation: u64,
+        callsign: String,
+        stations: Vec<DirectoryStation>,
+    },
+    Error {
+        generation: u64,
+        message: String,
+    },
+}
+
+pub type EcholinkCmdSender = crossbeam_channel::Sender<EcholinkCommand>;
+pub type EcholinkCmdReceiver = crossbeam_channel::Receiver<EcholinkCommand>;
+
+pub fn echolink_channel() -> (EcholinkCmdSender, EcholinkCmdReceiver) {
+    crossbeam_channel::unbounded()
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum QsoState {
+    Connecting,
+    Connected,
+    Released,
+}
+
+struct EcholinkDialog {
+    uuid: Option<Uuid>,
+    call: Option<NetworkCircuitCall>,
+    target: String,
+    remote_call: String,
+    remote_ip: IpAddr,
+    remote_audio: SocketAddr,
+    remote_control: SocketAddr,
+    state: QsoState,
+    audio: EcholinkAudioTranscoder,
+    media_ready: Option<(u16, u16, u8)>,
+    remote_floor_active: bool,
+    remote_floor_ready: bool,
+    remote_floor_since: Option<Instant>,
+    seq: u16,
+    inbound: bool,
+    started: Instant,
+    last_sdes: Instant,
+    last_audio_rx: Option<Instant>,
+}
+
+#[derive(Clone, Debug)]
+struct DirectoryStation {
+    callsign: String,
+    id: u32,
+    ip: IpAddr,
+}
+
+pub struct EcholinkEntity {
+    config: SharedConfig,
+    cmd_rx: EcholinkCmdReceiver,
+    audio_socket: Option<UdpSocket>,
+    control_socket: Option<UdpSocket>,
+    audio_bind: Option<String>,
+    control_bind: Option<String>,
+    dialogs: Vec<EcholinkDialog>,
+    dialog_by_slot: std::collections::HashMap<(u16, u8), usize>,
+    last_enabled: Option<bool>,
+    last_directory_status: String,
+    directory_stations: Vec<DirectoryStation>,
+    directory_stations_dirty: bool,
+    directory_event_tx: crossbeam_channel::Sender<EcholinkDirectoryEvent>,
+    directory_event_rx: crossbeam_channel::Receiver<EcholinkDirectoryEvent>,
+    directory_stop_tx: Option<crossbeam_channel::Sender<()>>,
+    directory_generation: u64,
+    directory_config_key: Option<String>,
+    last_rx: Option<String>,
+    last_tx: Option<String>,
+    last_error: Option<String>,
+    last_session_event: Option<String>,
+    telegram_sink: Option<TelegramAlertSink>,
+}
+
+impl EcholinkEntity {
+    pub fn new(config: SharedConfig, cmd_rx: EcholinkCmdReceiver, telegram_sink: Option<TelegramAlertSink>) -> Self {
+        let (directory_event_tx, directory_event_rx) = crossbeam_channel::unbounded();
+        let mut entity = Self {
+            config,
+            cmd_rx,
+            audio_socket: None,
+            control_socket: None,
+            audio_bind: None,
+            control_bind: None,
+            dialogs: Vec::new(),
+            dialog_by_slot: std::collections::HashMap::new(),
+            last_enabled: None,
+            last_directory_status: "disabled".to_string(),
+            directory_stations: Vec::new(),
+            directory_stations_dirty: true,
+            directory_event_tx,
+            directory_event_rx,
+            directory_stop_tx: None,
+            directory_generation: 0,
+            directory_config_key: None,
+            last_rx: None,
+            last_tx: None,
+            last_error: None,
+            last_session_event: None,
+            telegram_sink,
+        };
+        entity.refresh_status();
+        entity
+    }
+
+    fn effective(&self) -> CfgEcholink {
+        self.config.effective_echolink()
+    }
+
+    fn refresh_status(&mut self) {
+        let cfg = self.effective();
+        let connected = self.dialogs.iter().find(|d| d.state != QsoState::Released).map(|d| {
+            if d.remote_call.is_empty() {
+                d.target.clone()
+            } else {
+                d.remote_call.clone()
+            }
+        });
+        let qso_status = if self.dialogs.iter().any(|d| d.state == QsoState::Connected) {
+            "connected"
+        } else if self.dialogs.iter().any(|d| d.state == QsoState::Connecting) {
+            "connecting"
+        } else {
+            "idle"
+        };
+        let directory_stations = self.directory_stations_dirty.then(|| {
+            self.directory_stations
+                .iter()
+                .map(|s| EcholinkDirectoryStationStatus {
+                    callsign: s.callsign.clone(),
+                    id: s.id,
+                    ip: s.ip.to_string(),
+                })
+                .collect::<Vec<_>>()
+        });
+        if directory_stations.is_some() {
+            self.directory_stations_dirty = false;
+        }
+        let mut state = self.config.state_write();
+        let directory_stations = match directory_stations {
+            Some(stations) => stations,
+            None => std::mem::take(&mut state.echolink_status.directory_stations),
+        };
+        state.echolink_status = EcholinkRuntimeStatus {
+            configured: true,
+            enabled: cfg.enabled,
+            directory_status: self.last_directory_status.clone(),
+            qso_status: qso_status.to_string(),
+            bind: format!("{}:{}/{}", cfg.bind_addr, cfg.audio_port, cfg.control_port),
+            callsign: cfg.callsign.clone(),
+            connected_target: connected,
+            routed_tetra_dest: route_label(&cfg),
+            last_session_event: self.last_session_event.clone(),
+            last_rx: self.last_rx.clone(),
+            last_tx: self.last_tx.clone(),
+            last_error: self.last_error.clone(),
+            directory_stations,
+        };
+    }
+
+    fn set_error(&mut self, msg: impl Into<String>) {
+        let msg = msg.into();
+        tracing::warn!("EchoLink: {}", msg);
+        self.last_error = Some(msg);
+    }
+
+    fn ensure_ports(&mut self, cfg: &CfgEcholink) -> Result<(), String> {
+        let audio_bind = format!("{}:{}", cfg.bind_addr, cfg.audio_port);
+        if self.audio_bind.as_deref() != Some(audio_bind.as_str()) {
+            self.audio_socket = None;
+            self.audio_bind = None;
+        }
+        if self.audio_socket.is_none() {
+            let socket = UdpSocket::bind(&audio_bind).map_err(|e| format!("audio UDP bind {} failed: {}", audio_bind, e))?;
+            socket
+                .set_nonblocking(true)
+                .map_err(|e| format!("audio UDP nonblocking failed: {}", e))?;
+            self.audio_socket = Some(socket);
+            self.audio_bind = Some(audio_bind);
+        }
+        let control_bind = format!("{}:{}", cfg.bind_addr, cfg.control_port);
+        if self.control_bind.as_deref() != Some(control_bind.as_str()) {
+            self.control_socket = None;
+            self.control_bind = None;
+        }
+        if self.control_socket.is_none() {
+            let socket = UdpSocket::bind(&control_bind).map_err(|e| format!("control UDP bind {} failed: {}", control_bind, e))?;
+            socket
+                .set_nonblocking(true)
+                .map_err(|e| format!("control UDP nonblocking failed: {}", e))?;
+            self.control_socket = Some(socket);
+            self.control_bind = Some(control_bind);
+        }
+        Ok(())
+    }
+
+    fn release_ports(&mut self) {
+        self.audio_socket = None;
+        self.control_socket = None;
+        self.audio_bind = None;
+        self.control_bind = None;
+    }
+
+    fn handle_dashboard_commands(&mut self, queue: &mut MessageQueue, cfg: &CfgEcholink) {
+        while let Ok(cmd) = self.cmd_rx.try_recv() {
+            match cmd {
+                EcholinkCommand::Connect { target } => {
+                    let target = normalize_echolink_target(&target);
+                    if target.is_empty() {
+                        self.set_error("connect target is empty");
+                        continue;
+                    }
+                    if !target_allowed(cfg, &target, None, &self.directory_stations) {
+                        self.set_error(format!("target {target} is not allowed by EchoLink routing"));
+                        continue;
+                    }
+                    match self.resolve_target(cfg, &target) {
+                        Ok(ip) => {
+                            let Some(audio) = EcholinkAudioTranscoder::new() else {
+                                self.set_error("EchoLink GSM/TETRA codec allocation failed");
+                                continue;
+                            };
+                            let dialog = EcholinkDialog {
+                                uuid: None,
+                                call: None,
+                                target: target.clone(),
+                                remote_call: target.clone(),
+                                remote_ip: ip,
+                                remote_audio: SocketAddr::new(ip, cfg.audio_port),
+                                remote_control: SocketAddr::new(ip, cfg.control_port),
+                                state: QsoState::Connecting,
+                                audio,
+                                media_ready: None,
+                                remote_floor_active: false,
+                                remote_floor_ready: false,
+                                remote_floor_since: None,
+                                seq: 1,
+                                inbound: false,
+                                started: Instant::now(),
+                                last_sdes: Instant::now() - KEEPALIVE_INTERVAL,
+                                last_audio_rx: None,
+                            };
+                            self.dialogs.push(dialog);
+                            let idx = self.dialogs.len() - 1;
+                            self.send_sdes_idx(idx, cfg);
+                            self.last_tx = Some(format!("connect requested to {target} ({ip})"));
+                            tracing::info!("EchoLink: connect requested to {} ({})", target, ip);
+                        }
+                        Err(err) => self.set_error(err),
+                    }
+                }
+                EcholinkCommand::Disconnect => {
+                    self.disconnect_all(queue, true);
+                    self.last_tx = Some("disconnect requested".to_string());
+                }
+            }
+        }
+    }
+
+    fn start_outbound_call(&mut self, queue: &mut MessageQueue, cfg: &CfgEcholink, brew_uuid: Uuid, call: NetworkCircuitCall) {
+        if !cfg.outbound_enabled {
+            self.reject_setup(queue, brew_uuid, 34);
+            return;
+        }
+        let call = echolink_simplex_p2mp_call(call);
+        let target = normalize_echolink_target(&call.number);
+        if target.is_empty() {
+            self.set_error(format!("empty EchoLink target for uuid={}", brew_uuid));
+            self.reject_setup(queue, brew_uuid, 34);
+            return;
+        }
+        if !target_allowed(cfg, &target, None, &self.directory_stations) {
+            self.set_error(format!("target {target} is not allowed by EchoLink routing"));
+            self.reject_setup(queue, brew_uuid, 34);
+            return;
+        }
+        let remote_ip = match self.resolve_target(cfg, &target) {
+            Ok(ip) => ip,
+            Err(err) => {
+                self.set_error(err);
+                self.reject_setup(queue, brew_uuid, 34);
+                return;
+            }
+        };
+        let Some(audio) = EcholinkAudioTranscoder::new() else {
+            self.set_error(format!("EchoLink codec allocation failed for uuid={}", brew_uuid));
+            self.reject_setup(queue, brew_uuid, 34);
+            return;
+        };
+
+        let dialog = EcholinkDialog {
+            uuid: Some(brew_uuid),
+            call: Some(call),
+            target: target.clone(),
+            remote_call: target.clone(),
+            remote_ip,
+            remote_audio: SocketAddr::new(remote_ip, cfg.audio_port),
+            remote_control: SocketAddr::new(remote_ip, cfg.control_port),
+            state: QsoState::Connecting,
+            audio,
+            media_ready: None,
+            remote_floor_active: false,
+            remote_floor_ready: false,
+            remote_floor_since: None,
+            seq: 1,
+            inbound: false,
+            started: Instant::now(),
+            last_sdes: Instant::now() - KEEPALIVE_INTERVAL,
+            last_audio_rx: None,
+        };
+        self.dialogs.push(dialog);
+        let idx = self.dialogs.len() - 1;
+        self.send_setup_accept(queue, brew_uuid);
+        self.send_sdes_idx(idx, cfg);
+        self.last_tx = Some(format!("SETUP {} to EchoLink {}", brew_uuid, target));
+        tracing::info!("EchoLink: outbound setup uuid={} target={} ip={}", brew_uuid, target, remote_ip);
+    }
+
+    fn reject_setup(&self, queue: &mut MessageQueue, brew_uuid: Uuid, cause: u8) {
+        queue.push_back(SapMsg {
+            sap: Sap::Control,
+            src: TetraEntity::Echolink,
+            dest: TetraEntity::Cmce,
+            msg: SapMsgInner::CmceCallControl(CallControl::NetworkCircuitSetupReject { brew_uuid, cause }),
+        });
+    }
+
+    fn send_setup_accept(&self, queue: &mut MessageQueue, brew_uuid: Uuid) {
+        queue.push_back(SapMsg {
+            sap: Sap::Control,
+            src: TetraEntity::Echolink,
+            dest: TetraEntity::Cmce,
+            msg: SapMsgInner::CmceCallControl(CallControl::NetworkCircuitSetupAccept { brew_uuid }),
+        });
+    }
+
+    fn send_alert(&self, queue: &mut MessageQueue, brew_uuid: Uuid) {
+        queue.push_back(SapMsg {
+            sap: Sap::Control,
+            src: TetraEntity::Echolink,
+            dest: TetraEntity::Cmce,
+            msg: SapMsgInner::CmceCallControl(CallControl::NetworkCircuitAlert { brew_uuid }),
+        });
+    }
+
+    fn send_release_to_cmce(&self, queue: &mut MessageQueue, brew_uuid: Uuid, cause: u8) {
+        queue.push_back(SapMsg {
+            sap: Sap::Control,
+            src: TetraEntity::Echolink,
+            dest: TetraEntity::Cmce,
+            msg: SapMsgInner::CmceCallControl(CallControl::NetworkCircuitRelease { brew_uuid, cause }),
+        });
+    }
+
+    fn send_group_end_to_cmce(&self, queue: &mut MessageQueue, brew_uuid: Uuid) {
+        queue.push_back(SapMsg {
+            sap: Sap::Control,
+            src: TetraEntity::Echolink,
+            dest: TetraEntity::Cmce,
+            msg: SapMsgInner::CmceCallControl(CallControl::NetworkCallEnd { brew_uuid }),
+        });
+    }
+
+    fn request_group_floor_idx(&mut self, queue: &mut MessageQueue, cfg: &CfgEcholink, idx: usize, reason: &str) -> bool {
+        if idx >= self.dialogs.len() {
+            return false;
+        }
+        if !cfg.inbound_enabled || cfg.default_tetra_dest_issi == 0 {
+            self.set_error("EchoLink received audio but no inbound TETRA route is configured");
+            return false;
+        }
+        if !cfg.default_tetra_dest_is_group {
+            self.set_error("EchoLink received audio but simplex/P2MP requires default_tetra_dest_is_group=true");
+            return false;
+        }
+        if self.dialogs[idx].call.is_some() {
+            return false;
+        }
+
+        let now = Instant::now();
+        let (uuid, remote_call, remote_audio, remote_control) = {
+            let dialog = &mut self.dialogs[idx];
+            if dialog.remote_floor_active {
+                return true;
+            }
+            let uuid = dialog.uuid.unwrap_or_else(Uuid::new_v4);
+            dialog.uuid = Some(uuid);
+            dialog.remote_floor_active = true;
+            dialog.remote_floor_ready = false;
+            dialog.remote_floor_since = Some(now);
+            (uuid, dialog.remote_call.clone(), dialog.remote_audio, dialog.remote_control)
+        };
+
+        queue.push_back(SapMsg {
+            sap: Sap::Control,
+            src: TetraEntity::Echolink,
+            dest: TetraEntity::Cmce,
+            msg: SapMsgInner::CmceCallControl(CallControl::NetworkCallStart {
+                brew_uuid: uuid,
+                source_issi: cfg.default_tetra_source_issi,
+                dest_gssi: cfg.default_tetra_dest_issi,
+                priority: 0,
+            }),
+        });
+        tracing::info!(
+            "EchoLink: {} remote={} audio={} control={} -> GSSI {} source={} uuid={}",
+            reason,
+            remote_call,
+            remote_audio,
+            remote_control,
+            cfg.default_tetra_dest_issi,
+            cfg.default_tetra_source_issi,
+            uuid
+        );
+        true
+    }
+
+    fn release_remote_floor_idx(&mut self, queue: &mut MessageQueue, idx: usize, reason: &str) {
+        if idx >= self.dialogs.len() {
+            return;
+        }
+        let (uuid, remote_call, media_ready) = {
+            let dialog = &mut self.dialogs[idx];
+            if dialog.call.is_some() || !dialog.remote_floor_active {
+                return;
+            }
+            dialog.remote_floor_active = false;
+            dialog.remote_floor_ready = false;
+            dialog.remote_floor_since = None;
+            dialog.last_audio_rx = None;
+            (dialog.uuid.take(), dialog.remote_call.clone(), dialog.media_ready.take())
+        };
+
+        if let Some((_, carrier_num, ts)) = media_ready {
+            self.dialog_by_slot.remove(&(carrier_num, ts));
+        }
+        if let Some(uuid) = uuid {
+            self.send_group_end_to_cmce(queue, uuid);
+            if let Some((call_id, carrier_num, ts)) = media_ready {
+                tracing::info!(
+                    "EchoLink: {} remote={} -> releasing TETRA floor uuid={} call_id={} carrier={} ts={}",
+                    reason,
+                    remote_call,
+                    uuid,
+                    call_id,
+                    carrier_num,
+                    ts
+                );
+            } else {
+                tracing::info!(
+                    "EchoLink: {} remote={} -> cancelling pending TETRA floor uuid={}",
+                    reason,
+                    remote_call,
+                    uuid
+                );
+            }
+        }
+    }
+
+    fn maybe_connect_dialog(&mut self, queue: &mut MessageQueue, cfg: &CfgEcholink, idx: usize) {
+        enum ConnectAction {
+            ConfirmTetraOriginated(Uuid, NetworkCircuitCall),
+            StartGroupLeg {
+                uuid: Uuid,
+                source_issi: u32,
+                dest_gssi: u32,
+                remote_call: String,
+            },
+            Release(String),
+            None,
+        }
+
+        let action = {
+            let Some(dialog) = self.dialogs.get_mut(idx) else {
+                return;
+            };
+            if dialog.state == QsoState::Connected {
+                return;
+            }
+            dialog.state = QsoState::Connected;
+
+            if let (Some(uuid), Some(call)) = (dialog.uuid, dialog.call.clone()) {
+                ConnectAction::ConfirmTetraOriginated(uuid, echolink_simplex_p2mp_call(call))
+            } else if dialog.uuid.is_none() {
+                if !cfg.inbound_enabled || cfg.default_tetra_dest_issi == 0 {
+                    ConnectAction::Release("no inbound TETRA route configured for EchoLink dashboard connect".to_string())
+                } else if !cfg.default_tetra_dest_is_group {
+                    ConnectAction::Release("EchoLink simplex/P2MP requires default_tetra_dest_is_group=true".to_string())
+                } else {
+                    let uuid = Uuid::new_v4();
+                    let remote_call = dialog.remote_call.clone();
+                    dialog.uuid = Some(uuid);
+                    ConnectAction::StartGroupLeg {
+                        uuid,
+                        source_issi: cfg.default_tetra_source_issi,
+                        dest_gssi: cfg.default_tetra_dest_issi,
+                        remote_call,
+                    }
+                }
+            } else {
+                ConnectAction::None
+            }
+        };
+
+        let notify_connected = matches!(
+            &action,
+            ConnectAction::ConfirmTetraOriginated(_, _) | ConnectAction::StartGroupLeg { .. }
+        );
+        let connected_remote = self.dialogs.get(idx).map(|dialog| dialog.remote_call.clone()).unwrap_or_default();
+
+        match action {
+            ConnectAction::ConfirmTetraOriginated(uuid, call) => {
+                self.send_alert(queue, uuid);
+                queue.push_back(SapMsg {
+                    sap: Sap::Control,
+                    src: TetraEntity::Echolink,
+                    dest: TetraEntity::Cmce,
+                    msg: SapMsgInner::CmceCallControl(CallControl::NetworkCircuitConnectRequest { brew_uuid: uuid, call }),
+                });
+            }
+            ConnectAction::StartGroupLeg {
+                uuid,
+                source_issi,
+                dest_gssi,
+                remote_call,
+            } => {
+                queue.push_back(SapMsg {
+                    sap: Sap::Control,
+                    src: TetraEntity::Echolink,
+                    dest: TetraEntity::Cmce,
+                    msg: SapMsgInner::CmceCallControl(CallControl::NetworkCallStart {
+                        brew_uuid: uuid,
+                        source_issi,
+                        dest_gssi,
+                        priority: 0,
+                    }),
+                });
+                tracing::info!("EchoLink: dashboard QSO {} -> GSSI {}", remote_call, dest_gssi);
+            }
+            ConnectAction::Release(reason) => {
+                self.set_error(reason);
+                self.release_dialog_idx(queue, idx, false, true);
+            }
+            ConnectAction::None => {}
+        }
+        if notify_connected && !connected_remote.is_empty() {
+            self.last_session_event = Some(format!("connected {}", connected_remote));
+            self.notify_session(cfg, &connected_remote, true);
+        }
+    }
+
+    fn mark_media_ready(&mut self, brew_uuid: Uuid, call_id: u16, carrier_num: u16, ts: u8) {
+        if let Some((idx, dialog)) = self.dialogs.iter_mut().enumerate().find(|(_, d)| d.uuid == Some(brew_uuid)) {
+            dialog.media_ready = Some((call_id, carrier_num, ts));
+            dialog.remote_floor_active = true;
+            dialog.remote_floor_ready = true;
+            dialog.remote_floor_since = Some(Instant::now());
+            self.dialog_by_slot.insert((carrier_num, ts), idx);
+            tracing::info!(
+                "EchoLink: media ready remote={} uuid={} call_id={} carrier={} ts={}",
+                dialog.remote_call,
+                brew_uuid,
+                call_id,
+                carrier_num,
+                ts
+            );
+        }
+    }
+
+    fn release_dialog_by_uuid(&mut self, queue: &mut MessageQueue, brew_uuid: Uuid, from_cmce: bool) {
+        if let Some(idx) = self.dialogs.iter().position(|d| d.uuid == Some(brew_uuid)) {
+            self.release_dialog_idx(queue, idx, from_cmce, true);
+        }
+    }
+
+    fn release_dialog_by_call_id(&mut self, queue: &mut MessageQueue, call_id: u16, from_cmce: bool) {
+        if let Some(idx) = self
+            .dialogs
+            .iter()
+            .position(|d| d.media_ready.map(|(ready_call_id, _, _)| ready_call_id) == Some(call_id))
+        {
+            if from_cmce && self.dialogs.get(idx).is_some_and(|d| d.call.is_none()) {
+                self.clear_group_media_idx(idx, "CMCE released TETRA group leg");
+            } else {
+                self.release_dialog_idx(queue, idx, from_cmce, true);
+            }
+        }
+    }
+
+    fn clear_group_media_idx(&mut self, idx: usize, reason: &str) {
+        if idx >= self.dialogs.len() {
+            return;
+        }
+        let (remote_call, media_ready) = {
+            let dialog = &mut self.dialogs[idx];
+            let media_ready = dialog.media_ready.take();
+            dialog.uuid = None;
+            dialog.remote_floor_active = false;
+            dialog.remote_floor_ready = false;
+            dialog.remote_floor_since = None;
+            dialog.last_audio_rx = None;
+            (dialog.remote_call.clone(), media_ready)
+        };
+        if let Some((call_id, carrier_num, ts)) = media_ready {
+            self.dialog_by_slot.remove(&(carrier_num, ts));
+            tracing::debug!(
+                "EchoLink: {} remote={} call_id={} carrier={} ts={} (session kept)",
+                reason,
+                remote_call,
+                call_id,
+                carrier_num,
+                ts
+            );
+        }
+    }
+
+    fn release_dialog_idx(&mut self, queue: &mut MessageQueue, idx: usize, from_cmce: bool, send_bye: bool) {
+        if idx >= self.dialogs.len() {
+            return;
+        }
+        let remote_call = self.dialogs[idx].remote_call.clone();
+        let remote_control = self.dialogs[idx].remote_control;
+        let was_connected = self.dialogs[idx].state == QsoState::Connected;
+        if send_bye {
+            self.send_bye_idx(idx);
+        }
+        if let Some((_, carrier_num, ts)) = self.dialogs[idx].media_ready {
+            self.dialog_by_slot.remove(&(carrier_num, ts));
+        }
+        let uuid = self.dialogs[idx].uuid;
+        let is_circuit_call = self.dialogs[idx].call.is_some();
+        self.dialogs[idx].state = QsoState::Released;
+        if !from_cmce {
+            if let Some(uuid) = uuid {
+                if is_circuit_call {
+                    self.send_release_to_cmce(queue, uuid, 16);
+                } else {
+                    self.send_group_end_to_cmce(queue, uuid);
+                }
+            }
+        }
+        self.dialogs.remove(idx);
+        self.rebuild_ts_index();
+        if was_connected {
+            let cfg = self.effective();
+            self.notify_session(&cfg, &remote_call, false);
+            self.last_session_event = Some(format!("disconnected {} from {}", remote_call, remote_control));
+        }
+        tracing::info!(
+            "EchoLink: session closed remote={} control={} from_cmce={} bye_sent={}",
+            remote_call,
+            remote_control,
+            from_cmce,
+            send_bye
+        );
+    }
+
+    fn disconnect_all(&mut self, queue: &mut MessageQueue, send_bye: bool) {
+        while !self.dialogs.is_empty() {
+            self.release_dialog_idx(queue, 0, false, send_bye);
+        }
+    }
+
+    fn rebuild_ts_index(&mut self) {
+        self.dialog_by_slot.clear();
+        for (idx, dialog) in self.dialogs.iter().enumerate() {
+            if let Some((_, carrier_num, ts)) = dialog.media_ready {
+                self.dialog_by_slot.insert((carrier_num, ts), idx);
+            }
+        }
+    }
+
+    fn handle_ul_voice(&mut self, prim: TmdCircuitDataInd) {
+        let Some(&idx) = self.dialog_by_slot.get(&(prim.carrier_num, prim.ts)) else {
+            return;
+        };
+        let Some(socket) = self.audio_socket.as_ref().and_then(|s| s.try_clone().ok()) else {
+            return;
+        };
+        let decoded = {
+            let Some(dialog) = self.dialogs.get_mut(idx) else {
+                return;
+            };
+            if dialog.state != QsoState::Connected {
+                return;
+            }
+            let remote_audio = dialog.remote_audio;
+            let seq = dialog.seq;
+            dialog
+                .audio
+                .decode_tmd_to_gsm_packets(&prim.data)
+                .map(|payloads| (remote_audio, seq, payloads))
+        };
+        let Some((remote_audio, start_seq, payloads)) = decoded else {
+            self.set_error(format!(
+                "dropping unsupported TETRA audio block ts={} len={}",
+                prim.ts,
+                prim.data.len()
+            ));
+            return;
+        };
+        let mut seq = start_seq;
+        let mut sent_packets = 0usize;
+        let mut last_error = None;
+        for payload in payloads {
+            let packet = build_audio_packet(seq, &payload);
+            match socket.send_to(&packet, remote_audio) {
+                Ok(_) => {
+                    seq = seq.wrapping_add(1);
+                    sent_packets += 1;
+                }
+                Err(err) => {
+                    last_error = Some(format!("audio send to {} failed: {}", remote_audio, err));
+                    break;
+                }
+            }
+        }
+        if let Some(dialog) = self.dialogs.get_mut(idx) {
+            dialog.seq = seq;
+        }
+        if sent_packets > 0 {
+            self.last_tx = Some(format!("audio {} packet(s) to {}", sent_packets, remote_audio));
+        }
+        if let Some(err) = last_error {
+            self.set_error(err);
+        }
+    }
+
+    fn poll_audio(&mut self, queue: &mut MessageQueue) {
+        let Some(socket) = self.audio_socket.as_ref().and_then(|s| s.try_clone().ok()) else {
+            return;
+        };
+        let mut buf = [0u8; 1500];
+        for _ in 0..32 {
+            match socket.recv_from(&mut buf) {
+                Ok((len, addr)) => self.handle_audio_packet(queue, &buf[..len], addr),
+                Err(err) if err.kind() == std::io::ErrorKind::WouldBlock => break,
+                Err(err) => {
+                    self.set_error(format!("audio receive failed: {}", err));
+                    break;
+                }
+            }
+        }
+    }
+
+    fn handle_audio_packet(&mut self, queue: &mut MessageQueue, packet: &[u8], addr: SocketAddr) {
+        if packet.starts_with(b"oNDATA") {
+            tracing::debug!("EchoLink: oNDATA probe from {}", addr);
+            return;
+        }
+        if packet.len() < ECHOLINK_RTP_HEADER || packet[0] != 0xc0 {
+            return;
+        }
+        let payload_type = packet[1] & 0x7f;
+        if payload_type != ECHOLINK_RTP_GSM_PT {
+            tracing::trace!("EchoLink: dropping unsupported RTP payload type {}", payload_type);
+            return;
+        }
+        let Some(idx) = self.find_dialog_by_ip(addr.ip()) else {
+            return;
+        };
+        let payload = &packet[ECHOLINK_RTP_HEADER..];
+        if payload.len() < ECHOLINK_GSM_PACKET_BYTES || payload.len() % ECHOLINK_GSM_FRAME_BYTES != 0 {
+            tracing::trace!("EchoLink: dropping malformed GSM payload len={}", payload.len());
+            return;
+        }
+
+        enum AudioAction {
+            Forward {
+                carrier_num: u16,
+                ts: u8,
+                frames: Vec<Vec<u8>>,
+                remote_call: String,
+                first_packet: bool,
+            },
+            RequestFloor {
+                remote_call: String,
+            },
+            DropPending {
+                remote_call: String,
+            },
+        }
+
+        let now = Instant::now();
+        let action = {
+            let Some(dialog) = self.dialogs.get_mut(idx) else {
+                return;
+            };
+            if dialog.state != QsoState::Connected {
+                return;
+            }
+            let remote_call = dialog.remote_call.clone();
+            let first_packet = dialog.last_audio_rx.is_none();
+            dialog.remote_audio = addr;
+            dialog.last_audio_rx = Some(now);
+
+            if dialog.call.is_none() && !dialog.remote_floor_active {
+                AudioAction::RequestFloor { remote_call }
+            } else if dialog.call.is_none() && (!dialog.remote_floor_ready || dialog.media_ready.is_none()) {
+                AudioAction::DropPending { remote_call }
+            } else if let Some((_, carrier_num, ts)) = dialog.media_ready {
+                AudioAction::Forward {
+                    carrier_num,
+                    ts,
+                    frames: dialog.audio.decode_gsm_payload_to_tmd(payload),
+                    remote_call,
+                    first_packet,
+                }
+            } else {
+                AudioAction::DropPending { remote_call }
+            }
+        };
+
+        let (carrier_num, ts, frames, remote_call, first_packet) = match action {
+            AudioAction::Forward {
+                carrier_num,
+                ts,
+                frames,
+                remote_call,
+                first_packet,
+            } => (carrier_num, ts, frames, remote_call, first_packet),
+            AudioAction::RequestFloor { remote_call } => {
+                let cfg = self.effective();
+                tracing::info!(
+                    "EchoLink: RTP audio burst from {} at {} -> requesting TETRA floor",
+                    remote_call,
+                    addr
+                );
+                self.request_group_floor_idx(queue, &cfg, idx, "RTP audio burst");
+                self.last_rx = Some(format!("audio pending floor from {}", addr));
+                return;
+            }
+            AudioAction::DropPending { remote_call } => {
+                tracing::debug!("EchoLink: dropping RTP audio from {} while TETRA floor is not ready", remote_call);
+                self.last_rx = Some(format!("audio pending media from {}", addr));
+                return;
+            }
+        };
+
+        if first_packet {
+            tracing::info!(
+                "EchoLink: RTP audio started remote={} audio={} -> carrier={} ts={}",
+                remote_call,
+                addr,
+                carrier_num,
+                ts
+            );
+        } else {
+            tracing::debug!(
+                "EchoLink: RTP audio remote={} bytes={} -> carrier={} ts={}",
+                remote_call,
+                packet.len(),
+                carrier_num,
+                ts
+            );
+        }
+
+        for frame in frames {
+            queue.push_back(SapMsg {
+                sap: Sap::TmdSap,
+                src: TetraEntity::Echolink,
+                dest: TetraEntity::Umac,
+                msg: SapMsgInner::TmdCircuitDataReq(TmdCircuitDataReq {
+                    carrier_num,
+                    ts,
+                    data: frame,
+                }),
+            });
+        }
+        self.last_rx = Some(format!("audio {} bytes from {}", packet.len(), addr));
+    }
+
+    fn poll_control(&mut self, queue: &mut MessageQueue, cfg: &CfgEcholink) {
+        let Some(socket) = self.control_socket.as_ref().and_then(|s| s.try_clone().ok()) else {
+            return;
+        };
+        let mut buf = [0u8; 1500];
+        for _ in 0..32 {
+            match socket.recv_from(&mut buf) {
+                Ok((len, addr)) => self.handle_control_packet(queue, cfg, &buf[..len], addr),
+                Err(err) if err.kind() == std::io::ErrorKind::WouldBlock => break,
+                Err(err) => {
+                    self.set_error(format!("control receive failed: {}", err));
+                    break;
+                }
+            }
+        }
+    }
+
+    fn handle_control_packet(&mut self, queue: &mut MessageQueue, cfg: &CfgEcholink, packet: &[u8], addr: SocketAddr) {
+        if is_rtcp_bye(packet) {
+            if let Some(idx) = self.find_dialog_by_ip(addr.ip()) {
+                let remote_call = self
+                    .dialogs
+                    .get(idx)
+                    .map(|dialog| dialog.remote_call.clone())
+                    .unwrap_or_else(|| "-".to_string());
+                self.last_rx = Some(format!("BYE from {}", addr));
+                tracing::info!("EchoLink: BYE from remote={} control={}", remote_call, addr);
+                self.release_dialog_idx(queue, idx, false, false);
+            } else {
+                tracing::debug!("EchoLink: BYE from unknown control={} -> replying BYE", addr);
+                self.send_bye_to(addr);
+            }
+            return;
+        }
+
+        if let Some(remote_name) = parse_rtcp_sdes_name(packet) {
+            let remote_call = remote_name.split_whitespace().next().unwrap_or("").trim().to_ascii_uppercase();
+            if remote_call.is_empty() {
+                return;
+            }
+            self.last_rx = Some(format!("SDES {} from {}", remote_call, addr));
+            if let Some(idx) = self.find_dialog_by_ip(addr.ip()) {
+                if let Some(dialog) = self.dialogs.get_mut(idx) {
+                    tracing::debug!(
+                        "EchoLink: SDES refresh remote={} control={} previous_remote={}",
+                        remote_call,
+                        addr,
+                        dialog.remote_call
+                    );
+                    dialog.remote_control = addr;
+                    dialog.remote_audio = SocketAddr::new(addr.ip(), cfg.audio_port);
+                    dialog.remote_call = remote_call;
+                    dialog.last_sdes = Instant::now();
+                }
+                self.maybe_connect_dialog(queue, cfg, idx);
+                return;
+            }
+
+            if !cfg.inbound_enabled || cfg.default_tetra_dest_issi == 0 {
+                self.send_bye_to(addr);
+                return;
+            }
+            if !cfg.default_tetra_dest_is_group {
+                self.set_error("inbound EchoLink requires default_tetra_dest_is_group=true for simplex/P2MP");
+                self.send_bye_to(addr);
+                return;
+            }
+            if !target_allowed(cfg, &remote_call, Some(addr.ip()), &self.directory_stations) {
+                self.set_error(format!("inbound target {remote_call} is not allowed by EchoLink routing"));
+                tracing::info!(
+                    "EchoLink: rejecting inbound SDES remote={} control={} (not allowed)",
+                    remote_call,
+                    addr
+                );
+                self.send_bye_to(addr);
+                return;
+            }
+            tracing::info!("EchoLink: inbound SDES remote={} control={} accepted", remote_call, addr);
+            self.start_inbound_call(queue, cfg, remote_call, addr);
+        }
+    }
+
+    fn start_inbound_call(&mut self, queue: &mut MessageQueue, cfg: &CfgEcholink, remote_call: String, remote_control: SocketAddr) {
+        let Some(audio) = EcholinkAudioTranscoder::new() else {
+            self.set_error("EchoLink codec allocation failed for inbound QSO");
+            self.send_bye_to(remote_control);
+            return;
+        };
+        let dialog = EcholinkDialog {
+            uuid: None,
+            call: None,
+            target: remote_call.clone(),
+            remote_call: remote_call.clone(),
+            remote_ip: remote_control.ip(),
+            remote_audio: SocketAddr::new(remote_control.ip(), cfg.audio_port),
+            remote_control,
+            state: QsoState::Connected,
+            audio,
+            media_ready: None,
+            remote_floor_active: false,
+            remote_floor_ready: false,
+            remote_floor_since: None,
+            seq: 1,
+            inbound: true,
+            started: Instant::now(),
+            last_sdes: Instant::now(),
+            last_audio_rx: None,
+        };
+        self.dialogs.push(dialog);
+        let idx = self.dialogs.len() - 1;
+        self.send_sdes_idx(idx, cfg);
+        tracing::info!(
+            "EchoLink: inbound session opened remote={} control={} audio={} -> GSSI {}",
+            remote_call,
+            remote_control,
+            SocketAddr::new(remote_control.ip(), cfg.audio_port),
+            cfg.default_tetra_dest_issi
+        );
+        self.last_session_event = Some(format!("connected {} from {}", remote_call, remote_control));
+        self.notify_session(cfg, &remote_call, true);
+        self.request_group_floor_idx(queue, cfg, idx, "inbound simplex/P2MP QSO");
+    }
+
+    fn notify_session(&self, cfg: &CfgEcholink, remote_call: &str, connected: bool) {
+        if !cfg.telegram_session_alerts {
+            return;
+        }
+        let Some(sink) = &self.telegram_sink else {
+            tracing::debug!(
+                "EchoLink: Telegram session alert skipped for remote={} because Telegram is not configured",
+                remote_call
+            );
+            return;
+        };
+        sink.send_echolink_session(
+            cfg.telegram_session_prefix.clone(),
+            remote_call.to_string(),
+            connected,
+            route_label(cfg).unwrap_or_else(|| "not routed".to_string()),
+        );
+    }
+
+    fn send_sdes_idx(&mut self, idx: usize, cfg: &CfgEcholink) {
+        let Some(dialog) = self.dialogs.get(idx) else {
+            return;
+        };
+        let packet = build_sdes_packet(&cfg.callsign, &cfg.location);
+        let addr = dialog.remote_control;
+        if let Some(socket) = self.control_socket.as_ref().and_then(|s| s.try_clone().ok()) {
+            match socket.send_to(&packet, addr) {
+                Ok(_) => {
+                    if let Some(dialog) = self.dialogs.get_mut(idx) {
+                        dialog.last_sdes = Instant::now();
+                    }
+                    tracing::debug!("EchoLink: SDES sent to {}", addr);
+                    self.last_tx = Some(format!("SDES to {}", addr));
+                }
+                Err(err) => self.set_error(format!("SDES send to {} failed: {}", addr, err)),
+            }
+        }
+    }
+
+    fn send_bye_idx(&mut self, idx: usize) {
+        let Some(dialog) = self.dialogs.get(idx) else {
+            return;
+        };
+        let addr = dialog.remote_control;
+        self.send_bye_to(addr);
+    }
+
+    fn send_bye_to(&mut self, addr: SocketAddr) {
+        let packet = build_bye_packet();
+        if let Some(socket) = self.control_socket.as_ref().and_then(|s| s.try_clone().ok()) {
+            match socket.send_to(&packet, addr) {
+                Ok(_) => {
+                    tracing::info!("EchoLink: BYE sent to {}", addr);
+                    self.last_tx = Some(format!("BYE to {}", addr));
+                }
+                Err(err) => self.set_error(format!("BYE send to {} failed: {}", addr, err)),
+            }
+        }
+    }
+
+    fn maybe_keepalive(&mut self, cfg: &CfgEcholink) {
+        let now = Instant::now();
+        let mut idxs = Vec::new();
+        for (idx, dialog) in self.dialogs.iter().enumerate() {
+            if dialog.state != QsoState::Released && now.duration_since(dialog.last_sdes) >= KEEPALIVE_INTERVAL {
+                idxs.push(idx);
+            }
+        }
+        for idx in idxs {
+            self.send_sdes_idx(idx, cfg);
+        }
+    }
+
+    fn maybe_timeout(&mut self, queue: &mut MessageQueue) {
+        let now = Instant::now();
+        let mut idx = 0;
+        while idx < self.dialogs.len() {
+            if self.dialogs[idx].state == QsoState::Connecting && now.duration_since(self.dialogs[idx].started) >= CONNECT_TIMEOUT {
+                let target = self.dialogs[idx].target.clone();
+                self.set_error(format!("connect to {target} timed out"));
+                self.release_dialog_idx(queue, idx, false, true);
+            } else {
+                idx += 1;
+            }
+        }
+        self.maybe_release_stale_remote_floors(queue, now);
+    }
+
+    fn maybe_release_stale_remote_floors(&mut self, queue: &mut MessageQueue, now: Instant) {
+        let mut stale = Vec::new();
+        for (idx, dialog) in self.dialogs.iter().enumerate() {
+            if dialog.state != QsoState::Connected || dialog.call.is_some() || !dialog.remote_floor_active {
+                continue;
+            }
+            let timed_out = if !dialog.remote_floor_ready {
+                dialog
+                    .remote_floor_since
+                    .map(|since| now.duration_since(since) >= AUDIO_RX_SETUP_TIMEOUT)
+                    .unwrap_or(false)
+            } else if dialog.media_ready.is_some() {
+                dialog
+                    .last_audio_rx
+                    .map(|last| now.duration_since(last) >= AUDIO_RX_ACTIVITY_TIMEOUT)
+                    .unwrap_or_else(|| {
+                        dialog
+                            .remote_floor_since
+                            .map(|since| now.duration_since(since) >= AUDIO_RX_SETUP_TIMEOUT)
+                            .unwrap_or(false)
+                    })
+            } else {
+                dialog
+                    .remote_floor_since
+                    .map(|since| now.duration_since(since) >= AUDIO_RX_SETUP_TIMEOUT)
+                    .unwrap_or(false)
+            };
+            if timed_out {
+                stale.push(idx);
+            }
+        }
+
+        for idx in stale.into_iter().rev() {
+            self.release_remote_floor_idx(queue, idx, "RTP audio inactive");
+        }
+    }
+
+    fn find_dialog_by_ip(&self, ip: IpAddr) -> Option<usize> {
+        self.dialogs.iter().position(|d| d.state != QsoState::Released && d.remote_ip == ip)
+    }
+
+    fn resolve_target(&mut self, _cfg: &CfgEcholink, target: &str) -> Result<IpAddr, String> {
+        if let Ok(ip) = target.parse::<IpAddr>() {
+            return Ok(ip);
+        }
+        if self.directory_stations.is_empty() {
+            return Err("EchoLink directory station list is not ready yet".to_string());
+        }
+        let target_upper = normalize_echolink_target(target);
+        let station = if let Ok(node_id) = target_upper.parse::<u32>() {
+            self.directory_stations.iter().find(|s| s.id == node_id)
+        } else {
+            self.directory_stations
+                .iter()
+                .find(|s| station_matches_target(&s.callsign, &target_upper))
+        };
+        station
+            .map(|s| s.ip)
+            .ok_or_else(|| format!("EchoLink target {target_upper} not found in directory"))
+    }
+
+    fn start_directory_worker(&mut self) {
+        self.stop_directory_worker();
+
+        let config = self.config.clone();
+        let cfg = config.effective_echolink();
+        let config_key = directory_config_key(&cfg);
+        let event_tx = self.directory_event_tx.clone();
+        let (stop_tx, stop_rx) = crossbeam_channel::bounded(1);
+        self.directory_generation = self.directory_generation.wrapping_add(1);
+        let generation = self.directory_generation;
+        self.directory_stop_tx = Some(stop_tx);
+        self.directory_config_key = Some(config_key);
+        self.last_directory_status = "registering".to_string();
+        tracing::info!(
+            "EchoLink: directory registration worker starting for {} via {}:{}",
+            cfg.callsign,
+            cfg.directory_servers.join(","),
+            cfg.directory_port
+        );
+
+        let spawn = thread::Builder::new().name("flow-echolink-directory".to_string()).spawn(move || {
+            loop {
+                let cfg = config.effective_echolink();
+                if !cfg.enabled {
+                    break;
+                }
+
+                let wait = match directory_make_online_request(&cfg) {
+                    Ok(()) => {
+                        match directory_get_calls_request(&cfg) {
+                            Ok(stations) => {
+                                let _ = event_tx.send(EcholinkDirectoryEvent::Online {
+                                    generation,
+                                    callsign: cfg.callsign.clone(),
+                                    stations,
+                                });
+                            }
+                            Err(err) => {
+                                let _ = event_tx.send(EcholinkDirectoryEvent::Online {
+                                    generation,
+                                    callsign: cfg.callsign.clone(),
+                                    stations: Vec::new(),
+                                });
+                                let _ = event_tx.send(EcholinkDirectoryEvent::Error {
+                                    generation,
+                                    message: format!("directory list after ONLINE failed: {}", err),
+                                });
+                            }
+                        }
+                        DIRECTORY_REFRESH_INTERVAL
+                    }
+                    Err(err) => {
+                        let _ = event_tx.send(EcholinkDirectoryEvent::Error { generation, message: err });
+                        Duration::from_secs(cfg.reconnect_interval_secs.max(1))
+                    }
+                };
+
+                if !matches!(stop_rx.recv_timeout(wait), Err(crossbeam_channel::RecvTimeoutError::Timeout)) {
+                    break;
+                }
+            }
+        });
+
+        if let Err(err) = spawn {
+            self.directory_stop_tx = None;
+            self.directory_config_key = None;
+            self.set_error(format!("directory worker start failed: {}", err));
+        }
+    }
+
+    fn stop_directory_worker(&mut self) {
+        if let Some(stop_tx) = self.directory_stop_tx.take() {
+            let _ = stop_tx.send(());
+            self.directory_generation = self.directory_generation.wrapping_add(1);
+        }
+        self.directory_config_key = None;
+        self.directory_stations.clear();
+        self.directory_stations_dirty = true;
+    }
+
+    fn ensure_directory_worker(&mut self, cfg: &CfgEcholink) {
+        let key = directory_config_key(cfg);
+        if self.directory_stop_tx.is_none() || self.directory_config_key.as_deref() != Some(key.as_str()) {
+            self.start_directory_worker();
+        }
+    }
+
+    fn poll_directory_events(&mut self) {
+        while let Ok(event) = self.directory_event_rx.try_recv() {
+            match event {
+                EcholinkDirectoryEvent::Online {
+                    generation,
+                    callsign,
+                    stations,
+                } if generation == self.directory_generation => {
+                    let station_count = stations.len();
+                    self.directory_stations = stations;
+                    self.directory_stations_dirty = true;
+                    self.last_directory_status = format!("online; {} stations", station_count);
+                    self.last_error = None;
+                    self.last_tx = Some(format!("directory ONLINE refreshed for {} ({} stations)", callsign, station_count));
+                    tracing::info!("EchoLink: directory ONLINE refreshed for {} ({} stations)", callsign, station_count);
+                }
+                EcholinkDirectoryEvent::Error { generation, message } if generation == self.directory_generation => {
+                    self.last_directory_status = "directory error".to_string();
+                    self.set_error(message);
+                }
+                _ => {}
+            }
+        }
+    }
+}
+
+impl TetraEntityTrait for EcholinkEntity {
+    fn entity(&self) -> TetraEntity {
+        TetraEntity::Echolink
+    }
+
+    fn rx_prim(&mut self, queue: &mut MessageQueue, message: SapMsg) {
+        let cfg = self.effective();
+        match message.msg {
+            SapMsgInner::CmceCallControl(CallControl::NetworkCircuitSetupRequest { brew_uuid, call }) => {
+                self.start_outbound_call(queue, &cfg, brew_uuid, call);
+            }
+            SapMsgInner::CmceCallControl(CallControl::NetworkCallReady {
+                brew_uuid,
+                call_id,
+                carrier_num,
+                ts,
+                ..
+            }) => {
+                self.mark_media_ready(brew_uuid, call_id, carrier_num, ts);
+            }
+            SapMsgInner::CmceCallControl(CallControl::NetworkCallEnd { brew_uuid }) => {
+                self.release_dialog_by_uuid(queue, brew_uuid, true);
+            }
+            SapMsgInner::CmceCallControl(CallControl::CallEnded { call_id, .. }) => {
+                self.release_dialog_by_call_id(queue, call_id, true);
+            }
+            SapMsgInner::CmceCallControl(CallControl::NetworkCircuitSetupAccept { brew_uuid }) => {
+                tracing::info!("EchoLink: inbound setup accepted by CMCE uuid={}", brew_uuid);
+            }
+            SapMsgInner::CmceCallControl(CallControl::NetworkCircuitSetupReject { brew_uuid, cause }) => {
+                tracing::info!("EchoLink: setup rejected by CMCE uuid={} cause={}", brew_uuid, cause);
+                self.release_dialog_by_uuid(queue, brew_uuid, true);
+            }
+            SapMsgInner::CmceCallControl(CallControl::NetworkCircuitAlert { brew_uuid }) => {
+                tracing::info!("EchoLink: TETRA side alert uuid={}", brew_uuid);
+            }
+            SapMsgInner::CmceCallControl(CallControl::NetworkCircuitConnectRequest { brew_uuid, call }) => {
+                if let Some(dialog) = self.dialogs.iter_mut().find(|d| d.uuid == Some(brew_uuid)) {
+                    dialog.call = Some(echolink_simplex_p2mp_call(call));
+                    dialog.state = QsoState::Connected;
+                }
+                queue.push_back(SapMsg {
+                    sap: Sap::Control,
+                    src: TetraEntity::Echolink,
+                    dest: TetraEntity::Cmce,
+                    msg: SapMsgInner::CmceCallControl(CallControl::NetworkCircuitConnectConfirm {
+                        brew_uuid,
+                        grant: 0,
+                        permission: 0,
+                    }),
+                });
+            }
+            SapMsgInner::CmceCallControl(CallControl::NetworkCircuitConnectConfirm { .. }) => {}
+            SapMsgInner::CmceCallControl(CallControl::NetworkCircuitMediaReady {
+                brew_uuid,
+                call_id,
+                carrier_num,
+                ts,
+            }) => {
+                self.mark_media_ready(brew_uuid, call_id, carrier_num, ts);
+            }
+            SapMsgInner::CmceCallControl(CallControl::NetworkCircuitRelease { brew_uuid, .. }) => {
+                self.release_dialog_by_uuid(queue, brew_uuid, true);
+            }
+            SapMsgInner::TmdCircuitDataInd(prim) => {
+                self.handle_ul_voice(prim);
+            }
+            _ => {}
+        }
+        self.refresh_status();
+    }
+
+    fn tick_start(&mut self, queue: &mut MessageQueue, _ts: TdmaTime) {
+        let cfg = self.effective();
+        if !cfg.enabled {
+            if self.last_enabled != Some(false) {
+                tracing::info!("EchoLink integration disabled");
+                self.last_enabled = Some(false);
+            }
+            self.disconnect_all(queue, false);
+            self.release_ports();
+            self.stop_directory_worker();
+            self.last_directory_status = "disabled".to_string();
+            self.refresh_status();
+            return;
+        }
+
+        if self.last_enabled != Some(true) {
+            tracing::info!(
+                "EchoLink integration enabled (call={} inbound={} outbound={} ports={}/{})",
+                cfg.callsign,
+                cfg.inbound_enabled,
+                cfg.outbound_enabled,
+                cfg.audio_port,
+                cfg.control_port
+            );
+            self.last_enabled = Some(true);
+        }
+
+        match self.ensure_ports(&cfg) {
+            Ok(()) => {
+                if self.last_directory_status == "disabled" {
+                    self.last_directory_status = "ports ready".to_string();
+                }
+                self.ensure_directory_worker(&cfg);
+                self.poll_directory_events();
+                self.handle_dashboard_commands(queue, &cfg);
+                self.poll_control(queue, &cfg);
+                self.poll_audio(queue);
+                self.maybe_keepalive(&cfg);
+                self.maybe_timeout(queue);
+            }
+            Err(err) => {
+                self.last_directory_status = "error".to_string();
+                self.set_error(err);
+                self.release_ports();
+                self.stop_directory_worker();
+            }
+        }
+        self.refresh_status();
+    }
+}
+
+fn target_allowed(cfg: &CfgEcholink, target: &str, remote_ip: Option<IpAddr>, stations: &[DirectoryStation]) -> bool {
+    if cfg.allowed_callsigns.is_empty() && cfg.allowed_node_ids.is_empty() {
+        return true;
+    }
+    if cfg.allowed_callsigns.iter().any(|c| station_matches_target(c, target)) {
+        return true;
+    }
+    if target
+        .parse::<u32>()
+        .ok()
+        .map(|id| cfg.allowed_node_ids.contains(&id))
+        .unwrap_or(false)
+    {
+        return true;
+    }
+
+    stations
+        .iter()
+        .find(|station| station_matches_target(&station.callsign, target) || remote_ip.is_some_and(|ip| station.ip == ip))
+        .is_some_and(|station| {
+            cfg.allowed_node_ids.contains(&station.id)
+                || cfg
+                    .allowed_callsigns
+                    .iter()
+                    .any(|allowed| station_matches_target(allowed, &station.callsign))
+        })
+}
+
+fn station_matches_target(station: &str, target: &str) -> bool {
+    if station.eq_ignore_ascii_case(target) {
+        return true;
+    }
+    station.trim_matches('*').eq_ignore_ascii_case(target.trim_matches('*'))
+}
+
+fn echolink_simplex_p2mp_call(mut call: NetworkCircuitCall) -> NetworkCircuitCall {
+    call.duplex = 0;
+    call.communication = CommunicationType::P2Mp.into_raw() as u8;
+    call.timeout = CallTimeout::T5m.into_raw() as u8;
+    call
+}
+
+fn route_label(cfg: &CfgEcholink) -> Option<String> {
+    if cfg.default_tetra_dest_issi == 0 {
+        return None;
+    }
+    Some(format!(
+        "{} {} from {}",
+        if cfg.default_tetra_dest_is_group { "GSSI" } else { "ISSI" },
+        cfg.default_tetra_dest_issi,
+        cfg.default_tetra_source_issi
+    ))
+}
+
+fn directory_description(status_text: &str) -> String {
+    status_text
+        .trim()
+        .chars()
+        .map(|ch| if ch == '\r' || ch == '\n' { ' ' } else { ch })
+        .take(DIRECTORY_DESCRIPTION_MAX_CHARS)
+        .collect()
+}
+
+fn directory_config_key(cfg: &CfgEcholink) -> String {
+    format!(
+        "{}\u{1f}{}\u{1f}{}\u{1f}{}\u{1f}{}\u{1f}{}:{}:{}",
+        cfg.callsign,
+        cfg.password.as_ref(),
+        cfg.status_text,
+        cfg.directory_servers.join("\u{1e}"),
+        cfg.directory_port,
+        cfg.bind_addr,
+        cfg.audio_port,
+        cfg.control_port
+    )
+}
+
+fn directory_make_online_request(cfg: &CfgEcholink) -> Result<(), String> {
+    let mut stream = directory_connect(cfg)?;
+    let time = chrono::Local::now().format("%H:%M").to_string();
+    let description = directory_description(&cfg.status_text);
+    let mut cmd = Vec::new();
+    cmd.push(b'l');
+    cmd.extend_from_slice(cfg.callsign.as_bytes());
+    cmd.extend_from_slice(&[0xac, 0xac]);
+    cmd.extend_from_slice(cfg.password.as_ref().as_bytes());
+    cmd.extend_from_slice(b"\rONLINE3.38(");
+    cmd.extend_from_slice(time.as_bytes());
+    cmd.extend_from_slice(b")\r");
+    cmd.extend_from_slice(description.as_bytes());
+    cmd.extend_from_slice(b"\r");
+    stream
+        .write_all(&cmd)
+        .map_err(|e| format!("directory ONLINE write failed: {}", e))?;
+    let mut buf = [0u8; 256];
+    let len = stream.read(&mut buf).map_err(|e| format!("directory ONLINE read failed: {}", e))?;
+    let reply = String::from_utf8_lossy(&buf[..len]).to_string();
+    if reply.starts_with("OK") {
+        Ok(())
+    } else {
+        Err(format!("directory ONLINE rejected: {}", reply.trim()))
+    }
+}
+
+fn directory_get_calls_request(cfg: &CfgEcholink) -> Result<Vec<DirectoryStation>, String> {
+    let mut stream = directory_connect(cfg)?;
+    stream.write_all(b"s").map_err(|e| format!("directory list write failed: {}", e))?;
+    let mut buf = Vec::new();
+    let mut chunk = [0u8; 4096];
+    loop {
+        match stream.read(&mut chunk) {
+            Ok(0) => break,
+            Ok(len) => {
+                buf.extend_from_slice(&chunk[..len]);
+                if buf.windows(3).any(|w| w == b"+++") {
+                    break;
+                }
+            }
+            Err(err) if matches!(err.kind(), std::io::ErrorKind::WouldBlock | std::io::ErrorKind::TimedOut) && !buf.is_empty() => {
+                break;
+            }
+            Err(err) => return Err(format!("directory list read failed: {}", err)),
+        }
+    }
+    let text = String::from_utf8_lossy(&buf);
+    parse_directory_list(&text)
+}
+
+fn directory_connect(cfg: &CfgEcholink) -> Result<TcpStream, String> {
+    for server in &cfg.directory_servers {
+        let server = server.trim();
+        if server.is_empty() {
+            continue;
+        }
+        let addrs = (server, cfg.directory_port)
+            .to_socket_addrs()
+            .map_err(|e| format!("directory DNS {}:{} failed: {}", server, cfg.directory_port, e))?;
+        for addr in addrs {
+            match TcpStream::connect_timeout(&addr, DIRECTORY_TIMEOUT) {
+                Ok(stream) => {
+                    let _ = stream.set_read_timeout(Some(DIRECTORY_TIMEOUT));
+                    let _ = stream.set_write_timeout(Some(DIRECTORY_TIMEOUT));
+                    return Ok(stream);
+                }
+                Err(_) => continue,
+            }
+        }
+    }
+    Err("could not connect to any EchoLink directory server".to_string())
+}
+
+fn build_audio_packet(seq: u16, payload: &[u8]) -> Vec<u8> {
+    let mut packet = Vec::with_capacity(ECHOLINK_RTP_HEADER + payload.len());
+    packet.push(0xc0);
+    packet.push(ECHOLINK_RTP_GSM_PT);
+    packet.extend_from_slice(&seq.to_be_bytes());
+    packet.extend_from_slice(&0u32.to_be_bytes());
+    packet.extend_from_slice(&0u32.to_be_bytes());
+    packet.extend_from_slice(payload);
+    packet
+}
+
+fn build_sdes_packet(callsign: &str, name: &str) -> Vec<u8> {
+    let mut packet = Vec::new();
+    packet.push(RTP_VERSION_ECHOLINK << 6);
+    packet.push(RTCP_RR);
+    packet.extend_from_slice(&1u16.to_be_bytes());
+    packet.extend_from_slice(&0u32.to_be_bytes());
+
+    let sdes_start = packet.len();
+    packet.push((RTP_VERSION_ECHOLINK << 6) | 1);
+    packet.push(RTCP_SDES);
+    packet.extend_from_slice(&0u16.to_be_bytes());
+    packet.extend_from_slice(&0u32.to_be_bytes());
+
+    add_sdes_item(&mut packet, RTCP_SDES_CNAME, "CALLSIGN");
+    let display = format!("{:<15}{}", callsign, name);
+    add_sdes_item(&mut packet, RTCP_SDES_NAME, &display);
+    add_sdes_item(&mut packet, RTCP_SDES_EMAIL, "CALLSIGN");
+    let time = chrono::Local::now().format("%H:%M").to_string();
+    add_sdes_item(&mut packet, RTCP_SDES_PHONE, &time);
+    packet.push(RTCP_SDES_END);
+    packet.push(0);
+    while (packet.len() - sdes_start) % 4 != 0 {
+        packet.push(0);
+    }
+    let len_words = ((packet.len() - sdes_start) / 4).saturating_sub(1) as u16;
+    packet[sdes_start + 2..sdes_start + 4].copy_from_slice(&len_words.to_be_bytes());
+    packet
+}
+
+fn build_bye_packet() -> Vec<u8> {
+    let mut packet = Vec::new();
+    packet.push(RTP_VERSION_ECHOLINK << 6);
+    packet.push(RTCP_RR);
+    packet.extend_from_slice(&1u16.to_be_bytes());
+    packet.extend_from_slice(&0u32.to_be_bytes());
+
+    let bye_start = packet.len();
+    packet.push((RTP_VERSION_ECHOLINK << 6) | 1);
+    packet.push(RTCP_BYE);
+    packet.extend_from_slice(&0u16.to_be_bytes());
+    packet.extend_from_slice(&0u32.to_be_bytes());
+    add_counted_text(&mut packet, "jan2002");
+    while (packet.len() - bye_start) % 4 != 0 {
+        packet.push(0);
+    }
+    let len_words = ((packet.len() - bye_start) / 4).saturating_sub(1) as u16;
+    packet[bye_start + 2..bye_start + 4].copy_from_slice(&len_words.to_be_bytes());
+    packet
+}
+
+fn add_sdes_item(packet: &mut Vec<u8>, item_type: u8, text: &str) {
+    packet.push(item_type);
+    add_counted_text(packet, text);
+}
+
+fn add_counted_text(packet: &mut Vec<u8>, text: &str) {
+    let bytes = text.as_bytes();
+    let len = bytes.len().min(255);
+    packet.push(len as u8);
+    packet.extend_from_slice(&bytes[..len]);
+}
+
+fn is_rtcp_bye(packet: &[u8]) -> bool {
+    rtcp_contains(packet, RTCP_BYE)
+}
+
+fn parse_rtcp_sdes_name(packet: &[u8]) -> Option<String> {
+    let mut offset = 0usize;
+    while offset + 4 <= packet.len() {
+        let version = (packet[offset] >> 6) & 0x03;
+        if version != RTP_VERSION_ECHOLINK && version != 1 {
+            return None;
+        }
+        let pt = packet[offset + 1];
+        let words = u16::from_be_bytes([packet[offset + 2], packet[offset + 3]]) as usize + 1;
+        let len = words * 4;
+        if len == 0 || offset + len > packet.len() {
+            return None;
+        }
+        if pt == RTCP_SDES && offset + 8 <= packet.len() {
+            let mut item = offset + 8;
+            let end = offset + len;
+            while item + 2 <= end {
+                let item_type = packet[item];
+                if item_type == RTCP_SDES_END {
+                    break;
+                }
+                let item_len = packet[item + 1] as usize;
+                if item + 2 + item_len > end {
+                    break;
+                }
+                if item_type == RTCP_SDES_NAME {
+                    return Some(String::from_utf8_lossy(&packet[item + 2..item + 2 + item_len]).to_string());
+                }
+                item += 2 + item_len;
+            }
+        }
+        offset += len;
+    }
+    None
+}
+
+fn rtcp_contains(packet: &[u8], packet_type: u8) -> bool {
+    let mut offset = 0usize;
+    while offset + 4 <= packet.len() {
+        let version = (packet[offset] >> 6) & 0x03;
+        if version != RTP_VERSION_ECHOLINK && version != 1 {
+            return false;
+        }
+        let words = u16::from_be_bytes([packet[offset + 2], packet[offset + 3]]) as usize + 1;
+        let len = words * 4;
+        if len == 0 || offset + len > packet.len() {
+            return false;
+        }
+        if packet[offset + 1] == packet_type {
+            return true;
+        }
+        offset += len;
+    }
+    false
+}
+
+fn parse_directory_list(text: &str) -> Result<Vec<DirectoryStation>, String> {
+    let mut lines = text.lines();
+    let Some(start) = lines.next() else {
+        return Err("empty directory response".to_string());
+    };
+    if start.trim() != "@@@" {
+        return Err("directory response did not start with @@@".to_string());
+    }
+    let count = lines.next().and_then(|s| s.trim().parse::<usize>().ok()).unwrap_or(0);
+    let mut stations = Vec::new();
+    for _ in 0..count {
+        let Some(callsign) = lines.next() else {
+            break;
+        };
+        if callsign.trim() == "+++" {
+            break;
+        }
+        let _data = lines.next().unwrap_or_default();
+        let id = lines.next().and_then(|s| s.trim().parse::<u32>().ok()).unwrap_or(0);
+        let ip = lines.next().and_then(|s| s.trim().parse::<IpAddr>().ok());
+        if let Some(ip) = ip {
+            let callsign = callsign.trim().to_ascii_uppercase();
+            if !callsign.is_empty() && callsign != "." && callsign != " " {
+                stations.push(DirectoryStation { callsign, id, ip });
+            }
+        }
+    }
+    Ok(stations)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn echolink_conference_targets_match_with_or_without_stars() {
+        assert!(station_matches_target("*ECHOTEST*", "ECHOTEST"));
+        assert!(station_matches_target("ECHOTEST", "*ECHOTEST*"));
+        assert!(station_matches_target("*ECHOTEST*", "*ECHOTEST*"));
+    }
+
+    #[test]
+    fn node_id_allowlist_accepts_inbound_directory_callsign() {
+        let mut cfg = CfgEcholink::default();
+        cfg.allowed_node_ids = vec![123456];
+        let stations = vec![DirectoryStation {
+            callsign: "DB0ABC-L".to_string(),
+            id: 123456,
+            ip: "192.0.2.10".parse().unwrap(),
+        }];
+
+        assert!(target_allowed(&cfg, "DB0ABC-L", None, &stations));
+        assert!(target_allowed(&cfg, "DIFFERENT-L", Some("192.0.2.10".parse().unwrap()), &stations));
+        assert!(!target_allowed(&cfg, "DB0XYZ-L", None, &stations));
+    }
+}

--- a/crates/tetra-entities/src/net_telegram/alerter.rs
+++ b/crates/tetra-entities/src/net_telegram/alerter.rs
@@ -114,6 +114,12 @@ impl TelegramAlerter {
                 Ok(TelegramAlertMsg::Dapnet { prefix, callsign, text }) => self.handle_dapnet(prefix, callsign, text),
                 Ok(TelegramAlertMsg::Meshcom { prefix, src, text }) => self.handle_dapnet(prefix, src, text),
                 Ok(TelegramAlertMsg::Geoalarm { prefix, source, text }) => self.handle_dapnet(prefix, source, text),
+                Ok(TelegramAlertMsg::EcholinkSession {
+                    prefix,
+                    remote,
+                    connected,
+                    route,
+                }) => self.handle_echolink_session(prefix, remote, connected, route),
                 Err(RecvTimeoutError::Timeout) => {}
                 Err(RecvTimeoutError::Disconnected) => break,
             }
@@ -226,6 +232,14 @@ impl TelegramAlerter {
         let tg = self.cfg.effective_telegram();
         if tg.is_deliverable() {
             let html = format::dapnet(&self.station, &prefix, &callsign, &text);
+            self.send_all(&tg, &html);
+        }
+    }
+
+    fn handle_echolink_session(&self, prefix: String, remote: String, connected: bool, route: String) {
+        let tg = self.cfg.effective_telegram();
+        if tg.is_deliverable() {
+            let html = format::echolink_session(&self.station, &prefix, &remote, connected, &route);
             self.send_all(&tg, &html);
         }
     }

--- a/crates/tetra-entities/src/net_telegram/format.rs
+++ b/crates/tetra-entities/src/net_telegram/format.rs
@@ -186,6 +186,24 @@ pub fn dapnet(station: &StationInfo, prefix: &str, callsign: &str, text: &str) -
     )
 }
 
+/// An EchoLink station opened or closed a QSO session.
+pub fn echolink_session(station: &StationInfo, prefix: &str, remote: &str, connected: bool, route: &str) -> String {
+    let prefix = truncate_chars(prefix.trim(), 32);
+    let remote = truncate_chars(remote.trim(), 64);
+    let route = truncate_chars(route.trim(), 80);
+    let state = if connected { "connected" } else { "disconnected" };
+    frame(
+        if connected { "🔗" } else { "⛓️" },
+        if prefix.is_empty() { "EchoLink" } else { &prefix },
+        &[
+            format!("Remote: <code>{}</code>", escape_html(&remote)),
+            format!("State: <b>{state}</b>"),
+            format!("TETRA route: <code>{}</code>", escape_html(&route)),
+        ],
+        station,
+    )
+}
+
 /// Station health changed level. Lists the domains that are not Ok, plus the last action taken.
 pub fn health(station: &StationInfo, snap: &crate::health::HealthSnapshot) -> String {
     use crate::health::HealthLevel;
@@ -265,6 +283,15 @@ mod tests {
         assert!(m.contains("<b>DAPNET</b>"));
         assert!(m.contains("<code>DL1ABC</code>"));
         assert!(m.contains("Test &lt;msg&gt;"));
+    }
+
+    #[test]
+    fn echolink_session_contains_remote_state_and_route() {
+        let m = echolink_session(&station(), "EchoLink", "DJ2TH", true, "GSSI 8");
+        assert!(m.contains("<b>EchoLink</b>"));
+        assert!(m.contains("<code>DJ2TH</code>"));
+        assert!(m.contains("<b>connected</b>"));
+        assert!(m.contains("<code>GSSI 8</code>"));
     }
 
     #[test]

--- a/crates/tetra-entities/src/net_telegram/mod.rs
+++ b/crates/tetra-entities/src/net_telegram/mod.rs
@@ -37,6 +37,13 @@ pub enum TelegramAlertMsg {
     Meshcom { prefix: String, src: String, text: String },
     /// A GeoAlarm geofence event forwarded through the existing Telegram alert delivery path.
     Geoalarm { prefix: String, source: String, text: String },
+    /// An EchoLink session connected or disconnected.
+    EcholinkSession {
+        prefix: String,
+        remote: String,
+        connected: bool,
+        route: String,
+    },
 }
 
 /// Cloneable, push-only handle. Cloned into the telemetry-tee and dashboard-log threads.
@@ -75,6 +82,17 @@ impl TelegramAlertSink {
     #[inline]
     pub fn send_geoalarm(&self, prefix: String, source: String, text: String) {
         let _ = self.tx.send(TelegramAlertMsg::Geoalarm { prefix, source, text });
+    }
+
+    /// Forward an EchoLink session transition to the alerter for Telegram delivery.
+    #[inline]
+    pub fn send_echolink_session(&self, prefix: String, remote: String, connected: bool, route: String) {
+        let _ = self.tx.send(TelegramAlertMsg::EcholinkSession {
+            prefix,
+            remote,
+            connected,
+            route,
+        });
     }
 }
 

--- a/crates/tetra-entities/src/umac/umac_bs.rs
+++ b/crates/tetra-entities/src/umac/umac_bs.rs
@@ -1699,6 +1699,26 @@ impl UmacBs {
                     }
                 }
 
+                // Forward UL voice to EchoLink if the bridge is enabled. The EchoLink entity keeps
+                // its own ts -> QSO map and ignores unrelated circuits.
+                if self.config.effective_echolink().enabled {
+                    if self.scheduler_for(carrier_num).circuit_is_active(Direction::Ul, ts) {
+                        let msg = SapMsg {
+                            sap: Sap::TmdSap,
+                            src: TetraEntity::Umac,
+                            dest: TetraEntity::Echolink,
+                            msg: SapMsgInner::TmdCircuitDataInd(tetra_saps::tmd::TmdCircuitDataInd {
+                                carrier_num,
+                                ts,
+                                data: data.clone(),
+                            }),
+                        };
+                        queue.push_back(msg);
+                    } else {
+                        tracing::trace!("rx_tmd_prim: no active UL circuit on ts={}, dropping UL voice to EchoLink", ts);
+                    }
+                }
+
                 // Determine DL target timeslot:
                 //   - Full-duplex P2P (local): UL on `ts` cross-routed to peer MS's DL on `peer_ts`.
                 //   - Group / simplex (LocalLoopback, no peer_ts): same-ts loopback so all members hear.

--- a/crates/tetra-entities/tests/common/default_stack.rs
+++ b/crates/tetra-entities/tests/common/default_stack.rs
@@ -1,6 +1,6 @@
 use tetra_config::bluestation::{
-    CfgAsterisk, CfgCellInfo, CfgDapnet, CfgEmergency, CfgGeoalarm, CfgHealth, CfgMeshcom, CfgNetInfo, CfgPhyIo, CfgRecovery, CfgSecurity,
-    CfgSnomNotify, CfgTpg2200Action, CfgWxService, PhyBackend, StackConfig, StackMode,
+    CfgAsterisk, CfgCellInfo, CfgDapnet, CfgEcholink, CfgEmergency, CfgGeoalarm, CfgHealth, CfgMeshcom, CfgNetInfo, CfgPhyIo, CfgRecovery,
+    CfgSecurity, CfgSnomNotify, CfgTpg2200Action, CfgWxService, PhyBackend, StackConfig, StackMode,
 };
 use tetra_core::{freqs::FreqInfo, ranges::SortedDisjointSsiRanges};
 
@@ -23,6 +23,7 @@ pub fn default_test_config_bs() -> StackConfig {
         brew: None,
         asterisk: CfgAsterisk::default(),
         dapnet: CfgDapnet::default(),
+        echolink: CfgEcholink::default(),
         geoalarm: CfgGeoalarm::default(),
         meshcom: CfgMeshcom::default(),
         tpg2200_action: CfgTpg2200Action::default(),

--- a/example_config/config.toml
+++ b/example_config/config.toml
@@ -732,6 +732,52 @@ voice_service = true
 
 ###############################################################################
 
+# OPTIONAL: EchoLink directory and audio bridge
+#
+# Registers the station in the public EchoLink directory and bridges GSM-FR
+# audio to TETRA. Voice support requires a binary built with --features echolink
+# plus libgsm and the native tetra-codec library.
+#
+# Inbound EchoLink QSOs are simplex/P2MP group calls. Set default_tetra_dest_issi
+# to a GSSI and keep default_tetra_dest_is_group enabled. Outbound TETRA calls
+# can use either the prefix plus an EchoLink node ID or an explicit dial route.
+# Empty allowlists accept every remote station; otherwise callsign or node ID
+# must match. The normal network call lifecycle prevents media loops.
+#
+# [echolink]
+# enabled = false
+# callsign = "YOURCALL-L"
+# password = ""
+# location = "FlowStation"
+# status_text = "FlowStation EchoLink bridge"
+# directory_servers = ["servers.echolink.org", "backup.echolink.org"]
+# directory_port = 5200
+# bind_addr = "0.0.0.0"
+# audio_port = 5198
+# control_port = 5199
+#
+# inbound_enabled = true
+# outbound_enabled = true
+# outbound_prefix = "92"              # dial 92123456 to reach node 123456
+# strip_outbound_prefix = true
+# service_numbers = ["700"]
+# routes = { "700" = "ECHOTEST" }
+#
+# allowed_callsigns = []              # e.g. ["ECHOTEST", "DB0ABC-L"]
+# allowed_node_ids = []               # e.g. [9999, 123456]
+# auto_connect = ""
+# reconnect_interval_secs = 30
+# max_session_secs = 3600
+#
+# default_tetra_source_issi = 9999
+# default_tetra_dest_issi = 26225      # inbound destination GSSI
+# default_tetra_dest_is_group = true
+#
+# telegram_session_alerts = false
+# telegram_session_prefix = "EchoLink"
+
+###############################################################################
+
 # OPTIONAL: Snom/desk-phone ActionURL trigger for Motorola TPG2200 Call-Out
 #
 # Configure a Snom function key / ActionURL to call:


### PR DESCRIPTION
## Summary

- add the EchoLink directory, UDP control, GSM-FR/TETRA audio bridge, simplex/P2MP routing, call ownership, floor handling, and teardown
- add runtime configuration, callsign/node allowlists, dashboard persistence, directory search, connect/disconnect controls, health state, and optional Telegram session alerts
- keep native audio codecs behind the `echolink` feature so the default build does not gain mandatory Brew/voice packages
- document installation, firewall ports, feature builds, routing, configuration, and the annotated example config

## Validation

- `DOCS_RS=1 cargo check -p tetra-entities`
- `DOCS_RS=1 cargo check -p bluestation-bs --no-default-features`
- `DOCS_RS=1 cargo check -p bluestation-bs --no-default-features --features echolink`
- `DOCS_RS=1 cargo test -p tetra-config` (36 passed)
- `DOCS_RS=1 cargo test -p tetra-entities --lib` (195 passed, 5 ignored)
- targeted EchoLink allowlist and TOML persistence tests
- embedded dashboard JavaScript syntax check
- `git diff --check`

## Build note

EchoLink QSO audio requires `libgsm1-dev`, the native `tetra-codec` library, and:

```bash
cargo build --release --features echolink
```

The default build retains EchoLink configuration, directory status, and dashboard support without linking the native voice codecs.
