### PR TITLE
Fix web restart crash loop

### DIFF
--- a/contrib/packaging/bluestation-bs.service
+++ b/contrib/packaging/bluestation-bs.service
@@ -3,6 +3,14 @@ Description=FlowStation TETRA base station
 Documentation=https://github.com/razvanzeces/flowstation
 After=network-online.target
 Wants=network-online.target
+# Cap restarts so a startup that keeps failing — e.g. the SDR still held for a
+# moment after a *software* (web) restart — stops after a burst and lands in a
+# visible "failed" state instead of crash-looping forever. The window is generous:
+# legitimate web-triggered restarts and the in-process SDR-open retries never trip
+# it. If it does trip, recover with a power cycle + `systemctl start` (a hard power
+# cycle clears an SDR that a software restart couldn't), or `systemctl reset-failed`.
+StartLimitIntervalSec=300
+StartLimitBurst=10
 
 [Service]
 Type=simple
@@ -13,8 +21,6 @@ CPUSchedulingPriority=73
 KillSignal=SIGINT
 Restart=on-failure
 RestartSec=10
-# Let RestartSec govern the pace instead of systemd's 5-in-10s default.
-StartLimitIntervalSec=0
 
 [Install]
 WantedBy=multi-user.target

--- a/contrib/systemd/bluestation-bs.service
+++ b/contrib/systemd/bluestation-bs.service
@@ -22,6 +22,13 @@ Description=TETRA BlueStation base station service
 # not just "declared active" like network.target.
 After=network-online.target
 Wants=network-online.target
+# Cap restarts so a startup that keeps failing (e.g. an SDR still held for a
+# moment after a software restart) stops after a burst and lands in a visible
+# "failed" state instead of crash-looping forever. Generous enough that a
+# legitimate web-triggered restart and the in-process SDR-open retries never
+# trip it; recover with a power cycle + `systemctl start`, or `systemctl reset-failed`.
+StartLimitIntervalSec=300
+StartLimitBurst=10
 
 [Service]
 User=user
@@ -48,10 +55,6 @@ KillSignal=SIGINT
 # Does NOT restart on clean exit (systemctl stop) or SIGINT (graceful shutdown).
 Restart=on-failure
 RestartSec=10
-
-# Remove start rate limiting entirely — let RestartSec govern the pace.
-# Without this, systemd stops trying after 5 restarts in 10s (the default).
-StartLimitIntervalSec=0
 
 [Install]
 WantedBy=multi-user.target

--- a/crates/tetra-entities/src/phy/components/soapy_dev.rs
+++ b/crates/tetra-entities/src/phy/components/soapy_dev.rs
@@ -52,6 +52,51 @@ pub struct RxTxDevSoapySdr {
 
 type FftPlanner = rustfft::FftPlanner<RealSample>;
 
+/// Open the SDR, retrying briefly before giving up.
+///
+/// A *software* restart (e.g. the dashboard "Restart" button, which exits the process so systemd
+/// restarts it) can momentarily leave the USB SDR still held / mid-re-enumeration when the new
+/// process comes up, so the first open right after the old process exits often fails. Panicking on
+/// that first failure turned an ordinary restart into a systemd crash-loop ("web restart causes
+/// infinite crash loop"): every retry hit the same not-yet-released device. Retrying in-process
+/// lets the radio settle within this one process instead of bouncing the whole service. A genuinely
+/// absent or misconfigured radio still aborts after the window (and the unit's StartLimit then caps
+/// the systemd-level retries so it can't loop forever).
+fn open_sdr_with_retry(cfg: &SharedConfig) -> soapyio::SoapyIo {
+    const ATTEMPTS: u32 = 6;
+    const DELAY: std::time::Duration = std::time::Duration::from_secs(5);
+    for attempt in 1..=ATTEMPTS {
+        match soapyio::SoapyIo::new(cfg) {
+            Ok(sdr) => return sdr,
+            Err(e) if attempt < ATTEMPTS => {
+                tracing::warn!(
+                    "Failed to open SDR device (attempt {}/{}): {}. Retrying in {}s \
+                     (device may still be releasing after a restart)...",
+                    attempt,
+                    ATTEMPTS,
+                    e,
+                    DELAY.as_secs()
+                );
+                std::thread::sleep(DELAY);
+            }
+            Err(e) => {
+                // Out of attempts — nothing to transmit on, so this is fatal. Surface the actual
+                // cause and the usual culprits so log-only debugging is possible.
+                tracing::error!(
+                    "Failed to open SDR device after {} attempts: {}. Check that the SDR is plugged \
+                     in, not held by another process (SoapySDRUtil/GQRX/another bluestation-bs), and \
+                     that the device driver in [phy_io.soapysdr] matches the hardware. Cannot start \
+                     without a radio.",
+                    ATTEMPTS,
+                    e
+                );
+                panic!("Failed to open SDR device after {ATTEMPTS} attempts: {e}");
+            }
+        }
+    }
+    unreachable!("the loop returns on success or panics on the final attempt")
+}
+
 impl RxTxDevSoapySdr {
     pub fn new(cfg: &SharedConfig) -> Self {
         Self::with_telemetry(cfg, None)
@@ -116,24 +161,9 @@ impl RxTxDevSoapySdr {
             bs_carrier_numbers: &bs_carrier_numbers,
         };
 
-        let mut sdr = match soapyio::SoapyIo::new(cfg) {
-            Ok(sdr) => sdr,
-            Err(e) => {
-                // Failing to open the SDR at boot is fatal — there's nothing to transmit
-                // on. A panic here is acceptable (and systemd will retry), but the default
-                // .unwrap() message ("called Result::unwrap() on an Err...soapy_dev.rs:90")
-                // tells the operator nothing. Surface the actual cause and the usual
-                // culprits so log-only debugging is possible.
-                tracing::error!(
-                    "Failed to open SDR device: {}. Check that the SDR is plugged in, \
-                     not held by another process (SoapySDRUtil/GQRX/another bluestation-bs), \
-                     and that the device driver in [phy_io.soapysdr] matches the hardware. \
-                     Cannot start without a radio.",
-                    e
-                );
-                panic!("Failed to open SDR device: {e}");
-            }
-        };
+        // Retry the open briefly rather than panicking on the first failure — a software restart
+        // can leave the USB SDR held for a moment, which otherwise crash-loops the service.
+        let mut sdr = open_sdr_with_retry(cfg);
 
         let health_telemetry = telemetry.clone();
 


### PR DESCRIPTION
Confirmed the mechanism from the code + packaging (couldn't repro on real Pi/SDR here, but it all lines up):

The dashboard Restart button exits the process (exit 75) so systemd brings it back up. When the new process starts, the USB SDR is often still held for a moment from the old process, so `SoapyIo::new` fails and we `panic!` on the spot. The service unit has `StartLimitIntervalSec=0`, which removes systemd's crash-loop breaker, so systemd just keeps restarting into the same not-yet-released device — forever. A hard power cycle clears the SDR, a software restart doesn't, which is exactly why the sample systemd unit already has a USB-reset `ExecStartPre` with a comment about "software restarts (as opposed to hard power cycles)". The packaged `.deb` unit never got that reset, so `.deb` users get the loop.

Rather than shipping the broad "reset every USB device" hack in the `.deb` (dangerous for anyone booting off USB), fixed it two ways:

- **Retry the SDR open** (6 x 5s) before giving up, so the radio settles inside one process instead of bouncing the whole service. A genuinely missing/misconfigured radio still aborts after the window, same as before.
- **Cap the systemd start limit** (`StartLimitIntervalSec=300`, `StartLimitBurst=10`, moved to `[Unit]`) in both unit files, so any startup that keeps failing lands in a visible `failed` state instead of looping forever. The window is wide enough that a normal web restart and the in-process retries never trip it.

Both the packaged and sample units get the cap; the sample keeps its USB reset.

`cargo test --workspace` is green, `check` clean.

Not merging — up for review.