### PR TITLE
v0.3.9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -156,7 +156,7 @@ dependencies = [
 
 [[package]]
 name = "bluestation-bs"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "clap",
  "crossbeam-channel",
@@ -1833,7 +1833,7 @@ dependencies = [
 
 [[package]]
 name = "tetra-config"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "chrono-tz",
  "serde",
@@ -1843,7 +1843,7 @@ dependencies = [
 
 [[package]]
 name = "tetra-core"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "bitcode",
  "chrono",
@@ -1859,7 +1859,7 @@ dependencies = [
 
 [[package]]
 name = "tetra-entities"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "as-any",
  "base64",
@@ -1892,7 +1892,7 @@ dependencies = [
 
 [[package]]
 name = "tetra-pdus"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "tetra-config",
  "tetra-core",
@@ -1902,7 +1902,7 @@ dependencies = [
 
 [[package]]
 name = "tetra-saps"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "tetra-core",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,7 +86,7 @@ useless_format = "allow"
 while_let_loop = "allow"
 
 [workspace.package]
-version = "0.3.8"
+version = "0.3.9"
 edition = "2024"
 authors = ["Razvan Zeces / FlowStation.Dev"]
 license = "MIT"

--- a/crates/tetra-entities/src/cmce/subentities/cc_bs/state/mod.rs
+++ b/crates/tetra-entities/src/cmce/subentities/cc_bs/state/mod.rs
@@ -269,7 +269,16 @@ impl ActiveCall {
     #[inline]
     pub(super) fn call_timeout_expired(&self, now: TdmaTime) -> bool {
         match call_timeout_to_timeslots(self.call_timeout) {
-            Some(timeout) => self.last_activity_at.age(now) > timeout,
+            // ETSI EN 300 392-2 §14: the call time-out timer bounds the MAXIMUM duration of a
+            // call, measured from call establishment. It is an absolute ceiling that the SwMI
+            // applies regardless of ongoing traffic — when it expires the call is released
+            // (D-RELEASE) so a traffic channel can never be held indefinitely. Measuring it from
+            // `last_activity_at` (refreshed on every inbound network voice frame) let an
+            // endlessly-streaming Brew call reset the ceiling forever and pin the timeslot, which
+            // is NOT ETSI compliant. Inactivity-based reclaim — a talker going quiet, or a network
+            // media stream dying without a GROUP_IDLE — is handled separately by the hang-time and
+            // network-media-inactivity timers, not by stretching this absolute cap.
+            Some(timeout) => self.created_at.age(now) > timeout,
             None => false,
         }
     }

--- a/crates/tetra-entities/src/cmce/subentities/cc_bs/timers.rs
+++ b/crates/tetra-entities/src/cmce/subentities/cc_bs/timers.rs
@@ -8,6 +8,19 @@ use super::*;
 /// (6 s / (170/12 ms per slot) ≈ 423 timeslots.)
 pub(super) const EE_DSETUP_FALLBACK_TS: i32 = 423;
 
+/// Network (Brew) downlink media-inactivity guard, the downlink analogue of UMAC's UL stuck-
+/// transmitter timer. A network-originated group call carries no local uplink, so UMAC never arms
+/// the UL-inactivity timer for it (umac_bs.rs), and it only drops into hang-time when the backhaul
+/// signals GROUP_IDLE. If that GROUP_IDLE is lost — or a gateway keeps streaming / holds the call
+/// open — the call stays `Transmitting` with its traffic slot allocated until the absolute call
+/// time-out (and forever when that is configured Infinite). When no network media has refreshed
+/// `last_activity_at` for this long while a network speaker is nominally active, the stream is
+/// treated as dead and the call is released so the timeslot is reclaimed. Chosen well above the
+/// ~1 s media-activity signalling granularity and the continuous frame spacing of a live
+/// transmission, so a live stream is never cut — only a dead one. (10 s × 72 timeslots/s = 720;
+/// 72 = 18 frames × 4 slots.)
+pub(super) const NETWORK_MEDIA_INACTIVITY_TS: i32 = 10 * 18 * 4;
+
 impl CcBsSubentity {
     pub fn tick_start(&mut self, queue: &mut MessageQueue, dltime: TdmaTime) {
         self.dltime = dltime;
@@ -18,6 +31,8 @@ impl CcBsSubentity {
         self.check_individual_setup_timeout(queue);
         // Check hangtime expiry for active local calls
         self.check_hangtime_expiry(queue);
+        // Reclaim a network group-call timeslot whose backhaul media died without a GROUP_IDLE.
+        self.check_network_media_inactivity(queue);
 
         // Energy-economy group-call announce batching: re-emit the group D-SETUP across the
         // union of affiliated EE members' wake frames so members on a different sleep phase
@@ -501,6 +516,43 @@ impl CcBsSubentity {
 
         for call_id in expired {
             tracing::info!("Hangtime expired for call_id={}, releasing", call_id);
+            self.release_group_call(queue, call_id, DisconnectCause::SwmiRequestedDisconnection);
+        }
+    }
+
+    /// Reclaim a network group-call traffic slot whose backhaul media has gone silent without a
+    /// GROUP_IDLE (lost end-of-call signal, or a stuck/zombie gateway stream). See
+    /// [`NETWORK_MEDIA_INACTIVITY_TS`]. Only network-origin calls with a speaker still nominally
+    /// transmitting are eligible: once GROUP_IDLE arrives the call drops to hang-time
+    /// (`tx_active == false`) and the hang-time timer owns its teardown, and local calls never
+    /// refresh `last_activity_at` so they are excluded by the origin filter (their stuck-floor
+    /// case is covered by UMAC's UL-inactivity timer).
+    pub(super) fn check_network_media_inactivity(&mut self, queue: &mut MessageQueue) {
+        let stale: Vec<(u16, CallOrigin, u32)> = self
+            .active_calls
+            .iter()
+            .filter(|(_, call)| {
+                matches!(call.origin, CallOrigin::Network { .. })
+                    && call.tx_active
+                    && call.last_activity_at.age(self.dltime) > NETWORK_MEDIA_INACTIVITY_TS
+            })
+            .map(|(&call_id, call)| (call_id, call.origin.clone(), call.dest_gssi))
+            .collect();
+
+        for (call_id, origin, gssi) in stale {
+            tracing::info!(
+                "CMCE: releasing network group call_id={} gssi={} — no backhaul media for >{}s (lost GROUP_IDLE / dead stream)",
+                call_id,
+                gssi,
+                NETWORK_MEDIA_INACTIVITY_TS / (18 * 4)
+            );
+            // Mirror drop_group_calls_if_unlistened: tell the backhaul the call is over before we
+            // tear down locally, so a half-open Brew session doesn't keep us as a phantom leg.
+            if let CallOrigin::Network { brew_uuid } = origin {
+                if brew::is_brew_gssi_routable(&self.config, gssi) {
+                    self.notify_network_call_end(queue, brew_uuid);
+                }
+            }
             self.release_group_call(queue, call_id, DisconnectCause::SwmiRequestedDisconnection);
         }
     }

--- a/crates/tetra-entities/src/cmce/subentities/sds_bs.rs
+++ b/crates/tetra-entities/src/cmce/subentities/sds_bs.rs
@@ -526,6 +526,21 @@ impl SdsBsSubentity {
             v.extend_from_slice(&payload);
             v
         };
+        // The SDS-TL Type-4 length field is 16 bits (length in bits). A wrapped payload larger than
+        // u16::MAX/8 bytes would wrap the cast below and put a bogus length on the air — silent
+        // corruption. Real SDS text is far shorter; reject anything that cannot be represented
+        // rather than sending a malformed SDU (a non-browser control client could submit any size).
+        const MAX_SDS_PAYLOAD_BYTES: usize = (u16::MAX / 8) as usize; // 8191 bytes, incl. 4-byte header
+        if wrapped_payload.len() > MAX_SDS_PAYLOAD_BYTES {
+            tracing::warn!(
+                "SDS: refusing oversized message {}->{} ({} bytes wrapped, max {})",
+                source_ssi,
+                dest_ssi,
+                wrapped_payload.len(),
+                MAX_SDS_PAYLOAD_BYTES
+            );
+            return false;
+        }
         let wrapped_len_bits = (wrapped_payload.len() * 8) as u16;
         let sds_data = SdsUserData::Type4(wrapped_len_bits, wrapped_payload);
 

--- a/crates/tetra-entities/src/mm/mm_bs.rs
+++ b/crates/tetra-entities/src/mm/mm_bs.rs
@@ -111,6 +111,27 @@ impl MmBs {
             {
                 let mut state = self.config.state_write();
                 for group in rec.dgna_groups {
+                    // The recovery cache is on-disk and may be stale or corrupt. Validate each
+                    // persisted DGNA group before it re-enters the registry: an out-of-range GSSI
+                    // would later panic the 24-bit SS-DGNA PDU serializer, and an out-of-range
+                    // attachment mode would be silently coerced to a different mode. Skip bad entries.
+                    if group.gssi == 0 || group.gssi > 0xFF_FFFF {
+                        tracing::warn!(
+                            "MM: skipping restored DGNA group with out-of-range GSSI {} for ISSI {}",
+                            group.gssi,
+                            rec.issi
+                        );
+                        continue;
+                    }
+                    if GroupIdentityAttachmentMode::try_from(group.attachment_mode as u64).is_err() {
+                        tracing::warn!(
+                            "MM: skipping restored DGNA group GSSI {} for ISSI {} with invalid attachment mode {}",
+                            group.gssi,
+                            rec.issi,
+                            group.attachment_mode
+                        );
+                        continue;
+                    }
                     state
                         .subscribers
                         .remember_dgna_group(rec.issi, group.gssi, group.mnemonic, group.attachment_mode);
@@ -279,64 +300,6 @@ impl MmBs {
         );
         // handle = 0: addressed by ISSI on the MCCH (see send_d_location_update_command).
         Self::send_d_location_update_command(queue, issi, 0);
-    }
-
-    /// Force CMCE to release any individual P2P calls involving the given ISSI,
-    /// without touching Brew affiliations. Used on soft re-attach (e.g. MTP3550
-    /// 2s RF dropout) to prevent "PTT denied" caused by stale call state in CMCE.
-    ///
-    /// Implementation: sends Deregister to CMCE only (not Brew), then re-sends
-    /// Register + Affiliate so subscriber_groups and group_listener counts are
-    /// restored. Brew is not informed because the MS is still considered registered.
-    fn emit_individual_call_release_for_issi(&mut self, queue: &mut MessageQueue, issi: u32) {
-        let groups: Vec<u32> = self
-            .client_mgr
-            .get_client_by_issi(issi)
-            .map(|c| c.groups.iter().copied().collect())
-            .unwrap_or_default();
-
-        // CMCE Deregister: releases individual_calls + drops group_listener counts
-        let dereg = MmSubscriberUpdate {
-            issi,
-            groups: Vec::new(),
-            action: BrewSubscriberAction::Deregister,
-        };
-        queue.push_back(SapMsg {
-            sap: Sap::Control,
-            src: TetraEntity::Mm,
-            dest: TetraEntity::Cmce,
-            msg: SapMsgInner::MmSubscriberUpdate(dereg),
-        });
-
-        // CMCE Register: re-introduces the ISSI as known
-        let reg = MmSubscriberUpdate {
-            issi,
-            groups: Vec::new(),
-            action: BrewSubscriberAction::Register,
-        };
-        queue.push_back(SapMsg {
-            sap: Sap::Control,
-            src: TetraEntity::Mm,
-            dest: TetraEntity::Cmce,
-            msg: SapMsgInner::MmSubscriberUpdate(reg),
-        });
-
-        // CMCE Affiliate: restores group_listener counts so group calls still route
-        if !groups.is_empty() {
-            let aff = MmSubscriberUpdate {
-                issi,
-                groups,
-                action: BrewSubscriberAction::Affiliate,
-            };
-            queue.push_back(SapMsg {
-                sap: Sap::Control,
-                src: TetraEntity::Mm,
-                dest: TetraEntity::Cmce,
-                msg: SapMsgInner::MmSubscriberUpdate(aff),
-            });
-        }
-
-        tracing::info!("MM: forced individual call release for ISSI {} (soft re-attach)", issi);
     }
 
     fn emit_subscriber_update(&self, queue: &mut MessageQueue, issi: u32, groups: Vec<u32>, action: BrewSubscriberAction) {
@@ -537,87 +500,21 @@ impl MmBs {
         // affiliate() would otherwise recreate the registry entry and mask the drop.
         let was_dropped = !is_new && !self.config.state_read().subscribers.is_registered(issi);
         if !is_new {
-            // MS is re-registering while already known. Three cases:
+            // The terminal is re-registering while already known: a RoamingLocationUpdating after
+            // a PTT/RF blip (Sepura/Motorola do this routinely), a PeriodicLocationUpdating renewing
+            // T351, or a DemandLocationUpdating answering our COMMAND. In every case the radio is
+            // PRESENT, so we must NOT tear down its registration or group affiliations here.
             //
-            // A) RoamingLocationUpdating â€” MS re-registered from scratch (RF loss / reboot /
-            //    power-cycle, no prior U-ITSI-DETACH). Clean up stale state so CMCE releases
-            //    any ghost calls and group_listeners stays accurate.
-            //
-            // B) PeriodicLocationUpdating â€” healthy MS renewing its T351 timer. No cleanup.
-            //
-            // C) DemandLocationUpdating â€” MS responding to our D-LOCATION-UPDATE-COMMAND.
-            //    This is the second message in the normal registration flow; the first message
-            //    already registered+affiliated the MS. Do NOT clean up here.
-            let needs_cleanup = if pdu.location_update_type == LocationUpdateType::RoamingLocationUpdating
-                || pdu.location_update_type == LocationUpdateType::ServiceRestorationRoamingLocationUpdating
-            {
-                // Some terminals (e.g. Sepura) send RoamingLocationUpdating after every PTT
-                // release, not just on power-cycle or RF loss. If we treat this as a full reboot
-                // and do deregisterâ†’register, CMCE has a brief window where it doesn't know the
-                // terminal â€” a PTT press in that window gets "no listeners" and the terminal
-                // interprets it as a network error and fully disconnects.
-                //
-                // Heuristic: treat RoamingLocationUpdating as a soft re-attach (no cleanup) if
-                // the terminal registered less than 120 seconds ago.
-                let recently_registered = self
-                    .client_mgr
-                    .get_client_by_issi(issi)
-                    .map(|c| c.last_registration_time.elapsed().as_secs() < 120)
-                    .unwrap_or(false);
-                if recently_registered {
-                    tracing::debug!(
-                        "MM: ISSI {} RoamingLocationUpdating within 120s of last register â€” treating as soft re-attach (Sepura post-PTT)",
-                        issi
-                    );
-                    // Even on soft re-attach, force CMCE to release any individual P2P calls
-                    // involving this ISSI. Terminals (e.g. Motorola MTP3550) that drop RF for
-                    // 2s and re-attach lose call state but BS keeps the call alive â€” next PTT
-                    // is rejected ("PTT denied") because the terminal doesn't recognize the call_id
-                    // in our D-TX-GRANTED. Releasing the individual call here forces a clean U-SETUP
-                    // on the next PTT.
-                    self.emit_individual_call_release_for_issi(queue, issi);
-                    false
-                } else {
-                    true
-                }
-            } else {
-                false
-            };
-
-            // needs_cleanup: Roaming = MS rebooted, need full CMCE/Brew reset (deregister+register).
-            // was_pending: the MS is answering our T351 COMMAND â€” Brew still holds the subscriber
-            // (teardown is deferred to the confirmed-gone second expiry, which this answer prevents),
-            // so no Brew action is needed; CMCE is re-affiliated via the coverage-return path below.
-            if needs_cleanup {
-                let old_groups: Vec<u32> = self
-                    .client_mgr
-                    .get_client_by_issi(issi)
-                    .map(|c| c.groups.iter().copied().collect())
-                    .unwrap_or_default();
-                if !old_groups.is_empty() {
-                    self.emit_subscriber_update(queue, issi, old_groups.clone(), BrewSubscriberAction::Deaffiliate);
-                }
-                self.emit_subscriber_update(queue, issi, Vec::new(), BrewSubscriberAction::Deregister);
-                self.emit_subscriber_update(queue, issi, Vec::new(), BrewSubscriberAction::Register);
-                // The Deregister above wipes this subscriber's group affiliations in CMCE/Brew, but
-                // client_mgr still holds them. A roaming MS with persistent attachment
-                // (attachment_lifetime=0) re-reports its groups with group_identity_attach_detach_mode=0
-                // â€” which is a no-op in client_mgr (the group is already present), so
-                // try_attach_detach_groups emits NO Affiliate and CMCE is left with zero listeners.
-                // The next group PTT is then rejected "no listeners" and inbound group calls are dropped
-                // (observed for a Motorola MTP on RoamingLocationUpdating). Re-affiliate the stored
-                // groups now so CMCE/Brew stay in sync with client_mgr across the reset; the
-                // group-identity processing below then only needs to add genuinely new groups.
-                if !old_groups.is_empty() {
-                    {
-                        let mut state = self.config.state_write();
-                        for &gssi in &old_groups {
-                            state.subscribers.affiliate(issi, gssi);
-                        }
-                    }
-                    self.emit_subscriber_update(queue, issi, old_groups, BrewSubscriberAction::Affiliate);
-                }
-            } else if was_pending {
+            // A previous version treated a RoamingLocationUpdating older than 120s as a reboot and
+            // ran a Deaffiliate -> Deregister -> Register -> Affiliate "reset". That reset was
+            // net-harmful: the transient group_listeners -> 0 made CMCE drop the radio's ACTIVE
+            // group call (drop_group_calls_if_unlistened), and the brief "unknown subscriber" window
+            // made a PTT in that gap hit "no listeners" -- which the terminal reads as a network
+            // error and fully disconnects (the "radio constantly disconnects from the BTS" report).
+            // It re-affiliated the SAME groups immediately afterwards, so the reset only ever flapped
+            // the call. Genuine group-set changes are reconciled by the group-identity processing
+            // further down and by explicit U-ATTACH-DETACH, so no reset is needed here.
+            if was_pending {
                 tracing::info!("MM: ISSI {} re-registered after T351 COMMAND (Brew already holds it)", issi);
             }
             // Always reset the registration timer on any re-registration
@@ -1532,6 +1429,31 @@ impl MmBs {
         let is_dynamic = self.config.state_read().subscribers.has_dgna_group(issi, gssi);
         let is_attached = self.config.state_read().subscribers.attached_groups_of(issi).contains(&gssi);
         let route_gssi_hint = (!attach && is_attached).then_some(gssi);
+
+        // A GSSI is a 24-bit TETRA SSI. The SS-DGNA D-FACILITY encodes it into a 24-bit field, so a
+        // wider value would overflow the PDU serializer's `write_bits` assertion and panic the whole
+        // cell (the entities run on one un-isolated stack thread). This is the single MM funnel for
+        // every DGNA request — including unvalidated dashboard input — so reject an out-of-range
+        // group identity here, before any state mutation or PDU build. (0 is the "no group"
+        // sentinel used across the call/voice paths, so it is rejected too.)
+        const MAX_TETRA_SSI: u32 = 0xFF_FFFF;
+        if gssi == 0 || gssi > MAX_TETRA_SSI {
+            tracing::warn!(
+                "DGNA: refusing {} of out-of-range GSSI {} for ISSI {} (must be 1..=16777215)",
+                verb,
+                gssi,
+                issi
+            );
+            self.emit_dgna_status(
+                issi,
+                gssi,
+                attach,
+                false,
+                "MM",
+                format!("Rejected: GSSI {} out of range (must be 1..=16777215)", gssi),
+            );
+            return false;
+        }
 
         // The terminal must be registered on the cell â€” we cannot regroup a radio that is not here.
         if !self.client_mgr.client_is_known(issi) {

--- a/crates/tetra-entities/src/net_dashboard/server.rs
+++ b/crates/tetra-entities/src/net_dashboard/server.rs
@@ -3811,6 +3811,82 @@ fn serve_html(mut stream: TcpStream) {
     let _ = stream.write_all(body);
 }
 
+/// The placeholder characters the secret maskers emit — U+2022 BULLET (`mask_secret`/`mask_token`
+/// for short secrets) and U+2026 HORIZONTAL ELLIPSIS (the `head…tail` form). A posted secret value
+/// containing either is the mask echoed back unchanged by the editor, not a freshly typed secret.
+fn value_is_masked_secret(value: &str) -> bool {
+    value.contains('\u{2022}') || value.contains('\u{2026}')
+}
+
+/// Is `key` one of the secrets that `mask_config_secrets` masks before sending config to the browser?
+fn is_masked_secret_key(key: &str) -> bool {
+    matches!(key, "password" | "bot_token" | "rwth_core_authkey" | "ami_password")
+}
+
+/// Split a `key = "value"` TOML line into `(key, inner)`, mirroring `mask_toml_secret_line`: only a
+/// bare quoted-string assignment matches; comments and everything else return `None`. `inner` is the
+/// raw (still TOML-escaped) text between the quotes, so it can be re-wrapped verbatim.
+fn split_toml_str_assignment(line: &str) -> Option<(&str, &str)> {
+    let trimmed = line.trim_start();
+    if trimmed.starts_with('#') {
+        return None;
+    }
+    let eq = line.find('=')?;
+    let key = line[..eq].trim();
+    let rhs = line[eq + 1..].trim();
+    let inner = rhs.strip_prefix('"').and_then(|s| s.strip_suffix('"'))?;
+    Some((key, inner))
+}
+
+/// Restore secret values that the editor posted back still masked, from the currently-stored config.
+///
+/// `serve_config_get` masks secrets (`password`, `bot_token`, `rwth_core_authkey`, `ami_password`)
+/// with bullets/ellipsis before serving the config file to the browser, so cleartext never leaves the
+/// host. If the operator saves without retyping a secret, the editor posts that mask back verbatim —
+/// writing it would overwrite the real credential with placeholder characters and lock the operator
+/// out (the reported "passwords corrupted with random symbols" bug). Here we walk the posted `body`,
+/// and for any secret line whose value is still the mask, substitute the plaintext from the same
+/// `[section] key` in `current` (the on-disk config). Genuinely retyped secrets are left untouched.
+///
+/// Matching is section-aware so `[dashboard] password` and `[brew] password` — same bare key — are
+/// never crossed. A masked secret with no stored counterpart is left as-is (no worse than before).
+fn unmask_config_secrets(body: &str, current: &str) -> String {
+    // (section header, key) -> stored raw (escaped) value, for masked secret keys only.
+    let mut stored: std::collections::HashMap<(String, String), String> = std::collections::HashMap::new();
+    let mut section = String::new();
+    for line in current.lines() {
+        let t = line.trim();
+        if t.starts_with('[') && t.ends_with(']') {
+            section = t.to_string();
+        } else if let Some((key, inner)) = split_toml_str_assignment(line) {
+            if is_masked_secret_key(key) {
+                stored.insert((section.clone(), key.to_string()), inner.to_string());
+            }
+        }
+    }
+
+    let mut out = String::with_capacity(body.len());
+    let mut section = String::new();
+    for line in body.lines() {
+        let t = line.trim();
+        if t.starts_with('[') && t.ends_with(']') {
+            section = t.to_string();
+        } else if let Some((key, inner)) = split_toml_str_assignment(line) {
+            if is_masked_secret_key(key) && value_is_masked_secret(inner) {
+                if let Some(orig) = stored.get(&(section.clone(), key.to_string())) {
+                    let indent_len = line.len() - line.trim_start().len();
+                    out.push_str(&format!("{}{} = \"{}\"", &line[..indent_len], key, orig));
+                    out.push('\n');
+                    continue;
+                }
+            }
+        }
+        out.push_str(line);
+        out.push('\n');
+    }
+    out
+}
+
 /// Persist a posted config.toml after a dry-run parse + validate.
 ///
 /// Writing garbage here is what would brick the base station: the service restarts to apply config,
@@ -3821,6 +3897,13 @@ fn serve_html(mut stream: TcpStream) {
 ///
 /// Returns `Ok(())` on success, or `Err((http_code, message))` for the caller to relay.
 fn write_config_validated(config_path: &str, body: &str) -> Result<(), (u16, String)> {
+    // Secrets are served to the editor masked; restore any still-masked value from the stored config
+    // so a save that didn't retype a password keeps the real one instead of persisting the mask.
+    let body = match std::fs::read_to_string(config_path) {
+        Ok(current) => unmask_config_secrets(body, &current),
+        Err(_) => body.to_string(),
+    };
+    let body = body.as_str();
     match tetra_config::bluestation::parsing::from_toml_str(body) {
         Ok(cfg) => {
             if let Err(e) = cfg.validate() {
@@ -5569,5 +5652,63 @@ enabled = true
         // No usable hash baked in -> cannot tell.
         assert_eq!(binary_built_from("unknown", head), None);
         assert_eq!(binary_built_from("", head), None);
+    }
+
+    /// The reported "passwords corrupted with random symbols" bug: secrets are served masked, and a
+    /// save that doesn't retype them must restore the stored plaintext instead of persisting the
+    /// mask. This is the full round-trip: mask on read → post the masked body back (only a non-secret
+    /// field changed) → the real secrets survive. Section-aware, so `[dashboard] password` and
+    /// `[brew] password` (identical bare key) are never crossed.
+    #[test]
+    fn config_save_restores_unchanged_masked_secrets() {
+        use super::{mask_config_secrets, unmask_config_secrets};
+
+        let stored = "\
+[telegram_alerts]
+bot_token = \"123456:ABCdefGHIjklMNOpqrsWXYZ\"
+
+[dashboard]
+username = \"admin\"
+password = \"dashRealPw\"
+
+[brew]
+password = \"brewRealPw!\"
+enabled = true
+";
+        // What the browser's editor receives — cleartext never leaves the host.
+        let served = mask_config_secrets(stored);
+        assert!(!served.contains("dashRealPw"));
+        assert!(!served.contains("brewRealPw!"));
+        assert!(!served.contains("123456:ABCdefGHIjklMNOpqrsWXYZ"));
+
+        // Operator flips a non-secret field and posts the (still-masked) body back.
+        let posted = served.replace("enabled = true", "enabled = false");
+        let resolved = unmask_config_secrets(&posted, stored);
+
+        // Each real secret is restored to its own section — dashboard and brew not crossed.
+        assert!(resolved.contains("password = \"dashRealPw\""), "dashboard password restored");
+        assert!(resolved.contains("password = \"brewRealPw!\""), "brew password restored");
+        assert!(
+            resolved.contains("bot_token = \"123456:ABCdefGHIjklMNOpqrsWXYZ\""),
+            "bot token restored"
+        );
+        assert!(resolved.contains("enabled = false"), "non-secret edit preserved");
+        // No mask placeholder characters are ever written to disk.
+        assert!(
+            !resolved.contains('\u{2022}') && !resolved.contains('\u{2026}'),
+            "mask characters must not be persisted"
+        );
+    }
+
+    /// A genuinely retyped secret (no mask characters) must overwrite the stored one — otherwise the
+    /// operator could never change a password.
+    #[test]
+    fn config_save_keeps_freshly_typed_secret() {
+        use super::unmask_config_secrets;
+        let stored = "[dashboard]\npassword = \"old-pw\"\n";
+        let posted = "[dashboard]\npassword = \"brandNewPw\"\n";
+        let resolved = unmask_config_secrets(posted, stored);
+        assert!(resolved.contains("password = \"brandNewPw\""), "new password overwrites old");
+        assert!(!resolved.contains("old-pw"), "old password gone once retyped");
     }
 }

--- a/crates/tetra-entities/src/phy/components/soapy_dev.rs
+++ b/crates/tetra-entities/src/phy/components/soapy_dev.rs
@@ -90,8 +90,23 @@ impl RxTxDevSoapySdr {
             .bs_phase_mod_carriers()
             .expect("validated carrier configuration should compute");
         let bs_carrier_numbers = bs_carriers.iter().map(|(carrier_num, _, _)| *carrier_num).collect::<Vec<_>>();
-        let bs_dl_frequencies = bs_carriers.iter().map(|(_, dl_hz, _)| *dl_hz as f64).collect::<Vec<_>>();
-        let bs_ul_frequencies = bs_carriers.iter().map(|(_, _, ul_hz)| *ul_hz as f64).collect::<Vec<_>>();
+        // PPM-correct the per-carrier frequencies fed to the DSP channelizer, exactly as the SDR
+        // centre frequency is corrected before tuning (soapyio.rs). This is essential, not cosmetic:
+        // the FCFB places each carrier at bin offset `carrier - centre`, and `centre` is read back
+        // from the (already ppm-corrected) hardware LO. If the carriers stayed uncorrected the bin
+        // offset would absorb an equal-and-opposite `-err`, cancelling the LO correction so the net
+        // emitted/received RF never moved — the "changing ppm_err does nothing" bug. Correcting the
+        // carriers too makes net RF = carrier·(1+ppm/1e6), the intended calibration, and is robust to
+        // LO tuning quantisation since `centre` is the actual readback. NOTE: ppm_err is only read
+        // here at PHY construction, so a dashboard change still needs a stack restart to take effect.
+        let bs_dl_frequencies = bs_carriers
+            .iter()
+            .map(|(_, dl_hz, _)| soapy_cfg.correct_frequency(*dl_hz as f64).0)
+            .collect::<Vec<_>>();
+        let bs_ul_frequencies = bs_carriers
+            .iter()
+            .map(|(_, _, ul_hz)| soapy_cfg.correct_frequency(*ul_hz as f64).0)
+            .collect::<Vec<_>>();
 
         let phy_config = soapy_dev::PhyConfig {
             monitor_frequencies: &[],

--- a/crates/tetra-entities/tests/test_cmce_bs.rs
+++ b/crates/tetra-entities/tests/test_cmce_bs.rs
@@ -1137,18 +1137,9 @@ fn test_network_group_speaker_change_uses_remote_floor_grant() {
     );
 }
 
-#[test]
-fn test_network_group_call_timeout_refreshes_on_media_activity() {
-    debug::setup_logging_verbose();
-
-    let gssi = 220;
-    let local_issi = 9012003;
-    let source_issi = 2200010;
-    let brew_uuid = uuid::Uuid::new_v4();
-
-    let mut config = default_test_config_bs();
-    config.cell.call_timeout_secs = 30;
-    config.brew = Some(CfgBrew {
+/// Build a CfgBrew suitable for the network-call timeout tests.
+fn test_brew_cfg() -> CfgBrew {
+    CfgBrew {
         host: "127.0.0.1".into(),
         port: 0,
         tls: false,
@@ -1160,7 +1151,100 @@ fn test_network_group_call_timeout_refreshes_on_media_activity() {
         whitelisted_ssis: None,
         feature_rssi_export: false,
         pbx_gateway_issis: None,
+    }
+}
+
+/// ETSI EN 300 392-2 §14: the call time-out timer is an ABSOLUTE maximum call duration measured
+/// from call establishment. Ongoing network media must NOT push it out — a previous change measured
+/// it from the last media frame, letting an endlessly-streaming Brew call pin the traffic timeslot
+/// forever. Here we keep media flowing (gaps below the media-inactivity window) and assert the call
+/// is still released at created_at + call_timeout, never extended.
+#[test]
+fn test_network_group_call_absolute_timeout_is_not_extended_by_media() {
+    debug::setup_logging_verbose();
+
+    let gssi = 220;
+    let local_issi = 9012003;
+    let source_issi = 2200010;
+    let brew_uuid = uuid::Uuid::new_v4();
+
+    let mut config = default_test_config_bs();
+    config.cell.call_timeout_secs = 30; // 30 s = 2160 timeslots
+    config.brew = Some(test_brew_cfg());
+
+    let mut test = ComponentTest::from_config(config, Some(TdmaTime { h: 0, m: 1, f: 1, t: 1 }));
+    test.populate_entities(
+        vec![TetraEntity::Cmce],
+        vec![TetraEntity::Mle, TetraEntity::Umac, TetraEntity::Brew],
+    );
+    register_subscriber(&mut test, local_issi, gssi);
+
+    let media_activity = |test: &mut ComponentTest| {
+        test.submit_message(SapMsg {
+            sap: Sap::Control,
+            src: TetraEntity::Brew,
+            dest: TetraEntity::Cmce,
+            msg: SapMsgInner::CmceCallControl(CallControl::NetworkCallMediaActivity { brew_uuid }),
+        });
+    };
+
+    test.submit_message(SapMsg {
+        sap: Sap::Control,
+        src: TetraEntity::Brew,
+        dest: TetraEntity::Cmce,
+        msg: SapMsgInner::CmceCallControl(CallControl::NetworkCallStart {
+            brew_uuid,
+            source_issi,
+            dest_gssi: gssi,
+            priority: 1,
+        }),
     });
+    test.run_stack(Some(5));
+    test.dump_sinks();
+
+    // Keep media flowing with gaps (600 ts ≈ 8.3 s) below the 720 ts media-inactivity window, so the
+    // only thing that can end the call is the absolute cap. After ~1800 ts we are still below the
+    // 2160 ts cap → the call must still be up.
+    for _ in 0..3 {
+        media_activity(&mut test);
+        test.run_stack(Some(600));
+    }
+    let mid = test.dump_sinks();
+    assert!(
+        !mid.iter()
+            .any(|msg| matches!(&msg.msg, SapMsgInner::CmceCallControl(CallControl::CallEnded { .. }))),
+        "call must stay up while media flows and the absolute call time-out has not yet elapsed"
+    );
+
+    // Keep media flowing and cross the 2160 ts absolute cap. Pre-fix the late media would have
+    // pushed release out to ~1800+2160 ts; ETSI-compliant behaviour releases at the absolute cap.
+    media_activity(&mut test);
+    test.run_stack(Some(600));
+    let after = test.dump_sinks();
+    assert!(
+        after
+            .iter()
+            .any(|msg| matches!(&msg.msg, SapMsgInner::CmceCallControl(CallControl::CallEnded { .. }))),
+        "ETSI: call must be released at the absolute call time-out regardless of ongoing media"
+    );
+}
+
+/// A network (Brew) group call carries no local uplink, so UMAC never arms a UL-inactivity timer
+/// and the call only drops to hang-time on a GROUP_IDLE. If the backhaul media simply dies (lost
+/// GROUP_IDLE / zombie gateway stream), the downlink media-inactivity guard must reclaim the
+/// traffic timeslot — this is the "timeslot stays busy after the radio/stream is gone" regression.
+#[test]
+fn test_network_group_call_released_when_backhaul_media_dies() {
+    debug::setup_logging_verbose();
+
+    let gssi = 220;
+    let local_issi = 9012003;
+    let source_issi = 2200010;
+    let brew_uuid = uuid::Uuid::new_v4();
+
+    let mut config = default_test_config_bs();
+    config.cell.call_timeout_secs = 120; // long, so the absolute cap can't mask the inactivity guard
+    config.brew = Some(test_brew_cfg());
 
     let mut test = ComponentTest::from_config(config, Some(TdmaTime { h: 0, m: 1, f: 1, t: 1 }));
     test.populate_entities(
@@ -1180,37 +1264,32 @@ fn test_network_group_call_timeout_refreshes_on_media_activity() {
             priority: 1,
         }),
     });
-    test.run_stack(Some(1));
+    test.run_stack(Some(5));
     test.dump_sinks();
 
-    test.run_stack(Some(2000));
-    test.dump_sinks();
+    // The traffic slot is busy while the call is up.
+    {
+        let shared = test.get_shared_config();
+        assert!(
+            shared.state_read().active_call_ts.contains_key(&gssi),
+            "network group call should occupy a traffic timeslot once established"
+        );
+    }
 
-    test.submit_message(SapMsg {
-        sap: Sap::Control,
-        src: TetraEntity::Brew,
-        dest: TetraEntity::Cmce,
-        msg: SapMsgInner::CmceCallControl(CallControl::NetworkCallMediaActivity { brew_uuid }),
-    });
-    test.run_stack(Some(1));
-    test.dump_sinks();
-
-    test.run_stack(Some(400));
-    let still_active_msgs = test.dump_sinks();
+    // No further media arrives (lost GROUP_IDLE). Run past the 720 ts (10 s) inactivity window.
+    test.run_stack(Some(800));
+    let msgs = test.dump_sinks();
     assert!(
-        !still_active_msgs
-            .iter()
+        msgs.iter()
             .any(|msg| matches!(&msg.msg, SapMsgInner::CmceCallControl(CallControl::CallEnded { .. }))),
-        "network call must not end at the original timeout if Brew media refreshed it"
+        "network call with dead backhaul media must be released by the media-inactivity guard"
     );
 
-    test.run_stack(Some(2200));
-    let release_msgs = test.dump_sinks();
+    // …and the timeslot must be reclaimed — the actual operator-visible symptom.
+    let shared = test.get_shared_config();
     assert!(
-        release_msgs
-            .iter()
-            .any(|msg| matches!(&msg.msg, SapMsgInner::CmceCallControl(CallControl::CallEnded { .. }))),
-        "network call should release after the refreshed timeout window expires"
+        !shared.state_read().active_call_ts.contains_key(&gssi),
+        "traffic timeslot must be reclaimed (active_call_ts cleared) after media-inactivity release"
     );
 }
 

--- a/crates/tetra-entities/tests/test_mm_bs.rs
+++ b/crates/tetra-entities/tests/test_mm_bs.rs
@@ -12,6 +12,7 @@ use tetra_pdus::mm::enums::mm_pdu_type_dl::MmPduTypeDl;
 use tetra_pdus::mm::pdus::d_attach_detach_group_identity::DAttachDetachGroupIdentity;
 use tetra_pdus::mm::pdus::d_mm_status::DMmStatus;
 use tetra_pdus::mm::pdus::u_location_update_demand::ULocationUpdateDemand;
+use tetra_saps::control::brew::BrewSubscriberAction;
 use tetra_saps::lmm::LmmMleUnitdataInd;
 use tetra_saps::sapmsg::{SapMsg, SapMsgInner};
 
@@ -270,6 +271,114 @@ fn test_dgna_assign_affiliates_and_requests_ss_dgna() {
             .attached_groups_of(TEST_ISSI)
             .contains(&TEST_GSSI),
         "DGNA assign must affiliate the GSSI in the subscriber registry"
+    );
+}
+
+/// A DGNA request whose GSSI does not fit the 24-bit SS-DGNA field must be rejected at the MM
+/// funnel — no affiliation and no SS-DGNA emission — and must NOT panic. Pre-fix the oversized GSSI
+/// reached the PDU serializer's `write_bits` assertion and took down the whole cell.
+#[test]
+fn test_dgna_assign_rejects_out_of_range_gssi() {
+    debug::setup_logging_verbose();
+    const TEST_ISSI: u32 = 2260599;
+    const BAD_GSSI: u32 = 0x100_0000; // 16_777_216 — one past the 24-bit max
+
+    let mut test = ComponentTest::new(StackMode::Bs, Some(TdmaTime::default()));
+    test.populate_entities(vec![], vec![TetraEntity::Mle, TetraEntity::Cmce]);
+    let (dispatcher, endpoint) = make_control_link();
+    let mm = MmBs::new(test.get_shared_config(), None, Some(endpoint));
+    test.register_entity(mm);
+    register_terminal(&mut test, TEST_ISSI);
+    let _ = test.dump_sinks();
+
+    dispatcher.send(ControlCommand::Dgna {
+        issi: TEST_ISSI,
+        gssi: BAD_GSSI,
+        mnemonic: None,
+        attachment_mode: 0,
+        attach: true,
+    });
+    test.run_stack(Some(2)); // must not panic
+
+    let msgs = test.dump_sinks();
+    assert!(
+        find_ss_dgna_request(&msgs).is_none(),
+        "an out-of-range GSSI must not produce an SS-DGNA request"
+    );
+    assert!(
+        !test
+            .config
+            .state_read()
+            .subscribers
+            .attached_groups_of(TEST_ISSI)
+            .contains(&BAD_GSSI),
+        "an out-of-range GSSI must not be affiliated"
+    );
+}
+
+/// Regression: a RoamingLocationUpdating from a radio that is already registered and affiliated (the
+/// routine Sepura/Motorola post-PTT re-registration) must NOT tear the radio down. Previously MM ran
+/// a Deaffiliate -> Deregister -> Register -> Affiliate "reset" that transiently zeroed CMCE's group
+/// listeners — dropping the radio's active group call and opening an "unknown subscriber" window the
+/// terminal reads as a network error, disconnecting it ("radio constantly disconnects from the BTS").
+#[test]
+fn test_roaming_reregistration_keeps_present_radio_affiliated() {
+    debug::setup_logging_verbose();
+    const TEST_ISSI: u32 = 2260601;
+    const TEST_GSSI: u32 = 100;
+
+    let mut test = ComponentTest::new(StackMode::Bs, Some(TdmaTime::default()));
+    test.populate_entities(vec![], vec![TetraEntity::Mle, TetraEntity::Cmce]);
+    let (dispatcher, endpoint) = make_control_link();
+    let mm = MmBs::new(test.get_shared_config(), None, Some(endpoint));
+    test.register_entity(mm);
+
+    // Register the radio and affiliate it to a group.
+    register_terminal(&mut test, TEST_ISSI);
+    dispatcher.send(ControlCommand::Dgna {
+        issi: TEST_ISSI,
+        gssi: TEST_GSSI,
+        mnemonic: None,
+        attachment_mode: 0,
+        attach: true,
+    });
+    test.run_stack(Some(2));
+    let _ = test.dump_sinks(); // discard the registration + affiliation traffic
+    assert!(
+        test.config.state_read().subscribers.attached_groups_of(TEST_ISSI).contains(&TEST_GSSI),
+        "precondition: radio must be affiliated before re-registration"
+    );
+
+    // The radio re-registers (RoamingLocationUpdating after a PTT — the exact reported trigger).
+    register_terminal(&mut test, TEST_ISSI);
+    let msgs = test.dump_sinks();
+
+    // It must NOT emit a Deregister or Deaffiliate toward CMCE — either would transiently drop the
+    // radio's group listeners (and its active group call) and disconnect a present terminal.
+    let destructive: Vec<BrewSubscriberAction> = msgs
+        .iter()
+        .filter_map(|m| match &m.msg {
+            SapMsgInner::MmSubscriberUpdate(u)
+                if matches!(
+                    u.action,
+                    BrewSubscriberAction::Deregister | BrewSubscriberAction::Deaffiliate
+                ) =>
+            {
+                Some(u.action)
+            }
+            _ => None,
+        })
+        .collect();
+    assert!(
+        destructive.is_empty(),
+        "re-registration of a present radio must not tear it down, but emitted {:?}",
+        destructive
+    );
+
+    // And the affiliation must still be intact afterwards.
+    assert!(
+        test.config.state_read().subscribers.attached_groups_of(TEST_ISSI).contains(&TEST_GSSI),
+        "affiliation must survive a routine re-registration"
     );
 }
 

--- a/crates/tetra-pdus/src/cmce/ss_dgna/fields/group_assignment.rs
+++ b/crates/tetra-pdus/src/cmce/ss_dgna/fields/group_assignment.rs
@@ -119,10 +119,24 @@ impl GroupAssignment {
             }
         }
 
-        // Fixed (type-1) region.
+        // Fixed (type-1) region. Group SSI and group extension are 24-bit fields; a wider value
+        // would trip write_bits' range assertion and panic, so reject it as an InvalidValue before
+        // it reaches the bit writer (defence in depth — callers should range-check their input).
+        if self.group_ssi > 0xFF_FFFF {
+            return Err(PduParseErr::InvalidValue {
+                field: "group_ssi",
+                value: self.group_ssi as u64,
+            });
+        }
         buf.write_bits(self.group_ssi as u64, 24);
         buf.write_bits(self.group_extension.is_some() as u64, 1);
         if let Some(ext) = self.group_extension {
+            if ext > 0xFF_FFFF {
+                return Err(PduParseErr::InvalidValue {
+                    field: "group_extension",
+                    value: ext as u64,
+                });
+            }
             buf.write_bits(ext as u64, 24);
         }
         buf.write_bits(self.attachment_mode.into_raw(), 3);
@@ -291,5 +305,51 @@ impl fmt::Display for GroupAssignment {
             self.additional_group_information,
             self.vgssi
         )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample(group_ssi: u32) -> GroupAssignment {
+        GroupAssignment {
+            group_ssi,
+            group_extension: None,
+            attachment_mode: GroupIdentityAttachmentMode::AttachedPermanently,
+            class_of_usage: None,
+            mnemonic: None,
+            security_related_information: None,
+            additional_group_information: None,
+            vgssi: None,
+        }
+    }
+
+    /// A GSSI is a 24-bit field. A wider value used to abort the entire base station via the
+    /// write_bits range assertion; it must now be reported as a recoverable InvalidValue.
+    #[test]
+    fn to_bitbuf_rejects_out_of_range_gssi_instead_of_panicking() {
+        let mut buf = BitBuffer::new_autoexpand(16);
+        assert!(matches!(
+            sample(0x100_0000).to_bitbuf(&mut buf),
+            Err(PduParseErr::InvalidValue { field: "group_ssi", .. })
+        ));
+    }
+
+    #[test]
+    fn to_bitbuf_accepts_max_valid_gssi() {
+        let mut buf = BitBuffer::new_autoexpand(16);
+        assert!(sample(0xFF_FFFF).to_bitbuf(&mut buf).is_ok());
+    }
+
+    #[test]
+    fn to_bitbuf_rejects_out_of_range_group_extension() {
+        let mut ga = sample(1);
+        ga.group_extension = Some(0x100_0000);
+        let mut buf = BitBuffer::new_autoexpand(16);
+        assert!(matches!(
+            ga.to_bitbuf(&mut buf),
+            Err(PduParseErr::InvalidValue { field: "group_extension", .. })
+        ));
     }
 }

--- a/crates/tetra-pdus/src/cmce/ss_dgna/fields/group_deassignment.rs
+++ b/crates/tetra-pdus/src/cmce/ss_dgna/fields/group_deassignment.rs
@@ -38,9 +38,23 @@ impl GroupDeassignment {
     }
 
     pub fn to_bitbuf(&self, buf: &mut BitBuffer) -> Result<(), PduParseErr> {
+        // Group SSI and group extension are 24-bit fields; reject a wider value as InvalidValue
+        // rather than letting write_bits' range assertion panic the cell (defence in depth).
+        if self.group_ssi > 0xFF_FFFF {
+            return Err(PduParseErr::InvalidValue {
+                field: "group_ssi",
+                value: self.group_ssi as u64,
+            });
+        }
         buf.write_bits(self.group_ssi as u64, 24);
         buf.write_bits(self.group_extension.is_some() as u64, 1);
         if let Some(ext) = self.group_extension {
+            if ext > 0xFF_FFFF {
+                return Err(PduParseErr::InvalidValue {
+                    field: "group_extension",
+                    value: ext as u64,
+                });
+            }
             buf.write_bits(ext as u64, 24);
         }
         Ok(())
@@ -54,5 +68,35 @@ impl fmt::Display for GroupDeassignment {
             "GroupDeassignment {{ group_ssi: {} group_extension: {:?} }}",
             self.group_ssi, self.group_extension
         )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A GSSI is a 24-bit field; a wider value used to panic the whole cell in the bit writer and
+    /// must now be a recoverable InvalidValue.
+    #[test]
+    fn to_bitbuf_rejects_out_of_range_gssi_instead_of_panicking() {
+        let mut buf = BitBuffer::new_autoexpand(8);
+        let de = GroupDeassignment {
+            group_ssi: 0x100_0000,
+            group_extension: None,
+        };
+        assert!(matches!(
+            de.to_bitbuf(&mut buf),
+            Err(PduParseErr::InvalidValue { field: "group_ssi", .. })
+        ));
+    }
+
+    #[test]
+    fn to_bitbuf_accepts_max_valid_gssi() {
+        let mut buf = BitBuffer::new_autoexpand(8);
+        let de = GroupDeassignment {
+            group_ssi: 0xFF_FFFF,
+            group_extension: None,
+        };
+        assert!(de.to_bitbuf(&mut buf).is_ok());
     }
 }


### PR DESCRIPTION
Cutting 0.3.9. This is the batch of fixes for the stuff people flagged after the dashboard update, plus a couple that were already on my branch but never made it to main, so the box people are running is still on an old 0.3.8 build.

New here:

Config save was eating passwords. We mask secrets when we hand the config to the browser, but the save path wrote the body straight back, so if you saved without retyping a password it stored the mask (the bullets) as the new value. That's what locked people out. It hit both the dashboard login and the brew password because they use the same `password` key. Save now pulls any still-masked secret back from the config on disk before writing, and keeps the sections apart so dashboard and brew don't get swapped. Retyping a password still works. Added a couple of tests.

ppm_err wasn't doing anything. The correction went on the SDR centre freq, but the channelizer puts each carrier at (carrier - centre) and reads centre back from the already-corrected LO, while the carriers themselves stayed uncorrected, so it just cancelled out and the RF never moved. Corrected the carrier freqs too. Note ppm_err is only read at startup, so you still have to restart the stack after changing it.

Already on the branch, going to main with this:

- mm: stop tearing the radio down on re-registration. Every roaming location update (radios send those after each PTT and roughly once a minute idle) was doing a full deaffiliate/deregister/register/affiliate. The deregister dropped the group listener count to zero for a moment and CMCE released the whole group call, so the terminals saw a network fault and dropped. This is the "loses service every minute" report.
- pdus: don't panic on an out-of-range GSSI or an oversized SDS.
- cmce: absolute call timeout + media inactivity reclaim back to the ETSI behaviour.

The DGNA off-host thing was already fixed on main (5c0655b), the box just needs the new build.

cargo test --workspace is green, check is clean at 0.3.9.

Whoever's running the affected box needs a rebuild + restart to actually pick up the mm/dgna fixes since they weren't on main before.