### PR TITLE
fix(dashboard): drop localhost-only control gate that blocked DGNA

### DIFF
--- a/crates/tetra-entities/src/net_dashboard/server.rs
+++ b/crates/tetra-entities/src/net_dashboard/server.rs
@@ -1434,11 +1434,6 @@ fn handle_connection(
 ) {
     let _ = stream.set_read_timeout(Some(std::time::Duration::from_millis(500)));
 
-    // Capture the peer's loopback status before the stream is moved into any handler. When the
-    // dashboard runs with no auth, mutating requests (POST, WS upgrade) are restricted to localhost
-    // (the gate below). A failed peer lookup is treated as non-loopback (fail closed).
-    let peer_is_loopback = stream.peer_addr().map(|a| a.ip().is_loopback()).unwrap_or(false);
-
     // ── Read the first 4KB of headers into a buffer, peek first for routing ──
     // We need to both route on the request line AND read the Authorization header,
     // so we collect all headers before dispatching.
@@ -1608,34 +1603,13 @@ fn handle_connection(
         }
     }
 
-    // No-auth gate: when no credentials are configured the dashboard is open, so a mutating HTTP
-    // request (a POST that writes config, triggers an update, kicks a radio, etc.) must come from
-    // localhost. Read-only GETs are still served so a LAN overview keeps working. This is independent
-    // of the cookie gate above (which is inert without auth) and closes the "open dashboard on the
-    // LAN can change config / restart the BS" path even if the operator binds wide.
-    //
-    // The /ws WebSocket is intentionally NOT blocked here. It is the dashboard's live read-only feed
-    // (the initial snapshot plus every push: calls, traffic, registered radios, health), so 403-ing
-    // the upgrade left every off-host browser staring at an empty page with the BS shown as
-    // unavailable. We let the upgrade through and refuse the control commands that ride over it
-    // (restart/shutdown/dgna/sds/kick) inside handle_ws_command instead, so an off-host client without
-    // auth still gets a read-only view but cannot drive the stack.
-    if auth.is_none() && !peer_is_loopback && req_line.starts_with("POST ") {
-        drain_http_headers(&mut stream);
-        tracing::warn!(
-            "Dashboard: rejected unauthenticated off-host {} (mutations are localhost-only without auth)",
-            req_line
-        );
-        http_response(stream, 403, "Forbidden — set dashboard credentials for off-host control");
-        return;
-    }
-
+    // Access control is the cookie gate above: with credentials configured the dashboard requires a
+    // login for everything; without credentials it is fully open (the home-network default). We do
+    // NOT additionally restrict control by the peer's address — "is this localhost?" can't tell a
+    // browser running on the BTS that connects via the box's LAN IP from a remote one, so it wrongly
+    // blocked operators doing DGNA/SDS from the BTS itself. Set a username/password to lock it down.
     if req_line.contains("/ws") {
-        // The WS opens for everyone who reached this far (so the live read-only feed works off-host),
-        // but control commands over it are only honoured for an authenticated session or a localhost
-        // peer — same line the POST gate above draws.
-        let ws_control_allowed = auth.is_some() || peer_is_loopback;
-        handle_ws(stream, state, clients, cmd_tx, update_state, ws_control_allowed);
+        handle_ws(stream, state, clients, cmd_tx, update_state);
     } else if req_line.contains("GET /api/system/brightness") {
         // Backlight status probe (FH-FEAT-008) — lets the UI hide the slider on a panel-less host.
         drain_http_headers(&mut stream);
@@ -2272,13 +2246,11 @@ fn handle_ws(
     clients: WsClients,
     cmd_tx: Arc<Mutex<Option<CmdSender>>>,
     update_state: SharedUpdateState,
-    control_allowed: bool,
 ) {
     let _ = stream.set_read_timeout(Some(std::time::Duration::from_millis(50)));
 
     // Note: cookie-based auth is checked by handle_connection BEFORE we get here, so we don't
-    // re-validate during the WS upgrade. `control_allowed` carries the off-host/no-auth decision made
-    // there: when false the connection is read-only and inbound control commands are dropped.
+    // re-validate during the WS upgrade. The cookie travelled on the Upgrade request.
     let callback = move |_req: &Request, res: Response| -> Result<Response, _> { Ok(res) };
 
     let mut ws = match accept_hdr(stream, callback) {
@@ -2348,7 +2320,7 @@ fn handle_ws(
         // Then check for inbound messages from browser
         match ws.read() {
             Ok(Message::Text(text)) => {
-                handle_ws_command(&text, &state, &cmd_tx, &update_state, control_allowed);
+                handle_ws_command(&text, &state, &cmd_tx, &update_state);
             }
             Ok(Message::Close(_)) => break,
             Ok(Message::Ping(data)) => {
@@ -2367,29 +2339,12 @@ fn handle_ws_command(
     state: &DashboardState,
     cmd_tx: &Arc<Mutex<Option<CmdSender>>>,
     update_state: &SharedUpdateState,
-    control_allowed: bool,
 ) {
     let Ok(v) = serde_json::from_str::<serde_json::Value>(text) else {
         return;
     };
 
     let cmd_type = v.get("type").and_then(|t| t.as_str());
-
-    // A read-only connection (off-host without auth) still receives every live update, but it cannot
-    // drive the stack: drop the control commands here, mirroring the POST gate in handle_connection.
-    // `subscribe` and any unknown type are no-ops, so they fall through to the match below untouched.
-    if !control_allowed
-        && matches!(
-            cmd_type,
-            Some("kick" | "restart" | "shutdown" | "update" | "sds" | "dgna" | "emergency_clear")
-        )
-    {
-        tracing::warn!(
-            "Dashboard: ignored off-host WS '{}' command (set credentials for off-host control)",
-            cmd_type.unwrap_or("")
-        );
-        return;
-    }
 
     let send_cmd = |cmd: ControlCommand| -> bool {
         if let Ok(guard) = cmd_tx.lock() {
@@ -5269,36 +5224,6 @@ enabled = true
             server_version: 0,
         });
         assert_eq!(v(), 1, "reconnect reporting v0 must not downgrade a confirmed v1");
-    }
-
-    /// FH-BUG-055/056 regression: an off-host client without auth gets a read-only WS. Live data
-    /// still streams to it (the upgrade succeeds — that path is what was broken), but a control
-    /// command travelling over the socket must be dropped rather than dispatched. The same command
-    /// from a localhost or authenticated peer (control_allowed = true) reaches the dispatcher.
-    #[test]
-    fn offhost_ws_control_is_read_only() {
-        use super::{UpdateState, handle_ws_command};
-        use crate::net_control::commands::ControlCommand;
-        use std::sync::{Arc, Mutex};
-
-        let server = DashboardServer::new("/tmp/fs_ws_gate_test_config.toml".to_string());
-        let state = server.state.clone();
-        let update_state = Arc::new(Mutex::new(UpdateState::new()));
-        let (tx, rx) = crossbeam_channel::unbounded::<ControlCommand>();
-        let cmd_tx = Arc::new(Mutex::new(Some(tx)));
-
-        let kick = r#"{"type":"kick","issi":123}"#;
-
-        // Read-only peer: the kick is ignored, nothing reaches the control dispatcher.
-        handle_ws_command(kick, &state, &cmd_tx, &update_state, false);
-        assert!(rx.try_recv().is_err(), "off-host kick must not be dispatched");
-
-        // Localhost / authenticated peer: the same kick is dispatched.
-        handle_ws_command(kick, &state, &cmd_tx, &update_state, true);
-        match rx.try_recv() {
-            Ok(ControlCommand::KickMs { issi }) => assert_eq!(issi, 123),
-            other => panic!("expected KickMs dispatch, got {other:?}"),
-        }
     }
 
     #[test]


### PR DESCRIPTION
## The bug (FH-BUG, EA7KEN)

Operators sending DGNA from the dashboard got nothing, with this in the log:

```
WARN [net_dashboard] server.rs: Dashboard: ignored off-host WS 'dgna' command (set credentials for off-host control)
```

It happens **even when the operator is on the BTS itself**. The off-host hardening gated WS control commands (and POST mutations) on the peer being `127.0.0.1` when no credentials are configured. But a browser running on the BTS that opens the dashboard via the box's **LAN IP** (`http://<bts-ip>:8080`) is not loopback — so the gate treated the operator as a hostile off-host client and dropped the command. "Is the peer localhost" is simply not a reliable proxy for "is this the operator": LAN-IP access from the same machine, a second device on the desk, a reverse proxy — all look non-loopback.

## The fix

Remove the peer-address gate entirely — both the WS command gate and the POST off-host gate. Access control is the cookie auth, which is the right mechanism:

- **No credentials set** → the dashboard is fully open (the home-network default, and how it worked before the hardening).
- **`username`/`password` set** → every request needs a login, from anywhere.

So if you want the dashboard locked down, set credentials; otherwise it just works for the operator regardless of how they reach it. Net: −83/+8 lines, removing the broken heuristic.

## Testing
- `cargo test --workspace` green (entities lib 191, all integration suites); clippy clean (no new warnings).
- Removed the now-obsolete `offhost_ws_control_is_read_only` test that asserted the deleted behavior.
