### PR TITLE
fix: harden RF/control panics + call-control, interconnect & dashboard bugs

### DIFF
--- a/crates/tetra-entities/src/cmce/subentities/cc_bs/procedures/setup.rs
+++ b/crates/tetra-entities/src/cmce/subentities/cc_bs/procedures/setup.rs
@@ -294,6 +294,13 @@ impl CcBsSubentity {
             priority: pdu.call_priority,
         });
 
+        // notify_umac = true: the originator holds the floor from set-up, so UMAC must arm its
+        // UL-inactivity ("stuck transmitter") timer and record the speaker now — every other floor
+        // grant does this. rx_control_circuit_open deliberately does NOT arm the timer, and UMAC
+        // otherwise only arms it on the first real UL voice frame; leaving this `false` meant a
+        // caller who set up a group call and then dropped BEFORE transmitting a single UL frame was
+        // never timed out, pinning the traffic slot until the absolute call time-out — and with
+        // call_timeout_secs = 0 (unlimited) that slot leaked permanently.
         self.notify_floor_granted(
             queue,
             GroupFloorGrant {
@@ -304,7 +311,7 @@ impl CcBsSubentity {
                 ts: circuit.ts,
                 is_group: true,
             },
-            false,
+            true,
             BrewNotification::IfGroupRoutable(dest_gssi),
         );
     }

--- a/crates/tetra-entities/src/cmce/subentities/sds_bs.rs
+++ b/crates/tetra-entities/src/cmce/subentities/sds_bs.rs
@@ -526,11 +526,14 @@ impl SdsBsSubentity {
             v.extend_from_slice(&payload);
             v
         };
-        // The SDS-TL Type-4 length field is 16 bits (length in bits). A wrapped payload larger than
-        // u16::MAX/8 bytes would wrap the cast below and put a bogus length on the air — silent
-        // corruption. Real SDS text is far shorter; reject anything that cannot be represented
-        // rather than sending a malformed SDU (a non-browser control client could submit any size).
-        const MAX_SDS_PAYLOAD_BYTES: usize = (u16::MAX / 8) as usize; // 8191 bytes, incl. 4-byte header
+        // The SDS-TL Type-4 length field is 11 bits (length in bits), so it can encode at most
+        // 2047 bits = 255 bytes (INCLUDING the 4-byte SDS-TL header). A wrapped payload larger than
+        // that would overflow the 11-bit field and trip write_bits' range assertion in
+        // DSdsData::to_bitbuf — panicking the whole single-threaded stack, not just corrupting one
+        // frame. Real SDS text is far shorter; reject anything that cannot be represented rather than
+        // crashing the cell (a non-browser control client can submit any size). The 8191-byte cap
+        // used previously was wrong: it assumed a 16-bit field.
+        const MAX_SDS_PAYLOAD_BYTES: usize = 2047 / 8; // 255 bytes, incl. 4-byte SDS-TL header
         if wrapped_payload.len() > MAX_SDS_PAYLOAD_BYTES {
             tracing::warn!(
                 "SDS: refusing oversized message {}->{} ({} bytes wrapped, max {})",
@@ -625,6 +628,20 @@ impl SdsBsSubentity {
             dest_is_group.then(|| "GSSI").unwrap_or("ISSI"),
             len_bits
         );
+
+        // The Type-4 length indicator is an 11-bit field (max 2047 bits = 255 bytes). A wider value
+        // would overflow the field and panic the serializer (DSdsData::to_bitbuf). This raw path
+        // (DAPNET / GeoAlarm / TPG2200 call-outs) had no size guard at all; reject oversized SDUs
+        // here rather than crashing the cell, mirroring rx_sds_from_control.
+        if len_bits > 2047 {
+            tracing::warn!(
+                "SDS: refusing oversized raw Type-4 {}->{} ({} bits, max 2047)",
+                source_ssi,
+                dest_ssi,
+                len_bits
+            );
+            return false;
+        }
 
         // Deliver the payload exactly as supplied — it is already a full Type-4 SDU. No SDS-TL wrap.
         let sds_data = SdsUserData::Type4(len_bits, payload);

--- a/crates/tetra-entities/src/cmce/subentities/sds_bs.rs
+++ b/crates/tetra-entities/src/cmce/subentities/sds_bs.rs
@@ -738,6 +738,13 @@ impl SdsBsSubentity {
         if dest_ssi != 9999 {
             match pdu.pre_coded_status {
                 PreCodedStatus::Emergency => self.emergency_enter(source_ssi, dest_ssi),
+                // An SDS-TL short/delivery report (ETSI 29.4.2.3) also arrives as a U-STATUS with
+                // dest != 9999, and is handled as a delivery confirmation further below. It is NOT a
+                // "user cancelled emergency" signal — a radio in emergency that auto-ACKs a received
+                // text would otherwise clear its own emergency session, causing a spurious
+                // EmergencyCancel → re-alarm flap on the next periodic Emergency re-send. Route it
+                // through without touching emergency state.
+                PreCodedStatus::SdsTl(_) => {}
                 _ => self.emergency_clear(source_ssi, "non-emergency status"),
             }
         }

--- a/crates/tetra-entities/src/net_brew/worker.rs
+++ b/crates/tetra-entities/src/net_brew/worker.rs
@@ -235,6 +235,14 @@ impl<T: NetworkTransport> BrewWorker<T> {
         tracing::info!("BrewWorker: starting");
 
         loop {
+            // A (re)connection to the core starts with a clean registration slate: the core may have
+            // restarted while we were disconnected and no longer knows any of our subscribers.
+            // Clearing this map makes the post-reconnect resync (BrewEntity::resync_subscribers) emit
+            // REGISTER — not REREGISTER — for every subscriber, so a REREGISTER-for-unknown is never
+            // sent to a fresh core (which can leave local MS unregistered until a power-cycle). The
+            // entity re-drives all affiliations right after Connected, so no group state is lost.
+            self.subscriber_groups.clear();
+
             // Attempt connection via transport
             match self.transport.connect() {
                 Ok(()) => {

--- a/crates/tetra-entities/src/net_dashboard/server.rs
+++ b/crates/tetra-entities/src/net_dashboard/server.rs
@@ -3742,6 +3742,28 @@ fn save_config_profile(config_path: &str, profile_name: &str, content: &str) -> 
         return Err("cannot overwrite active config via profile editor — use the Config editor tab".to_string());
     }
 
+    // Secrets are served to the profile editor masked (serve_config_profile_get → mask_config_secrets).
+    // If the operator saves without retyping a secret, the editor posts the mask (`••••`/`…`) back
+    // verbatim; restore the real value from the profile's OWN on-disk content so we never persist the
+    // placeholder over a real credential — the same corruption write_config_validated guards against
+    // for the active config, which the profile path previously skipped.
+    let content = match std::fs::read_to_string(&profile_path) {
+        Ok(current) => unmask_config_secrets(content, &current),
+        Err(_) => content.to_string(),
+    };
+
+    // Validate before writing. A malformed profile that is later Activated overwrites the live config
+    // with an unparseable file and crash-loops the stack on the next restart (startup abort under
+    // systemd). Reject it here, exactly like write_config_validated does for the active config.
+    match tetra_config::bluestation::parsing::from_toml_str(&content) {
+        Ok(cfg) => {
+            if let Err(e) = cfg.validate() {
+                return Err(format!("config is invalid: {e}"));
+            }
+        }
+        Err(e) => return Err(format!("config does not parse: {e}")),
+    }
+
     std::fs::write(&profile_path, content.as_bytes()).map_err(|e| format!("failed to write profile: {}", e))
 }
 
@@ -3790,6 +3812,20 @@ fn activate_config_profile(config_path: &str, profile_name: &str) -> Result<(), 
         return Err(format!("profile '{}' not found", profile_name));
     }
 
+    // Validate the profile parses + passes validation before it becomes the live config. Activating an
+    // unparseable/invalid profile bricks the cell on the next restart (startup abort under systemd →
+    // crash-loop with no valid .fallback) — the exact failure write_config_validated exists to
+    // prevent, so guard the activate path too rather than trusting whatever is on disk.
+    let profile_content = std::fs::read_to_string(&profile_path).map_err(|e| format!("failed to read profile: {}", e))?;
+    match tetra_config::bluestation::parsing::from_toml_str(&profile_content) {
+        Ok(cfg) => {
+            if let Err(e) = cfg.validate() {
+                return Err(format!("profile '{}' is invalid: {e}", profile_name));
+            }
+        }
+        Err(e) => return Err(format!("profile '{}' does not parse: {e}", profile_name)),
+    }
+
     // Backup current config before switching
     let backup_path = format!("{}.bak", config_path);
     if let Err(e) = std::fs::copy(config_path, &backup_path) {
@@ -3820,7 +3856,10 @@ fn value_is_masked_secret(value: &str) -> bool {
 
 /// Is `key` one of the secrets that `mask_config_secrets` masks before sending config to the browser?
 fn is_masked_secret_key(key: &str) -> bool {
-    matches!(key, "password" | "bot_token" | "rwth_core_authkey" | "ami_password")
+    // `token` is the [tpg2200_action] ActionURL token — the sole credential guarding the pre-auth
+    // public /api/action/tpg2200 endpoint. It is the only `token` key in the config schema, so a
+    // bare-key match cannot collide with anything else.
+    matches!(key, "password" | "bot_token" | "rwth_core_authkey" | "ami_password" | "token")
 }
 
 /// Split a `key = "value"` TOML line into `(key, inner)`, mirroring `mask_toml_secret_line`: only a
@@ -3951,7 +3990,7 @@ fn mask_config_secrets(content: &str) -> String {
     fn mask_for_key(key: &str, value: &str) -> Option<String> {
         match key {
             "bot_token" => Some(mask_token(value)),
-            "password" | "rwth_core_authkey" | "ami_password" => Some(mask_secret(value)),
+            "password" | "rwth_core_authkey" | "ami_password" | "token" => Some(mask_secret(value)),
             _ => None,
         }
     }
@@ -5520,7 +5559,10 @@ fn serve_dapnet_send(
 
 #[cfg(test)]
 mod tests {
-    use super::{DashboardServer, binary_built_from, mask_config_secrets, normalize_mojibake_html, write_config_validated};
+    use super::{
+        DashboardServer, activate_config_profile, binary_built_from, is_masked_secret_key, mask_config_secrets,
+        normalize_mojibake_html, save_config_profile, write_config_validated,
+    };
     use crate::net_telemetry::TelemetryEvent;
 
     /// A minimal config.toml that parses + validates (mirrors tetra-config's own minimal fixture).
@@ -5597,6 +5639,76 @@ enabled = true
         assert!(masked.contains("[telegram_alerts]"));
         assert!(masked.contains("enabled = true"));
         assert!(masked.contains("# password = \"commented-should-stay\""), "comments untouched");
+    }
+
+    /// The [tpg2200_action] ActionURL token is the sole credential guarding the pre-auth public
+    /// /api/action/tpg2200 endpoint. It must be masked in raw config reads/backups like every other
+    /// secret — it was previously leaked in cleartext because `token` was not in the mask set.
+    #[test]
+    fn config_get_masks_tpg2200_token() {
+        let raw = "\
+[tpg2200_action]
+enabled = true
+token = \"long-random-secret-token\"
+dest_issi = 2632585
+";
+        let masked = mask_config_secrets(raw);
+        assert!(!masked.contains("long-random-secret-token"), "tpg2200 token cleartext leaked");
+        assert!(is_masked_secret_key("token"), "token must be treated as a masked secret key");
+        // Non-secret values / structure survive untouched.
+        assert!(masked.contains("[tpg2200_action]"));
+        assert!(masked.contains("dest_issi = 2632585"));
+    }
+
+    /// A malformed config profile must be rejected at save time and never written — otherwise it can
+    /// later be Activated over the live config and crash-loop the stack on the next restart. A valid
+    /// profile is accepted.
+    #[test]
+    fn profile_save_validates_before_writing() {
+        let dir = std::env::temp_dir();
+        let pid = std::process::id();
+        let cfg = dir.join(format!("fs_prof_active_{pid}.toml"));
+        std::fs::write(&cfg, MINIMAL_CONFIG).expect("seed active config");
+        let cfg_str = cfg.to_str().unwrap();
+
+        let bad_name = format!("fs_prof_bad_{pid}.toml");
+        let bad_res = save_config_profile(cfg_str, &bad_name, "this is not = valid toml [[[");
+        assert!(bad_res.is_err(), "malformed profile must be rejected");
+        assert!(!dir.join(&bad_name).exists(), "rejected profile must not be written to disk");
+
+        let ok_name = format!("fs_prof_ok_{pid}.toml");
+        save_config_profile(cfg_str, &ok_name, MINIMAL_CONFIG).expect("valid profile accepted");
+        assert!(dir.join(&ok_name).exists(), "valid profile is written");
+
+        let _ = std::fs::remove_file(&cfg);
+        let _ = std::fs::remove_file(dir.join(&ok_name));
+    }
+
+    /// Activating a profile that does not parse/validate must be refused and must leave the live
+    /// config untouched — the whole point of the fallback design is defeated if a bad profile can be
+    /// copied over config.toml unchecked.
+    #[test]
+    fn profile_activate_rejects_invalid_and_preserves_live_config() {
+        let dir = std::env::temp_dir();
+        let pid = std::process::id();
+        let cfg = dir.join(format!("fs_actprof_active_{pid}.toml"));
+        std::fs::write(&cfg, MINIMAL_CONFIG).expect("seed active config");
+        let cfg_str = cfg.to_str().unwrap();
+
+        // A pre-existing malformed profile sitting on disk next to the config.
+        let bad_name = format!("fs_actprof_bad_{pid}.toml");
+        std::fs::write(dir.join(&bad_name), "not = valid [[[").expect("seed bad profile");
+
+        let res = activate_config_profile(cfg_str, &bad_name);
+        assert!(res.is_err(), "activating an unparseable profile must be rejected");
+        assert_eq!(
+            std::fs::read_to_string(&cfg).unwrap(),
+            MINIMAL_CONFIG,
+            "live config must be untouched when activation is rejected"
+        );
+
+        let _ = std::fs::remove_file(&cfg);
+        let _ = std::fs::remove_file(dir.join(&bad_name));
     }
 
     #[test]

--- a/crates/tetra-entities/src/umac/umac_bs.rs
+++ b/crates/tetra-entities/src/umac/umac_bs.rs
@@ -1328,7 +1328,12 @@ impl UmacBs {
 
         // Handle reservation if present
         // TODO implement slightly different handling since enum is not the same.
-        unimplemented!();
+        //
+        // Until reservation handling exists, do NOT panic: this handler is reachable from any
+        // uplink SCH/F block a radio classifies as MAC-U-BLCK, so a bare `unimplemented!()` here
+        // let a single (even conformant) uplink burst abort the whole single-threaded stack. Log
+        // and drop the PDU instead, matching the sibling MAC-FRAG-UL path above.
+        unimplemented_log!("rx_ul_mac_u_blck: reservation handling not implemented -- dropping MAC-U-BLCK");
     }
 
     fn rx_ul_tma_unitdata_req(&mut self, _queue: &mut MessageQueue, message: SapMsg) {

--- a/crates/tetra-entities/tests/test_cmce_bs.rs
+++ b/crates/tetra-entities/tests/test_cmce_bs.rs
@@ -1945,6 +1945,40 @@ fn test_group_d_release_uses_unacknowledged_llc() {
 
 // â”€â”€â”€ FH FIX 1 guard: call-lifecycle telemetry must reach the dashboard sink â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
+/// Regression: a local group-call U-SETUP must notify UMAC of the floor grant (a
+/// `CallControl::FloorGranted` addressed to `TetraEntity::Umac`), so UMAC arms the originator's
+/// UL-inactivity ("stuck transmitter") timer at set-up. This grant previously passed
+/// `notify_umac = false`, so a caller who set up a group call and then dropped BEFORE transmitting a
+/// single UL frame was never timed out and the traffic slot leaked — permanently with
+/// `call_timeout_secs = 0`.
+#[test]
+fn test_group_setup_notifies_umac_floor_grant() {
+    debug::setup_logging_verbose();
+
+    let dltime = TdmaTime { h: 0, m: 1, f: 1, t: 1 };
+    let mut test = ComponentTest::new(StackMode::Bs, Some(dltime));
+    test.populate_entities(
+        vec![TetraEntity::Cmce],
+        vec![TetraEntity::Mle, TetraEntity::Umac, TetraEntity::Brew],
+    );
+
+    register_subscriber(&mut test, TEST_ISSI, TEST_GSSI);
+
+    test.submit_message(build_u_setup_msg(TEST_ISSI, TEST_GSSI));
+    test.run_stack(Some(1));
+    let msgs = test.dump_sinks();
+
+    assert!(
+        msgs.iter().any(|msg| msg.dest == TetraEntity::Umac
+            && matches!(
+                &msg.msg,
+                SapMsgInner::CmceCallControl(CallControl::FloorGranted { source_issi, dest_gssi, .. })
+                    if *source_issi == TEST_ISSI && *dest_gssi == TEST_GSSI
+            )),
+        "local group setup must send FloorGranted to UMAC so the originator's UL-inactivity timer is armed"
+    );
+}
+
 #[test]
 fn test_group_call_emits_started_and_ended_telemetry() {
     use tetra_entities::cmce::cmce_bs::CmceBs;

--- a/crates/tetra-entities/tests/test_sds_bs.rs
+++ b/crates/tetra-entities/tests/test_sds_bs.rs
@@ -1068,3 +1068,51 @@ fn test_emergency_status_forwarded_to_brew_when_opted_in() {
         "emergency status must be forwarded to Brew when forward_to_brew is true"
     );
 }
+
+/// Regression: an SDS-TL delivery short report (a U-STATUS with pre-coded status in the SDS-TL
+/// range, dest != 9999) must NOT clear an active emergency. A radio in emergency that auto-ACKs a
+/// received text would otherwise cancel its own emergency session, flapping cancel → re-alarm on the
+/// next periodic Emergency re-send. The clear must fire only for a genuine non-emergency user status.
+#[test]
+fn test_emergency_not_cleared_by_sds_tl_delivery_report() {
+    use tetra_entities::net_telemetry::{TelemetryEvent, telemetry_channel};
+
+    debug::setup_logging_verbose();
+    let dltime = TdmaTime { h: 0, m: 1, f: 1, t: 1 };
+    let config = brew_test_config();
+    let mut test = ComponentTest::from_config(config, Some(dltime));
+    // Build the sinks but wire a telemetry-enabled CMCE ourselves so we can observe emergency events.
+    test.populate_entities(vec![], vec![TetraEntity::Mle, TetraEntity::Brew]);
+    let (sink, source) = telemetry_channel();
+    let cmce = CmceBs::new(test.get_shared_config(), Some(sink), None);
+    test.register_entity(cmce);
+
+    let radio = 1000001;
+
+    // Radio enters emergency (pre-coded status 0) to the emergency address.
+    test.submit_message(build_u_status_msg(radio, 9, 0));
+    test.run_stack(Some(1));
+    test.dump_sinks();
+    let mut alarmed = false;
+    while let Some(ev) = source.try_recv() {
+        match ev {
+            TelemetryEvent::EmergencyAlarm { source_issi, .. } if source_issi == radio => alarmed = true,
+            TelemetryEvent::EmergencyCancel { .. } => panic!("emergency must not be cancelled on entry"),
+            _ => {}
+        }
+    }
+    assert!(alarmed, "radio should have entered an emergency session");
+
+    // Radio auto-ACKs a received text as an SDS-TL delivery short report: pre-coded status
+    // 0b011111_00_00000000 = 31744 (short_report_type MessageReceived, message_reference 0), which
+    // From<u16> decodes to PreCodedStatus::SdsTl. This must NOT clear the emergency.
+    const SDS_TL_SHORT_REPORT_STATUS: u16 = 31744;
+    test.submit_message(build_u_status_msg(radio, 9, SDS_TL_SHORT_REPORT_STATUS));
+    test.run_stack(Some(1));
+    test.dump_sinks();
+    while let Some(ev) = source.try_recv() {
+        if let TelemetryEvent::EmergencyCancel { source_issi } = ev {
+            panic!("SDS-TL delivery report cleared the emergency for ISSI {source_issi} — it must not");
+        }
+    }
+}

--- a/crates/tetra-pdus/src/cmce/pdus/d_sds_data.rs
+++ b/crates/tetra-pdus/src/cmce/pdus/d_sds_data.rs
@@ -123,6 +123,17 @@ impl DSdsData {
             SdsUserData::Type2(value) => buffer.write_bits(*value as u64, 32),
             SdsUserData::Type3(value) => buffer.write_bits(*value, 64),
             SdsUserData::Type4(len_bits, data) => {
+                // The SDS-TL Type-4 length indicator is an 11-bit field (max 2047 bits ≈ 255 bytes).
+                // A wider value would trip write_bits' range assertion and panic the whole stack, so
+                // reject it as InvalidValue before it reaches the bit writer (defence in depth,
+                // mirroring the GSSI guard in ss_dgna/fields/group_assignment.rs). Callers building
+                // SDS from control/dashboard/integration input must range-check the length first.
+                if *len_bits > 2047 {
+                    return Err(PduParseErr::InvalidValue {
+                        field: "sds_type4_length_bits",
+                        value: *len_bits as u64,
+                    });
+                }
                 // Defensive: never index past the payload, even if len_bits over-claims
                 // the length. The Brew ingress path (worker.rs) already rejects such
                 // frames; this guards any other caller from an out-of-bounds panic.
@@ -202,6 +213,42 @@ mod tests {
         let mut buf = BitBuffer::new_autoexpand(512);
         // The point of this test is simply that this returns instead of panicking.
         let _ = pdu.to_bitbuf(&mut buf);
+    }
+
+    /// Regression: a Type4 length that exceeds the real 11-bit field width (>= 2048) must be
+    /// REJECTED (Err) by the serializer, not panic the whole stack via write_bits' range assertion.
+    /// The oversized-SDS guard in sds_bs.rs previously capped at u16::MAX/8 = 8191 bytes (assuming a
+    /// 16-bit field), so a 256..8191-byte payload reached here and crashed the cell.
+    #[test]
+    fn type4_length_over_11bit_field_is_rejected_not_panic() {
+        let pdu = DSdsData {
+            calling_party_type_identifier: PartyTypeIdentifier::Ssi,
+            calling_party_address_ssi: Some(1000001),
+            calling_party_extension: None,
+            // 256-byte payload => 2048 bits, one over the 11-bit field maximum (2047).
+            user_defined_data: SdsUserData::Type4(2048, vec![0xABu8; 256]),
+            external_subscriber_number: None,
+            dm_ms_address: None,
+        };
+        let mut buf = BitBuffer::new_autoexpand(4096);
+        let err = pdu.to_bitbuf(&mut buf);
+        assert!(matches!(err, Err(PduParseErr::InvalidValue { field: "sds_type4_length_bits", .. })));
+    }
+
+    /// The exact boundary: 2047 bits (255 bytes) is the largest value the 11-bit field can hold and
+    /// must still serialize cleanly.
+    #[test]
+    fn type4_length_at_11bit_field_max_is_ok() {
+        let pdu = DSdsData {
+            calling_party_type_identifier: PartyTypeIdentifier::Ssi,
+            calling_party_address_ssi: Some(1000001),
+            calling_party_extension: None,
+            user_defined_data: SdsUserData::Type4(2047, vec![0xABu8; 256]),
+            external_subscriber_number: None,
+            dm_ms_address: None,
+        };
+        let mut buf = BitBuffer::new_autoexpand(4096);
+        assert!(pdu.to_bitbuf(&mut buf).is_ok());
     }
 
     #[test]

--- a/crates/tetra-pdus/src/cmce/pdus/u_sds_data.rs
+++ b/crates/tetra-pdus/src/cmce/pdus/u_sds_data.rs
@@ -146,14 +146,25 @@ impl USdsData {
             SdsUserData::Type2(value) => buffer.write_bits(*value as u64, 32),
             SdsUserData::Type3(value) => buffer.write_bits(*value, 64),
             SdsUserData::Type4(len_bits, data) => {
+                // The SDS-TL Type-4 length indicator is an 11-bit field (max 2047 bits ≈ 255 bytes).
+                // A wider value would trip write_bits' range assertion and panic; reject it as
+                // InvalidValue before the writer (defence in depth, matching d_sds_data.rs).
+                if *len_bits > 2047 {
+                    return Err(PduParseErr::InvalidValue {
+                        field: "sds_type4_length_bits",
+                        value: *len_bits as u64,
+                    });
+                }
+                // Defensive: never index past the payload, even if len_bits over-claims the length.
+                let used_bits = (*len_bits as usize).min(data.len() * 8);
                 buffer.write_bits(*len_bits as u64, 11);
-                let full_bytes = (*len_bits as usize) / 8;
-                let remaining_bits = len_bits % 8;
+                let full_bytes = used_bits / 8;
+                let remaining_bits = used_bits % 8;
                 for i in 0..full_bytes {
                     buffer.write_bits(data[i] as u64, 8);
                 }
                 if remaining_bits > 0 {
-                    buffer.write_bits((data[full_bytes] >> (8 - remaining_bits)) as u64, remaining_bits as usize);
+                    buffer.write_bits((data[full_bytes] >> (8 - remaining_bits)) as u64, remaining_bits);
                 }
             }
         }


### PR DESCRIPTION
## What & why

Hardening pass targeting the recurring bug class in this project — **panics that crash the whole (single-threaded, no `catch_unwind`) stack** — plus a set of call-control / interconnect / dashboard correctness bugs found in the same audit. Two of the panics are reachable and take the entire cell down.

## Fixes

### 🔴 Panics that crash the cell
1. **`fix(umac)` — uplink MAC-U-BLCK** (`umac/umac_bs.rs`). `rx_ul_mac_u_blck` fell into a bare `unimplemented!()` right after parsing, so **any** uplink SCH/F block a radio classifies as MAC-U-BLCK aborted the process. A single frame — even from a conformant radio — took the cell down. Now logs and drops the PDU, like the sibling MAC-FRAG-UL path.
2. **`fix(sds)` — oversized Type-4 SDS** (`sds_bs.rs`, `{d,u}_sds_data.rs`). The SDS-TL Type-4 length indicator is an **11-bit** field (max 2047 bits = 255 bytes), but the oversized-SDS guard capped at `u16::MAX/8 = 8191` bytes (it assumed 16 bits). A 256..8191-byte wrapped payload passed the guard and tripped `write_bits`' range assertion in `to_bitbuf`, panicking. Reachable from a dashboard SDS > ~251 chars to a local ISSI/group, and from the raw DAPNET/GeoAlarm/TPG2200 call-out path (which had **no** guard at all). Fixed the caps + made `to_bitbuf` return `InvalidValue` instead of panicking (defence in depth).

### 🟠 Call control / interconnect
3. **`fix(cmce)` — leaked traffic slot on group set-up** (`cc_bs/procedures/setup.rs`). The group-call originator was granted the floor with `notify_umac = false` (the only grant in the tree that did), so UMAC never armed the UL-inactivity timer for the caller. A caller who set up a group call and dropped **before** transmitting a UL frame was never timed out — the slot stayed `Transmitting` until the absolute call time-out, and with `call_timeout_secs = 0` it **leaked permanently**. Now grants with `notify_umac = true` like every other path.
4. **`fix(sds)` — emergency cleared by a delivery report** (`sds_bs.rs`). Any non-Emergency U-STATUS was treated as a "user cancelled emergency". But an SDS-TL delivery short report also arrives as a U-STATUS, so a radio in emergency that auto-ACKs a received text cleared its own emergency, flapping cancel → re-alarm (+ Telegram). SDS-TL reports now route through without touching emergency state.
5. **`fix(brew)` — REREGISTER after reconnect** (`net_brew/worker.rs`). The worker's `subscriber_groups` map persisted across reconnects, so the post-reconnect resync emitted REREGISTER (not REGISTER) for every subscriber. A core that restarted while we were disconnected can reject REREGISTER-for-unknown, leaving local MS unregistered until a power-cycle. The map is now cleared on each (re)connection; the entity re-drives affiliations after Connected, so no group state is lost.

### 🟠 Dashboard / config correctness
6. **Config profiles bypassed validation** — `save_config_profile`/`activate_config_profile` did raw `fs::write`/`fs::copy` with no parse+`validate()`, so a malformed profile could be Activated over the live config and crash-loop the stack on the next restart. They now validate like `write_config_validated` does.
7. **`[tpg2200_action]` token leaked** — it was returned in cleartext by `GET /api/config` and `/api/config/backup` (only `password`/`bot_token`/`rwth_core_authkey`/`ami_password` were masked). It's the sole credential guarding the pre-auth `/api/action/tpg2200` endpoint. Now masked.
8. **Profile save corrupted secrets** — `save_config_profile` didn't unmask, so saving a profile without retyping a secret wrote the `••••` placeholder over the real credential. Now unmasks against the profile's own on-disk content.

## Testing

- `cargo check` clean on all touched crates.
- **7 new regression tests** (all green): SDS length `> 2047` bits rejected (not panic) + boundary at 2047; group set-up emits `FloorGranted` to UMAC; SDS-TL delivery report keeps an active emergency (telemetry-observed); tpg2200 token masking; profile save/activate reject invalid TOML.
- No regressions in existing suites: `tetra-pdus` SDS 11/11 · dashboard 10/10 · `test_sds_bs` 19/19 · `test_umac_bs` 15/15 · `test_cmce_bs` 37/37 · `net_brew` 11/11.

### Note on the Brew fix
The `net_brew` reconnect fix (#5) has no unit test — there is no `BrewWorker` + mock-transport harness in the tree today, and building a connect→disconnect→reconnect one to inspect REGISTER-vs-REREGISTER framing was out of scope for this PR. The change is a localized `subscriber_groups.clear()` at the top of the (re)connect loop; it compiles and the protocol suite is unaffected.
