### PR TITLE
dgna: send talkgroup display name as the ASSIGN mnemonic (for beta)

### DIFF
--- a/crates/tetra-config/src/bluestation/parsing.rs
+++ b/crates/tetra-config/src/bluestation/parsing.rs
@@ -665,6 +665,22 @@ main_carrier_number = 1586
     }
 
     #[test]
+    fn dgna_group_names_parse_string_keys_to_gssi() {
+        let cfg = from_toml_str(&minimal_toml(
+            r#"dgna_group_names = { "22" = "Echo", "1" = "Main", "bad" = "Dropped" }"#,
+        ))
+        .expect("parse");
+        assert_eq!(cfg.cell.dgna_group_names.get(&22).map(String::as_str), Some("Echo"));
+        assert_eq!(cfg.cell.dgna_group_names.get(&1).map(String::as_str), Some("Main"));
+        // A non-numeric GSSI key is dropped, not a parse error.
+        assert_eq!(cfg.cell.dgna_group_names.len(), 2);
+
+        // Absent => empty map (no names sent).
+        let cfg = from_toml_str(&minimal_toml("")).expect("parse");
+        assert!(cfg.cell.dgna_group_names.is_empty());
+    }
+
+    #[test]
     fn telegram_alerts_section_parses() {
         let toml = minimal_toml("")
             + r#"

--- a/crates/tetra-config/src/bluestation/sec_cell.rs
+++ b/crates/tetra-config/src/bluestation/sec_cell.rs
@@ -218,6 +218,12 @@ pub struct CfgCellInfo {
     /// IDENTITY (EN 300 392-2 V2.4.1 cl.16.8) which only toggles the L2 attachment of a group the
     /// radio already knows. Kept as a rollback switch for the SS-DGNA rollout.
     pub dgna_use_ss_facility: bool,
+
+    /// Optional display names for talkgroups, keyed by GSSI. When an operator assigns a group via
+    /// DGNA, the SS-DGNA ASSIGN carries this name as the mnemonic so a terminal that renders it shows
+    /// the name instead of the bare number. Empty = no names sent (the radio shows its own provisioned
+    /// name, or the GSSI). Names are ISO-8859-1 and truncated to 15 characters on the air.
+    pub dgna_group_names: HashMap<u32, String>,
 }
 
 #[derive(Default, Deserialize)]
@@ -297,6 +303,10 @@ pub struct CellInfoDto {
     /// Emit operator DGNA as an SS-DGNA D-FACILITY. Absent = true (the SS-DGNA path is the
     /// default); set false to roll back to the legacy MM D-ATTACH/DETACH GROUP IDENTITY path.
     pub dgna_use_ss_facility: Option<bool>,
+
+    /// Talkgroup display names keyed by GSSI (as a string in TOML), e.g.
+    /// `dgna_group_names = { "22" = "Echo", "1" = "Main" }`. Carried as the SS-DGNA ASSIGN mnemonic.
+    pub dgna_group_names: Option<HashMap<String, String>>,
 
     #[serde(flatten)]
     pub extra: HashMap<String, Value>,
@@ -383,6 +393,13 @@ pub fn cell_dto_to_cfg(ci: CellInfoDto) -> CfgCellInfo {
         }),
         release_group_on_same_speaker_retake: ci.release_group_on_same_speaker_retake.unwrap_or(false),
         dgna_use_ss_facility: ci.dgna_use_ss_facility.unwrap_or(true),
+        // GSSI keys arrive as TOML strings; drop any that don't parse as a number.
+        dgna_group_names: ci
+            .dgna_group_names
+            .unwrap_or_default()
+            .into_iter()
+            .filter_map(|(k, v)| k.trim().parse::<u32>().ok().map(|gssi| (gssi, v)))
+            .collect(),
     }
 }
 

--- a/crates/tetra-entities/src/cmce/cmce_bs.rs
+++ b/crates/tetra-entities/src/cmce/cmce_bs.rs
@@ -283,7 +283,21 @@ impl TetraEntityTrait for CmceBs {
                     };
                     // MM owns the group registry/affiliation; it has already committed the change and
                     // asks CMCE only to put the SS-DGNA ASSIGN/DEASSIGN on the air as a D-FACILITY.
-                    self.ss.send_d_facility_dgna(queue, issi, gssi, attach);
+                    // A configured display name for the GSSI rides along as the mnemonic so terminals
+                    // that render it show the talkgroup name instead of the number. The name is copied
+                    // into an owned buffer so the config lock is released before the send.
+                    let group_name = if attach {
+                        self.config
+                            .config()
+                            .cell
+                            .dgna_group_names
+                            .get(&gssi)
+                            .map(|name| dgna_mnemonic_bytes(name))
+                            .filter(|b| !b.is_empty())
+                    } else {
+                        None
+                    };
+                    self.ss.send_d_facility_dgna(queue, issi, gssi, attach, group_name);
                 }
                 ControlRoute::Unsupported => {
                     panic!("Unexpected control message: {:?}", message.msg);
@@ -293,5 +307,27 @@ impl TetraEntityTrait for CmceBs {
                 panic!("Unexpected SAP: {:?}", message.sap);
             }
         }
+    }
+}
+
+/// Encode a talkgroup display name for the SS-DGNA mnemonic: ISO-8859-1 octets (non-Latin characters
+/// become '?'), truncated to the 15-character on-air limit (EN 300 392-9 V1.7.1 table 15).
+fn dgna_mnemonic_bytes(name: &str) -> Vec<u8> {
+    name.chars()
+        .take(15)
+        .map(|c| if (c as u32) <= 0xFF { c as u8 } else { b'?' })
+        .collect()
+}
+
+#[cfg(test)]
+mod dgna_mnemonic_tests {
+    use super::dgna_mnemonic_bytes;
+
+    #[test]
+    fn truncates_to_15_and_maps_non_latin() {
+        assert_eq!(dgna_mnemonic_bytes("Echo"), b"Echo");
+        assert_eq!(dgna_mnemonic_bytes("0123456789ABCDEF").len(), 15, "capped at 15 chars");
+        assert_eq!(dgna_mnemonic_bytes("café"), vec![b'c', b'a', b'f', 0xE9], "é is ISO-8859-1 0xE9");
+        assert_eq!(dgna_mnemonic_bytes("日本"), vec![b'?', b'?'], "non-Latin -> '?'");
     }
 }

--- a/crates/tetra-entities/src/cmce/subentities/ss_bs.rs
+++ b/crates/tetra-entities/src/cmce/subentities/ss_bs.rs
@@ -42,14 +42,22 @@ impl SsBsSubentity {
     /// ASSIGN uses attachment mode 000 (attached permanently, TS Table 51) so
     /// the PDU both defines and attaches the group in one step (cl.6.5.2.1) —
     /// the same MLE handoff the MM D-ATTACH does, but only after the radio has
-    /// the group definition. No mnemonic is carried in v1: a real terminal shows
-    /// its own provisioned name for the GSSI, or the bare number.
+    /// the group definition. The optional `group_name` is carried as the SS-DGNA mnemonic so a
+    /// terminal that renders it shows the talkgroup name instead of the bare GSSI; when `None`, the
+    /// radio falls back to its own provisioned name (or the number).
     ///
     /// Reliability rests on the LLC ACK of the FACILITY transport, not a
     /// DGNA-layer retransmit (cl.6.6 mandates no protocol timer), so this is sent
     /// with `Layer2Service::Acknowledged` — the same choice the MM DGNA path made
     /// for its individually-addressed D-ATTACH.
-    pub fn send_d_facility_dgna(&self, queue: &mut MessageQueue, issi: u32, gssi: u32, attach: bool) {
+    pub fn send_d_facility_dgna(
+        &self,
+        queue: &mut MessageQueue,
+        issi: u32,
+        gssi: u32,
+        attach: bool,
+        group_name: Option<Vec<u8>>,
+    ) {
         let ss_pdu = if attach {
             SsDgnaPdu::Assign(Assign {
                 groups: vec![GroupAssignment {
@@ -59,8 +67,9 @@ impl SsBsSubentity {
                     // update, matching the persistent (lifetime=0) MM D-ATTACH the legacy path sent.
                     attachment_mode: GroupIdentityAttachmentMode::AttachedPermanently,
                     class_of_usage: Some(DGNA_CLASS_OF_USAGE),
-                    // No group-name config in v1 — the radio displays its own provisioned name.
-                    mnemonic: None,
+                    // Optional talkgroup display name (config dgna_group_names), shown by terminals
+                    // that render the DGNA mnemonic.
+                    mnemonic: group_name,
                     security_related_information: None,
                     additional_group_information: None,
                     vgssi: None,

--- a/crates/tetra-entities/tests/common/default_stack.rs
+++ b/crates/tetra-entities/tests/common/default_stack.rs
@@ -96,6 +96,7 @@ pub fn default_cell_info(freq_info: FreqInfo) -> CfgCellInfo {
         sds_command_control: None,
         release_group_on_same_speaker_retake: false,
         dgna_use_ss_facility: true,
+        dgna_group_names: std::collections::HashMap::new(),
     }
 }
 

--- a/crates/tetra-pdus/src/cmce/ss_dgna/fields/group_assignment.rs
+++ b/crates/tetra-pdus/src/cmce/ss_dgna/fields/group_assignment.rs
@@ -85,9 +85,9 @@ impl GroupAssignment {
         // Class of usage (type-2), 3b.
         let class_of_usage = typed::parse_type2_generic(obit, buf, 3, "class_of_usage")?.map(|v| v as u8);
 
-        // Mnemonic group name (type-2): P-bit, then 6b length (octet count),
-        // then length octets of ISO-8859-1.
-        let mnemonic = Self::parse_type2_octets(obit, buf, "mnemonic")?;
+        // Mnemonic group name (type-2): P-bit, then the EN 300 392-9 V1.7.1 table 17 character-string
+        // element (7b text coding scheme, 8b length-in-bits, then the characters).
+        let mnemonic = Self::parse_type2_mnemonic(obit, buf)?;
 
         // Security related information (type-2): same length+value shape.
         let security_related_information = Self::parse_type2_octets(obit, buf, "security_related_information")?;
@@ -141,15 +141,9 @@ impl GroupAssignment {
 
         // Type-2 elements, each preceded by its P-bit, in Table 45 order.
         typed::write_type2_generic(obit, buf, self.class_of_usage.map(|v| v as u64), 3);
-        // FIXME(C2): the mnemonic group name is framed here as P-bit + 6-bit octet count + N octets,
-        // the same opaque shape as the security / additional-group fields. A display name is really a
-        // TETRA text string (coding-scheme byte + length, like net_brew's SS-TPI mnemonic), so the
-        // octet-count framing is likely wrong and, since the mnemonic precedes the remaining type-2
-        // elements, a populated one would shift every following P-bit. This is latent: the only
-        // constructor (ss_bs.rs) hard-codes mnemonic = None, so it is never emitted on-air. Before any
-        // path populates it, give the mnemonic its own writer using the TETRA text format and verify
-        // the exact widths against TS 100 392-12-22 V1.5.1 Table 45.
-        Self::write_type2_octets(obit, buf, &self.mnemonic)?;
+        // The mnemonic group name is a TETRA character string, framed per EN 300 392-9 V1.7.1 table 17
+        // (clause 8.4.2) — NOT the 6-bit-octet-count shape the security / additional-group fields use.
+        Self::write_type2_mnemonic(obit, buf, &self.mnemonic)?;
         Self::write_type2_octets(obit, buf, &self.security_related_information)?;
         Self::write_type2_octets(obit, buf, &self.additional_group_information)?;
         typed::write_type2_generic(obit, buf, self.vgssi.map(|v| v as u64), 24);
@@ -200,6 +194,57 @@ impl GroupAssignment {
         }
         Ok(())
     }
+
+    /// Parse the mnemonic group name (type-2). Per EN 300 392-9 V1.7.1 table 17 the value is a
+    /// character-string element: 7-bit text coding scheme, 8-bit length (in *bits*), then the
+    /// characters. We return the raw character octets (`bit_len / 8`), which round-trips an 8-bit
+    /// coding scheme losslessly and keeps any other scheme's bytes intact.
+    fn parse_type2_mnemonic(obit: bool, buf: &mut BitBuffer) -> Result<Option<Vec<u8>>, PduParseErr> {
+        if !obit {
+            return Ok(None);
+        }
+        if !delimiters::read_pbit(buf)? {
+            return Ok(None);
+        }
+        let _coding_scheme = buf.read_field(7, "mnemonic_coding_scheme")?;
+        let bit_len = buf.read_field(8, "mnemonic_length")? as usize;
+        let octet_count = bit_len / 8;
+        let mut bytes = Vec::with_capacity(octet_count);
+        for _ in 0..octet_count {
+            bytes.push(buf.read_field(8, "mnemonic")? as u8);
+        }
+        Ok(Some(bytes))
+    }
+
+    /// Write the mnemonic group name (type-2) per EN 300 392-9 V1.7.1 table 17 (clause 8.4.2): P-bit,
+    /// 7-bit text coding scheme (1 = ISO-8859-1), 8-bit length in *bits*, then the characters as 8-bit
+    /// octets. The display name is at most 15 characters (table 15), so the bit length fits 8 bits.
+    fn write_type2_mnemonic(obit: bool, buf: &mut BitBuffer, value: &Option<Vec<u8>>) -> Result<(), PduParseErr> {
+        if !obit {
+            assert!(value.is_none(), "Type2 element cannot be present when obit is false");
+            return Ok(());
+        }
+        match value {
+            Some(chars) => {
+                if chars.len() > 15 {
+                    return Err(PduParseErr::InvalidValue {
+                        field: "mnemonic_length",
+                        value: chars.len() as u64,
+                    });
+                }
+                delimiters::write_pbit(buf, 1);
+                buf.write_bits(0x01, 7); // text coding scheme: ISO-8859-1 (8-bit characters)
+                buf.write_bits((chars.len() * 8) as u64, 8); // length of the mnemonic name, in bits
+                for c in chars {
+                    buf.write_bits(*c as u64, 8);
+                }
+            }
+            None => {
+                delimiters::write_pbit(buf, 0);
+            }
+        }
+        Ok(())
+    }
 }
 
 impl fmt::Display for GroupAssignment {
@@ -216,5 +261,59 @@ impl fmt::Display for GroupAssignment {
             self.additional_group_information,
             self.vgssi
         )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::cmce::ss_dgna::enums::results::GroupIdentityAttachmentMode;
+
+    /// The mnemonic group name must be framed exactly as EN 300 392-9 V1.7.1 table 17: P-bit, 7-bit
+    /// text coding scheme (1 = ISO-8859-1), 8-bit length in bits, then the characters. A radio that
+    /// renders DGNA names relies on this layout, so pin the exact bits for "TG" on GSSI 22.
+    #[test]
+    fn mnemonic_matches_en300392_9_table_17() {
+        let ga = GroupAssignment {
+            group_ssi: 22,
+            group_extension: None,
+            attachment_mode: GroupIdentityAttachmentMode::AttachedPermanently,
+            class_of_usage: None,
+            mnemonic: Some(b"TG".to_vec()),
+            security_related_information: None,
+            additional_group_information: None,
+            vgssi: None,
+        };
+        let mut buf = BitBuffer::new_autoexpand(16);
+        ga.to_bitbuf(&mut buf).expect("serialize");
+        let total = buf.get_pos();
+        buf.seek(0);
+        let got: String = (0..total)
+            .map(|_| if buf.read_bits(1).unwrap() == 1 { '1' } else { '0' })
+            .collect();
+        assert_eq!(got, "00000000000000000001011000001010000001000100000101010001000111000");
+    }
+
+    /// A populated mnemonic round-trips: the character octets survive write -> parse unchanged, and
+    /// the surrounding type-2 elements stay aligned (security/vgssi still decode).
+    #[test]
+    fn mnemonic_round_trips_with_other_type2_fields() {
+        let ga = GroupAssignment {
+            group_ssi: 1234,
+            group_extension: None,
+            attachment_mode: GroupIdentityAttachmentMode::AttachedPermanently,
+            class_of_usage: Some(4),
+            mnemonic: Some(b"Echo-1".to_vec()),
+            security_related_information: None,
+            additional_group_information: None,
+            vgssi: Some(987654),
+        };
+        let mut buf = BitBuffer::new_autoexpand(32);
+        ga.to_bitbuf(&mut buf).expect("serialize");
+        buf.seek(0);
+        let parsed = GroupAssignment::from_bitbuf(&mut buf).expect("parse");
+        assert_eq!(parsed, ga);
+        assert_eq!(parsed.mnemonic.as_deref(), Some(&b"Echo-1"[..]));
+        assert_eq!(parsed.vgssi, Some(987654));
     }
 }

--- a/crates/tetra-pdus/src/cmce/ss_dgna/pdus/assign.rs
+++ b/crates/tetra-pdus/src/cmce/ss_dgna/pdus/assign.rs
@@ -215,10 +215,11 @@ mod tests {
         assert_eq!(&s[28..29], "1", "O-bit set");
         assert_eq!(&s[29..30], "0", "P-bit for class of usage = 0 (absent)");
         assert_eq!(&s[30..31], "1", "P-bit for mnemonic = 1 (present)");
-        // 6-bit length = 2 octets.
-        assert_eq!(&s[31..37], "000010", "mnemonic length = 2");
-        assert_eq!(&s[37..45], "01000001", "first octet 'A' (0x41)");
-        assert_eq!(&s[45..53], "01000010", "second octet 'B' (0x42)");
+        // Mnemonic per EN 300 392-9 table 17: 7-bit coding scheme, 8-bit length-in-bits, then chars.
+        assert_eq!(&s[31..38], "0000001", "text coding scheme = 1 (ISO-8859-1)");
+        assert_eq!(&s[38..46], "00010000", "mnemonic length = 16 bits (2 chars)");
+        assert_eq!(&s[46..54], "01000001", "first char 'A' (0x41)");
+        assert_eq!(&s[54..62], "01000010", "second char 'B' (0x42)");
 
         // Round-trip both.
         for ga in [absent, present] {

--- a/example_config/config.toml
+++ b/example_config/config.toml
@@ -186,6 +186,13 @@ voice_service = true
 # Absent = true. Set false only to roll back to the legacy path.
 # dgna_use_ss_facility = true
 
+# Optional talkgroup display names, keyed by GSSI. When you assign a group via DGNA, the SS-DGNA
+# ASSIGN carries this name as the mnemonic, so a terminal that renders DGNA names shows the name
+# instead of the bare number. Names are ISO-8859-1 and truncated to 15 characters on the air.
+# NB: same codeplug caveat as above — a terminal that doesn't render the DGNA mnemonic still shows
+# its own provisioned name (or the number) regardless of what we send.
+# dgna_group_names = { "22" = "Echo", "1" = "Main" }
+
 # Maximum active call duration in seconds — ETSI EN 300 392-2 §14.9.1 T310 equivalent (FlowStation).
 # After this time the BS sends D-RELEASE regardless of call activity.
 # 0 = no limit (infinite — call runs until U-DISCONNECT or hangtime).


### PR DESCRIPTION
## Bug 2 — DGNA shows the number, operator wants the talkgroup name

From the log, DGNA assigns the group fine (the radio ACKs Accepted/Attached and calls GSSI 22) — decoding the on-air ASSIGN confirms it carries exactly `group_ssi: 22`. The problem is purely the **display**: the ASSIGN sent **no name** (`mnemonic: None`), so the radio shows the bare number.

This lets the operator name talkgroups and sends the name as the SS-DGNA mnemonic.

## What's in it
- **Config**: `[cell_info] dgna_group_names = { "22" = "Echo", "1" = "Main" }` — a GSSI→name map. GSSI keys are TOML strings parsed to numbers; a non-numeric key is dropped, not a parse error.
- **Plumbing**: CMCE looks up the name for the assigned GSSI (config lock released before the send) and passes it to `send_d_facility_dgna`, which sets it as the mnemonic. Names are ISO-8859-1, non-Latin characters become `?`, truncated to the 15-char on-air limit.
- **Encoding fix**: the mnemonic was framed as a 6-bit octet count — wrong, and since it precedes the other type-2 fields a populated one would have **mis-framed the whole ASSIGN**. It's now the **EN 300 392-9 V1.7.1 table 17** character string (7-bit text coding scheme = ISO-8859-1, 8-bit length-in-bits, then the chars), pinned by a bit-exact test. There was a FIXME in the code warning exactly this; it's now resolved. No mnemonic was ever emitted before, so configs without names are byte-identical on air.

## Important caveat
Whether the name actually appears is **terminal-dependent**. A radio that doesn't render the DGNA mnemonic still shows its own codeplug name (or the number), same as today — the example config already notes this next to the existing "DGNA notification must be provisioned in the codeplug" caveat. So: this is the correct BS-side behavior, but if your radio ignores it, the fallback is to provision the name in the codeplug.

## Why beta
It's an air-interface change to the SS-DGNA ASSIGN PDU. Tests are bit-exact and green, but it wants a **real-radio check** that a named DGNA shows the name on a terminal that supports it.

## Testing
- `cargo test --workspace` green: new bit-exact mnemonic test (table 17), round-trip with other type-2 fields, name truncation/Latin-mapping, config string-key→GSSI parse; all existing DGNA tests (cmce/mm integration) still pass.
- clippy clean; example_config parses.
