### PR TITLE
v0.4.0 hardening: reachable panics, unbounded state, and the two SIP bugs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -156,7 +156,7 @@ dependencies = [
 
 [[package]]
 name = "bluestation-bs"
-version = "0.3.9"
+version = "0.4.0"
 dependencies = [
  "clap",
  "crossbeam-channel",
@@ -1833,7 +1833,7 @@ dependencies = [
 
 [[package]]
 name = "tetra-config"
-version = "0.3.9"
+version = "0.4.0"
 dependencies = [
  "chrono-tz",
  "serde",
@@ -1843,7 +1843,7 @@ dependencies = [
 
 [[package]]
 name = "tetra-core"
-version = "0.3.9"
+version = "0.4.0"
 dependencies = [
  "bitcode",
  "chrono",
@@ -1859,7 +1859,7 @@ dependencies = [
 
 [[package]]
 name = "tetra-entities"
-version = "0.3.9"
+version = "0.4.0"
 dependencies = [
  "as-any",
  "base64",
@@ -1892,7 +1892,7 @@ dependencies = [
 
 [[package]]
 name = "tetra-pdus"
-version = "0.3.9"
+version = "0.4.0"
 dependencies = [
  "tetra-config",
  "tetra-core",
@@ -1902,7 +1902,7 @@ dependencies = [
 
 [[package]]
 name = "tetra-saps"
-version = "0.3.9"
+version = "0.4.0"
 dependencies = [
  "tetra-core",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,7 +86,7 @@ useless_format = "allow"
 while_let_loop = "allow"
 
 [workspace.package]
-version = "0.3.9"
+version = "0.4.0"
 edition = "2024"
 authors = ["Razvan Zeces / FlowStation.Dev"]
 license = "MIT"

--- a/bins/bluestation-bs/src/main.rs
+++ b/bins/bluestation-bs/src/main.rs
@@ -225,6 +225,15 @@ fn build_bs_stack(
                     restart_on_core_stall: hcfg.restart_on_core_stall,
                     restart_after_critical: Duration::from_secs(hcfg.restart_after_critical_secs),
                     restart_cooldown: Duration::from_secs(hcfg.restart_cooldown_secs),
+                    // The cooldown has to survive the restart it triggers, otherwise a stall that
+                    // reproduces at boot reboots forever. Stamp file next to the config, same
+                    // convention as recovery_cache.json.
+                    restart_state_path: Some(
+                        std::path::Path::new(config_path)
+                            .parent()
+                            .map(|d| d.join("health_restart_state"))
+                            .unwrap_or_else(|| std::path::PathBuf::from("health_restart_state")),
+                    ),
                 },
             );
         }

--- a/contrib/packaging/bluestation-bs.service
+++ b/contrib/packaging/bluestation-bs.service
@@ -9,6 +9,10 @@ Wants=network-online.target
 # legitimate web-triggered restarts and the in-process SDR-open retries never trip
 # it. If it does trip, recover with a power cycle + `systemctl start` (a hard power
 # cycle clears an SDR that a software restart couldn't), or `systemctl reset-failed`.
+# Outer limiter for every restart cause: a panic exit (101), a watchdog restart
+# (75) and an OTA/web restart all count against it. The in-process watchdog
+# cooldown persists its last-restart stamp (health_restart_state, next to the
+# config) so it survives a restart too.
 StartLimitIntervalSec=300
 StartLimitBurst=10
 
@@ -19,6 +23,9 @@ ExecStart=/usr/bin/bluestation-bs /etc/flowstation/config.toml
 CPUSchedulingPolicy=fifo
 CPUSchedulingPriority=73
 KillSignal=SIGINT
+# on-failure covers a panic exit (101) and the watchdog's restart exit (75), but
+# not a clean stop/SIGINT. RestartSec spaces the retries so the burst above takes
+# ~2 min of wall clock instead of a second.
 Restart=on-failure
 RestartSec=10
 

--- a/contrib/systemd/bluestation-bs.service
+++ b/contrib/systemd/bluestation-bs.service
@@ -27,6 +27,10 @@ Wants=network-online.target
 # "failed" state instead of crash-looping forever. Generous enough that a
 # legitimate web-triggered restart and the in-process SDR-open retries never
 # trip it; recover with a power cycle + `systemctl start`, or `systemctl reset-failed`.
+# This is the outer limiter for every restart cause: a panic exit (101), a
+# watchdog restart (75) and an OTA/web restart all count against it. The
+# in-process watchdog cooldown persists its last-restart stamp
+# (health_restart_state, next to the config), so it survives a restart too.
 StartLimitIntervalSec=300
 StartLimitBurst=10
 
@@ -53,6 +57,8 @@ KillSignal=SIGINT
 # Restart automatically on crash or unexpected exit.
 # on-failure covers: non-zero exit, killed by signal, timeout.
 # Does NOT restart on clean exit (systemctl stop) or SIGINT (graceful shutdown).
+# RestartSec spaces the retries out so 10 attempts take ~2 min of wall clock,
+# not 10 attempts in a second.
 Restart=on-failure
 RestartSec=10
 

--- a/crates/tetra-config/src/bluestation/sec_asterisk.rs
+++ b/crates/tetra-config/src/bluestation/sec_asterisk.rs
@@ -28,6 +28,14 @@ pub struct CfgAsterisk {
     pub password: SecretField,
     pub realm: String,
     pub options_interval_secs: u64,
+    /// RTP packet duration in ms. Real trunks expect 20 ms / 160 byte G.711 packets.
+    pub ptime_ms: u16,
+    /// Extra source hosts allowed to talk SIP to us besides the resolved Asterisk peer.
+    pub allow_from: Vec<String>,
+    /// Cap on dialogs that have not been answered yet, per bridge.
+    pub max_pending_dialogs: usize,
+    /// Inbound INVITEs accepted per source address per minute (0 disables the limit).
+    pub max_invites_per_minute: u32,
 }
 
 impl Default for CfgAsterisk {
@@ -78,6 +86,14 @@ pub struct CfgAsteriskDto {
     pub realm: String,
     #[serde(default = "default_options_interval_secs")]
     pub options_interval_secs: u64,
+    #[serde(default = "default_ptime_ms")]
+    pub ptime_ms: u16,
+    #[serde(default)]
+    pub allow_from: Vec<String>,
+    #[serde(default = "default_max_pending_dialogs")]
+    pub max_pending_dialogs: usize,
+    #[serde(default = "default_max_invites_per_minute")]
+    pub max_invites_per_minute: u32,
 
     #[serde(flatten)]
     pub extra: HashMap<String, Value>,
@@ -106,6 +122,10 @@ impl Default for CfgAsteriskDto {
             password: String::new(),
             realm: default_realm(),
             options_interval_secs: default_options_interval_secs(),
+            ptime_ms: default_ptime_ms(),
+            allow_from: Vec::new(),
+            max_pending_dialogs: default_max_pending_dialogs(),
+            max_invites_per_minute: default_max_invites_per_minute(),
             extra: HashMap::new(),
         }
     }
@@ -139,8 +159,9 @@ fn default_rtp_port_max() -> u16 {
     30100
 }
 
+// Loopback by default: anything reachable on this port can place calls into the TETRA cell.
 fn default_bind_addr() -> String {
-    "0.0.0.0".to_string()
+    "127.0.0.1".to_string()
 }
 
 fn default_bind_port() -> u16 {
@@ -179,6 +200,18 @@ fn default_options_interval_secs() -> u64 {
     30
 }
 
+fn default_ptime_ms() -> u16 {
+    20
+}
+
+fn default_max_pending_dialogs() -> usize {
+    8
+}
+
+fn default_max_invites_per_minute() -> u32 {
+    30
+}
+
 pub fn apply_asterisk_patch(src: CfgAsteriskDto) -> Result<CfgAsterisk, String> {
     if src.enabled {
         if src.bind_port == 0 {
@@ -209,6 +242,17 @@ pub fn apply_asterisk_patch(src: CfgAsteriskDto) -> Result<CfgAsterisk, String> 
         return Err("asterisk: only codec = \"PCMU\" is currently supported".to_string());
     }
 
+    if !matches!(src.ptime_ms, 20 | 40 | 60) {
+        return Err("asterisk: ptime_ms must be 20, 40 or 60".to_string());
+    }
+
+    let allow_from = src
+        .allow_from
+        .into_iter()
+        .map(|h| h.trim().to_string())
+        .filter(|h| !h.is_empty())
+        .collect();
+
     let service_numbers = src
         .service_numbers
         .into_iter()
@@ -237,5 +281,9 @@ pub fn apply_asterisk_patch(src: CfgAsteriskDto) -> Result<CfgAsterisk, String> 
         password: SecretField::from(src.password),
         realm: src.realm,
         options_interval_secs: src.options_interval_secs,
+        ptime_ms: src.ptime_ms,
+        allow_from,
+        max_pending_dialogs: src.max_pending_dialogs,
+        max_invites_per_minute: src.max_invites_per_minute,
     })
 }

--- a/crates/tetra-config/src/bluestation/sec_security.rs
+++ b/crates/tetra-config/src/bluestation/sec_security.rs
@@ -1,24 +1,105 @@
 use serde::Deserialize;
 
+/// How `issi_whitelist` is interpreted. A bare `Vec` cannot express "deny everyone": an operator
+/// who empties the list to lock the cell down actually opens it fully under the legacy semantics.
+/// This makes the posture explicit.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum WhitelistMode {
+    /// No mode configured — legacy semantics: an empty list means "open network", a non-empty
+    /// list is an allow-list. Default so existing configs behave exactly as before.
+    #[default]
+    Auto,
+    /// Access control off: every ISSI is allowed whatever the list holds.
+    Open,
+    /// The list is authoritative. An EMPTY list therefore means DENY-ALL — the only way to
+    /// express "lock the cell down", which `Auto` cannot.
+    Enforce,
+}
+
+impl WhitelistMode {
+    fn parse(s: &str) -> Option<Self> {
+        match s.trim().to_ascii_lowercase().as_str() {
+            "auto" => Some(WhitelistMode::Auto),
+            "open" | "off" | "disabled" => Some(WhitelistMode::Open),
+            "enforce" | "strict" => Some(WhitelistMode::Enforce),
+            _ => None,
+        }
+    }
+}
+
+/// Default cap on the MM client registry. Uplink is unauthenticated (EN 300 392-7 TEA is not
+/// implemented), so any radio can claim any of the 2^24 ISSIs — without a cap a registration
+/// flood grows the registry until the cell is OOM-killed.
+pub const DEFAULT_MAX_REGISTERED_CLIENTS: usize = 2048;
+/// Default accepted registrations per minute, per source ISSI. Generous for a real radio (T351
+/// plus a post-PTT roaming update), tight enough that one forged ISSI cannot churn the registry.
+pub const DEFAULT_REGISTRATION_RATE_LIMIT_PER_MIN: u32 = 30;
+
 /// Access control / security configuration
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone)]
 pub struct CfgSecurity {
-    /// ISSI whitelist. If non-empty, only these ISSIs are allowed to register.
-    /// An empty list means all ISSIs are accepted (open network).
+    /// ISSI whitelist. Interpretation depends on `whitelist_mode`.
     /// Example config:
     ///   [security]
     ///   issi_whitelist = [2260571, 1001, 1002]
+    ///   whitelist_mode = "enforce"   # empty list = deny-all
     pub issi_whitelist: Vec<u32>,
+    /// See [`WhitelistMode`].
+    pub whitelist_mode: WhitelistMode,
+    /// Honour an unauthenticated U-ITSI-DETACH / migrating location update as a teardown of the
+    /// claimed ISSI. There is no air-interface authentication, so such a PDU is forgeable and a
+    /// replay is a targeted DoS; an operator who does not need detach at all can switch it off.
+    pub honour_unauthenticated_detach: bool,
+    /// Hard cap on the MM client registry (0 = unlimited, pre-hardening behaviour).
+    pub max_registered_clients: usize,
+    /// Accepted registrations per minute per source ISSI (0 = disabled).
+    pub registration_rate_limit_per_min: u32,
+}
+
+impl Default for CfgSecurity {
+    fn default() -> Self {
+        CfgSecurity {
+            issi_whitelist: Vec::new(),
+            whitelist_mode: WhitelistMode::Auto,
+            honour_unauthenticated_detach: true,
+            max_registered_clients: DEFAULT_MAX_REGISTERED_CLIENTS,
+            registration_rate_limit_per_min: DEFAULT_REGISTRATION_RATE_LIMIT_PER_MIN,
+        }
+    }
 }
 
 impl CfgSecurity {
     /// Returns true if the given ISSI is allowed to register.
-    /// When the whitelist is empty, all ISSIs are allowed.
     pub fn is_issi_allowed(&self, issi: u32) -> bool {
-        if self.issi_whitelist.is_empty() {
-            return true;
+        self.allows(issi, None)
+    }
+
+    /// Whitelist decision honouring an optional runtime (dashboard) override list, which replaces
+    /// the configured list. The mode applies to whichever list is effective, so an operator who
+    /// clears the list from the dashboard under `enforce` gets deny-all, not an open cell.
+    pub fn allows(&self, issi: u32, override_list: Option<&[u32]>) -> bool {
+        let list = override_list.unwrap_or(&self.issi_whitelist);
+        match self.whitelist_mode {
+            WhitelistMode::Open => true,
+            WhitelistMode::Auto => list.is_empty() || list.contains(&issi),
+            WhitelistMode::Enforce => list.contains(&issi),
         }
-        self.issi_whitelist.contains(&issi)
+    }
+
+    /// One-line description of the effective access-control posture, for the startup log. The
+    /// whole point is that an operator can read the cell's real posture out of the log rather
+    /// than inferring it from an empty TOML array.
+    pub fn access_control_posture(&self) -> String {
+        let n = self.issi_whitelist.len();
+        match self.whitelist_mode {
+            WhitelistMode::Open => "OPEN — access control disabled (whitelist_mode = \"open\")".to_string(),
+            WhitelistMode::Auto if n == 0 => {
+                "OPEN — no issi_whitelist configured; ANY ISSI may register (set whitelist_mode = \"enforce\" to lock down)".to_string()
+            }
+            WhitelistMode::Auto => format!("ALLOW-LIST — {n} ISSI(s) may register"),
+            WhitelistMode::Enforce if n == 0 => "DENY-ALL — whitelist_mode = \"enforce\" with an empty issi_whitelist".to_string(),
+            WhitelistMode::Enforce => format!("ALLOW-LIST (enforced) — {n} ISSI(s) may register"),
+        }
     }
 }
 
@@ -26,10 +107,68 @@ impl CfgSecurity {
 pub struct CfgSecurityDto {
     #[serde(default)]
     pub issi_whitelist: Vec<u32>,
+    #[serde(default)]
+    pub whitelist_mode: Option<String>,
+    #[serde(default)]
+    pub honour_unauthenticated_detach: Option<bool>,
+    #[serde(default)]
+    pub max_registered_clients: Option<usize>,
+    #[serde(default)]
+    pub registration_rate_limit_per_min: Option<u32>,
 }
 
 pub fn apply_security_patch(dto: CfgSecurityDto) -> CfgSecurity {
+    let defaults = CfgSecurity::default();
+    // An unrecognised mode falls back to "auto"; the effective posture is logged at startup
+    // (see access_control_posture) so a typo can't silently pass for a lockdown.
+    let whitelist_mode = dto
+        .whitelist_mode
+        .as_deref()
+        .map(|s| WhitelistMode::parse(s).unwrap_or(WhitelistMode::Auto))
+        .unwrap_or(WhitelistMode::Auto);
     CfgSecurity {
         issi_whitelist: dto.issi_whitelist,
+        whitelist_mode,
+        honour_unauthenticated_detach: dto.honour_unauthenticated_detach.unwrap_or(defaults.honour_unauthenticated_detach),
+        max_registered_clients: dto.max_registered_clients.unwrap_or(defaults.max_registered_clients),
+        registration_rate_limit_per_min: dto
+            .registration_rate_limit_per_min
+            .unwrap_or(defaults.registration_rate_limit_per_min),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The footgun: an empty list must stay "open" under the legacy default, but `enforce` must
+    /// make the same empty list mean deny-all.
+    #[test]
+    fn empty_whitelist_semantics_depend_on_mode() {
+        let mut cfg = CfgSecurity::default();
+        assert!(cfg.is_issi_allowed(1234), "empty list under auto = open network");
+
+        cfg.whitelist_mode = WhitelistMode::Enforce;
+        assert!(!cfg.is_issi_allowed(1234), "empty list under enforce = deny-all");
+
+        cfg.issi_whitelist = vec![1234];
+        assert!(cfg.is_issi_allowed(1234));
+        assert!(!cfg.is_issi_allowed(5678));
+
+        cfg.whitelist_mode = WhitelistMode::Open;
+        assert!(cfg.is_issi_allowed(5678), "open ignores the list entirely");
+    }
+
+    /// The dashboard override replaces the list but not the mode.
+    #[test]
+    fn override_list_follows_the_configured_mode() {
+        let mut cfg = CfgSecurity::default();
+        cfg.issi_whitelist = vec![1];
+        assert!(cfg.allows(2, Some(&[2])), "override list is authoritative");
+        assert!(!cfg.allows(1, Some(&[2])), "config list is ignored when overridden");
+        assert!(cfg.allows(9, Some(&[])), "empty override under auto = open");
+
+        cfg.whitelist_mode = WhitelistMode::Enforce;
+        assert!(!cfg.allows(9, Some(&[])), "empty override under enforce = deny-all");
     }
 }

--- a/crates/tetra-core/src/bitbuffer.rs
+++ b/crates/tetra-core/src/bitbuffer.rs
@@ -135,19 +135,35 @@ impl BitBuffer {
     }
 
     /// Takes slice as parameter for output. Reads slice.len() bits from bitbuf[pos], and writes to output slice. 1 bit per byte.
-    pub fn to_bitarr(&mut self, buf: &mut [u8]) {
-        // TODO bounds check here, optimize performance
+    /// Returns None without advancing if fewer than `buf.len()` bits remain in the window.
+    #[must_use]
+    pub fn try_to_bitarr(&mut self, buf: &mut [u8]) -> Option<()> {
+        // Bounds check up front so the reads below cannot fail halfway through
+        if self.get_len_remaining() < buf.len() {
+            return None;
+        }
+
+        // TODO optimize performance
         let num_bits = buf.len();
         let mut bits_remaining = num_bits;
         while bits_remaining > 0 {
             let bits_to_read = usize::min(bits_remaining, 64);
-            let v = self.read_bits(bits_to_read).unwrap(); // Guaranteed
+            let v = self.read_bits(bits_to_read)?; // Guaranteed by the check above
             for i in 0..bits_to_read {
                 let bit = ((v >> (bits_to_read - 1 - i)) & 0x1) as u8;
                 buf[buf.len() - bits_remaining + i] = bit;
             }
             bits_remaining -= bits_to_read;
         }
+        Some(())
+    }
+
+    /// Takes slice as parameter for output. Reads slice.len() bits from bitbuf[pos], and writes to output slice. 1 bit per byte.
+    /// Panics if fewer than `buf.len()` bits remain: only for fixed-size blocks, anything
+    /// sized by wire data must use `try_to_bitarr`.
+    pub fn to_bitarr(&mut self, buf: &mut [u8]) {
+        self.try_to_bitarr(buf)
+            .expect("to_bitarr: not enough bits remaining in window");
     }
 
     /// Convert the entire window (start to end) into a String of '0'/'1' characters.
@@ -173,15 +189,17 @@ impl BitBuffer {
         // let abs_offset = self.pos as isize + offset;
         // tracing::trace!("peek_bits_posoffset: {} bits at {}", num_bits, self.pos as isize + offset);
         // println!("peek_bits_offset: {} bits at {}", num_bits, self.pos as isize + offset);
-        let start_offset = self.pos - self.start + offset as usize;
+        // Checked: a negative or oversized offset must return None, not wrap into a huge usize
+        let start_offset = (self.pos - self.start).checked_add_signed(offset)?;
         self.peek_bits_startoffset(start_offset, num_bits)
     }
 
     /// Peek `num_bits` with offset from window start, without advancing.
     /// Returns None on overflow or if `num_bits>64`.
     pub fn peek_bits_startoffset(&self, offset: usize, num_bits: usize) -> Option<u64> {
-        let abs_pos = self.start + offset;
-        if num_bits > 64 || self.start + offset + num_bits > self.end {
+        // Checked adds: `offset` may come from wire data, and overflowing here panics on debug builds
+        let abs_pos = self.start.checked_add(offset)?;
+        if num_bits > 64 || abs_pos.checked_add(num_bits)? > self.end {
             return None;
         }
 
@@ -211,7 +229,11 @@ impl BitBuffer {
     /// Read `num_bits` at the current pos, advancing pos, and write them into the provided output slice as bytes
     pub fn read_bits_into_slice(&mut self, num_bits: usize, buf: &mut [u8]) -> Option<()> {
         let num_bytes = num_bits.div_ceil(8);
-        assert!(buf.len() >= num_bytes, "output buffer too small for num_bits");
+        // `num_bits` is typically wire-derived (e.g. SDS user data length), so a too-small
+        // output buffer is a decode failure, not a bug: return None instead of panicking
+        if buf.len() < num_bytes {
+            return None;
+        }
 
         let mut bits_remaining = num_bits;
         for i in 0..num_bytes {
@@ -480,30 +502,56 @@ impl BitBuffer {
     }
 
     /// Seek `pos` to `offset` (relative to window start).
+    /// Returns None and leaves `pos` untouched if the target lies outside the window.
+    /// Use this, not `seek`, for any offset derived from wire data.
+    #[must_use]
+    pub fn try_seek(&mut self, offset: usize) -> Option<()> {
+        let abs = self.start.checked_add(offset)?;
+        if abs > self.end {
+            return None;
+        }
+        self.pos = abs;
+        Some(())
+    }
+
+    /// Seek `pos` to `offset` (relative to window start).
+    /// Panics if out of window: only for provably-in-range offsets, wire-derived
+    /// offsets must go through `try_seek`.
     pub fn seek(&mut self, offset: usize) {
-        let abs = self.start + offset;
         assert!(
-            abs <= self.end,
+            self.try_seek(offset).is_some(),
             "seek out of window: got {}, allowed [{},{}]",
-            abs,
+            self.start.wrapping_add(offset),
             self.start,
             self.end
         );
-        self.pos = abs;
+    }
+
+    /// Move the current bit-pointer by `offset` bits (can be negative).
+    /// Returns None and leaves `pos` untouched if the resulting position would lie
+    /// outside the window `[start..=end]`.
+    /// Use this, not `seek_rel`, for any offset derived from wire data.
+    #[must_use]
+    pub fn try_seek_rel(&mut self, offset: isize) -> Option<()> {
+        let new_pos = self.pos.checked_add_signed(offset)?;
+        if new_pos < self.start || new_pos > self.end {
+            return None;
+        }
+        self.pos = new_pos;
+        Some(())
     }
 
     /// Move the current bit‐pointer by `offset` bits (can be negative).
     /// Panics if the resulting position would lie outside the window `[start..=end]`.
+    /// Only for provably-in-range offsets: wire-derived offsets must go through `try_seek_rel`.
     pub fn seek_rel(&mut self, offset: isize) {
-        let new_pos = (self.pos as isize + offset) as usize;
         assert!(
-            new_pos >= self.start && new_pos <= self.end,
+            self.try_seek_rel(offset).is_some(),
             "seek out of window: got {}, allowed [{},{}]",
-            new_pos,
+            (self.pos as isize).wrapping_add(offset),
             self.start,
             self.end
         );
-        self.pos = new_pos;
     }
 
     // Raw operations that do not take start, end cursors into account ///////////////////////////////////////
@@ -872,6 +920,44 @@ mod tests {
         let mut arr = vec![0u8; 8];
         bb.to_bitarr(&mut arr);
         assert_eq!(arr, vec![1, 0, 1, 1, 0, 0, 1, 1]);
+    }
+
+    #[test]
+    fn test_try_seek_out_of_window() {
+        let mut bb = BitBuffer::from_bitstr("10110011");
+        bb.seek(4);
+
+        // Past the end, before the start, and a wrapping-huge offset all fail without moving pos
+        assert!(bb.try_seek_rel(5).is_none());
+        assert!(bb.try_seek_rel(-5).is_none());
+        assert!(bb.try_seek_rel(isize::MIN).is_none());
+        assert!(bb.try_seek(9).is_none());
+        assert_eq!(bb.get_pos(), 4);
+
+        // Landing exactly on the end is allowed
+        assert!(bb.try_seek_rel(4).is_some());
+        assert_eq!(bb.get_pos(), 8);
+        assert!(bb.try_seek(0).is_some());
+        assert_eq!(bb.get_pos(), 0);
+    }
+
+    #[test]
+    fn test_try_to_bitarr_short_buffer() {
+        let mut bb = BitBuffer::from_bitstr("1011");
+        let mut arr = [0u8; 8];
+        assert!(bb.try_to_bitarr(&mut arr).is_none());
+        assert_eq!(bb.get_pos(), 0);
+        assert!(bb.try_to_bitarr(&mut arr[0..4]).is_some());
+        assert_eq!(arr, [1, 0, 1, 1, 0, 0, 0, 0]);
+    }
+
+    #[test]
+    fn test_read_bits_into_slice_short_buffer() {
+        let mut bb = BitBuffer::from_bitstr("10110011011");
+        let mut out = [0u8; 1];
+        // Output slice too small for a (wire-derived) length: None instead of a panic
+        assert!(bb.read_bits_into_slice(11, &mut out).is_none());
+        assert_eq!(bb.get_pos(), 0);
     }
 
     #[test]

--- a/crates/tetra-core/src/typed_pdu_fields.rs
+++ b/crates/tetra-core/src/typed_pdu_fields.rs
@@ -226,6 +226,15 @@ pub mod typed {
             }
         };
 
+        // The length indicator is attacker-controlled: if it claims more bits than the SDU
+        // actually holds, bail out here. Otherwise the skip-forward below would seek past the
+        // window end and panic the entity.
+        if len_bits > buffer.get_len_remaining() {
+            return Err(PduParseErr::BufferEnded {
+                field: Some("parse_type3_generic data"),
+            });
+        }
+
         // Read up to 128 bits of payload. BitBuffer::read_bits is u64-only, so for
         // lengths over 64 we split into two reads (high half first, then low half).
         let read_bits = if len_bits > 128 { 128 } else { len_bits };
@@ -263,7 +272,11 @@ pub mod typed {
         // Seek forward past any bits beyond what we stored (>128 bits).
         if len_bits > 128 {
             tracing::warn!("Type3 element {} length {} exceeds 128 bits, data truncated", id, len_bits);
-            buffer.seek_rel(len_bits as isize - 128);
+            if buffer.try_seek_rel(len_bits as isize - 128).is_none() {
+                return Err(PduParseErr::BufferEnded {
+                    field: Some("parse_type3_generic skip"),
+                });
+            }
         }
 
         Ok(Some(Type3FieldGeneric {
@@ -468,7 +481,23 @@ pub mod typed {
             buffer.dump_bin()
         );
 
-        Ok(Some((num_elems, len_bits - 6)))
+        // The wire length covers the 6-bit element counter plus the payload. Anything below 6 is
+        // malformed and would underflow the subtraction (panic on overflow-checked builds, huge
+        // value otherwise, feeding the seek in parse_type4_generic).
+        let payload_bits = len_bits.checked_sub(6).ok_or(PduParseErr::InconsistentLength {
+            expected: 6,
+            found: len_bits,
+        })?;
+
+        // Attacker-controlled length: reject anything longer than the SDU actually holds, so
+        // callers can never seek or read past the window end.
+        if payload_bits > buffer.get_len_remaining() {
+            return Err(PduParseErr::BufferEnded {
+                field: Some("parse_type4_header payload"),
+            });
+        }
+
+        Ok(Some((num_elems, payload_bits)))
     }
 
     /// Parse a Type-4 element into a Vec of structs that implement `from_bitbuf`.
@@ -554,7 +583,11 @@ pub mod typed {
                 // Seek forward to end of element, if larger than 64 bits
                 if len_bits > 64 {
                     tracing::warn!("Type4 element {} length {} exceeds 64 bits, data truncated", id, len_bits);
-                    buffer.seek_rel(len_bits as isize - 64);
+                    if buffer.try_seek_rel(len_bits as isize - 64).is_none() {
+                        return Err(PduParseErr::BufferEnded {
+                            field: Some("parse_type4_generic skip"),
+                        });
+                    }
                 }
 
                 // Parsed and expected length matches, return result
@@ -642,5 +675,143 @@ pub mod typed {
         }
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::typed::{parse_type3_generic, parse_type4_generic};
+    use super::{Type3FieldGeneric, Type4FieldGeneric};
+    use crate::{bitbuffer::BitBuffer, pdu_parse_error::PduParseErr};
+
+    /// Build a Type-3 element on the wire: m-bit + 4-bit id + 11-bit length + payload
+    fn type3_elem(id: u64, len_bits: usize, payload: &str) -> BitBuffer {
+        BitBuffer::from_bitstr(&format!("1{:04b}{:011b}{}", id, len_bits, payload))
+    }
+
+    /// Build a Type-4 element on the wire: m-bit + 4-bit id + 11-bit length + 6-bit count + payload
+    fn type4_elem(id: u64, len_bits: usize, num_elems: usize, payload: &str) -> BitBuffer {
+        BitBuffer::from_bitstr(&format!("1{:04b}{:011b}{:06b}{}", id, len_bits, num_elems, payload))
+    }
+
+    #[test]
+    fn test_type3_length_exceeds_buffer_errors() {
+        // 128 payload bits present, wire claims 129: must error, not panic on the skip-forward
+        let mut buf = type3_elem(1, 129, &"0".repeat(128));
+        assert_eq!(
+            parse_type3_generic(true, &mut buf, 1u64),
+            Err(PduParseErr::BufferEnded {
+                field: Some("parse_type3_generic data")
+            })
+        );
+    }
+
+    #[test]
+    fn test_type3_long_length_exceeds_buffer_errors() {
+        // Same, but on the >128 bit truncation path: 130 bits present, 160 claimed
+        let mut buf = type3_elem(1, 160, &"1".repeat(130));
+        assert_eq!(
+            parse_type3_generic(true, &mut buf, 1u64),
+            Err(PduParseErr::BufferEnded {
+                field: Some("parse_type3_generic data")
+            })
+        );
+    }
+
+    #[test]
+    fn test_type3_length_exactly_remaining_parses() {
+        // Short element, length exactly matches what is present
+        let mut buf = type3_elem(1, 8, "10101010");
+        assert_eq!(
+            parse_type3_generic(true, &mut buf, 1u64),
+            Ok(Some(Type3FieldGeneric {
+                field_id: 1,
+                len: 8,
+                data: 0xAA,
+            }))
+        );
+        assert_eq!(buf.get_len_remaining(), 0);
+
+        // Boundary of the two-read path: exactly 128 bits present and claimed
+        let mut buf = type3_elem(2, 128, &format!("{}1", "0".repeat(127)));
+        assert_eq!(
+            parse_type3_generic(true, &mut buf, 2u64),
+            Ok(Some(Type3FieldGeneric {
+                field_id: 2,
+                len: 128,
+                data: 1,
+            }))
+        );
+        assert_eq!(buf.get_len_remaining(), 0);
+    }
+
+    #[test]
+    fn test_type3_over_128_bits_truncates_and_skips() {
+        // 160 bits present and claimed: keep the first 128, skip the rest
+        let mut buf = type3_elem(3, 160, &"1".repeat(160));
+        assert_eq!(
+            parse_type3_generic(true, &mut buf, 3u64),
+            Ok(Some(Type3FieldGeneric {
+                field_id: 3,
+                len: 160,
+                data: u128::MAX,
+            }))
+        );
+        assert_eq!(buf.get_len_remaining(), 0);
+    }
+
+    #[test]
+    fn test_type4_length_below_header_errors() {
+        // Length under 6 used to underflow `len_bits - 6`
+        for len_bits in 0..6 {
+            let mut buf = type4_elem(2, len_bits, 1, &"0".repeat(64));
+            assert_eq!(
+                parse_type4_generic(true, &mut buf, 2u64),
+                Err(PduParseErr::InconsistentLength {
+                    expected: 6,
+                    found: len_bits
+                })
+            );
+        }
+    }
+
+    #[test]
+    fn test_type4_length_exceeds_buffer_errors() {
+        // Claims 80 payload bits, only 40 present: must error, not seek past the window end
+        let mut buf = type4_elem(2, 6 + 80, 1, &"1".repeat(40));
+        assert_eq!(
+            parse_type4_generic(true, &mut buf, 2u64),
+            Err(PduParseErr::BufferEnded {
+                field: Some("parse_type4_header payload")
+            })
+        );
+    }
+
+    #[test]
+    fn test_type4_length_exactly_remaining_parses() {
+        let mut buf = type4_elem(2, 6 + 8, 2, "11110000");
+        assert_eq!(
+            parse_type4_generic(true, &mut buf, 2u64),
+            Ok(Some(Type4FieldGeneric {
+                field_id: 2,
+                len: 8,
+                elems: 2,
+                data: 0xF0,
+            }))
+        );
+        assert_eq!(buf.get_len_remaining(), 0);
+
+        // Boundary of the truncation path: 80 bits present and claimed
+        let mut buf = type4_elem(3, 6 + 80, 1, &"1".repeat(80));
+        assert_eq!(
+            parse_type4_generic(true, &mut buf, 3u64),
+            Ok(Some(Type4FieldGeneric {
+                field_id: 3,
+                len: 80,
+                elems: 1,
+                data: u64::MAX,
+            }))
+        );
+        assert_eq!(buf.get_len_remaining(), 0);
     }
 }

--- a/crates/tetra-entities/src/cmce/subentities/cc_bs/pdu.rs
+++ b/crates/tetra-entities/src/cmce/subentities/cc_bs/pdu.rs
@@ -1152,14 +1152,15 @@ impl CcBsSubentity {
     /// eligible. Only calls of *strictly lower* priority than `incoming_priority` may be
     /// pre-empted (equal priority keeps the channel — first come, first served). Among eligible
     /// calls the victim is chosen by: lowest priority first; then a call that is not actively
-    /// transmitting (a group call in hangtime / a P2P call still in set-up — least disruptive to
-    /// release); then the lowest call_id, purely for deterministic behaviour. `exclude` holds
-    /// call_ids already released this round so the loop always makes progress.
+    /// transmitting (a group call in hangtime / a P2P call still in set-up or with no floor
+    /// holder — least disruptive to release); then the call freeing the most timeslots; then the
+    /// lowest call_id, purely for deterministic behaviour. `exclude` holds call_ids already
+    /// released this round so the loop always makes progress.
     fn select_preemption_victim(&self, incoming_priority: u8, exclude: &[u16]) -> Option<PreemptVictim> {
-        let mut candidates: Vec<(u8, u16, PreemptVictim, usize)> = Vec::new();
+        let mut candidates: Vec<(u8, bool, u16, PreemptVictim, usize)> = Vec::new();
         for (id, call) in self.active_calls.iter() {
             if call.priority < incoming_priority && !exclude.contains(id) {
-                candidates.push((call.priority, *id, PreemptVictim::Group(*id), 1));
+                candidates.push((call.priority, call.is_tx_active(), *id, PreemptVictim::Group(*id), 1));
             }
         }
         for (id, call) in self.individual_calls.iter() {
@@ -1169,13 +1170,16 @@ impl CcBsSubentity {
                 } else {
                     2
                 };
-                candidates.push((call.priority, *id, PreemptVictim::Individual(*id), slots));
+                // A call still in set-up carries no speech; a connected simplex call only does
+                // while someone holds the floor. Duplex is two-way as soon as it is active.
+                let transmitting = call.is_active() && (!call.is_simplex() || call.floor_holder.is_some());
+                candidates.push((call.priority, transmitting, *id, PreemptVictim::Individual(*id), slots));
             }
         }
         candidates
             .into_iter()
-            .min_by_key(|(priority, call_id, _, slots)| (*priority, usize::MAX - *slots, *call_id))
-            .map(|(_, _, victim, _)| victim)
+            .min_by_key(|(priority, transmitting, call_id, _, slots)| (*priority, *transmitting, usize::MAX - *slots, *call_id))
+            .map(|(_, _, _, victim, _)| victim)
     }
 
     /// ETSI EN 300 392-2 clause 14.8 pre-emptive priority handling. When a call requested at a

--- a/crates/tetra-entities/src/cmce/subentities/cc_bs/procedures/isi.rs
+++ b/crates/tetra-entities/src/cmce/subentities/cc_bs/procedures/isi.rs
@@ -765,6 +765,11 @@ impl CcBsSubentity {
             return;
         }
 
+        // Emergency / pre-emptive priority: free a traffic channel by releasing a lower-priority
+        // call before allocating, as the local group set-up path does (ETSI EN 300 392-2 clause
+        // 14.8). No-op for ordinary priority.
+        self.ensure_timeslots_for_priority(queue, 1, priority);
+
         // New network call - allocate circuit
         let circuit = match {
             let mut state = self.config.state_write();
@@ -779,6 +784,9 @@ impl CcBsSubentity {
             Ok(c) => c.clone(),
             Err(err) => {
                 tracing::warn!("CMCE: failed to allocate circuit for network call: {:?}", err);
+                // Like the sibling early-exits above: without this the backhaul keeps the session
+                // open with no CMCE call behind it — a phantom leg until the remote times out.
+                self.notify_network_call_end(queue, brew_uuid);
                 return;
             }
         };

--- a/crates/tetra-entities/src/cmce/subentities/cc_bs/procedures/restoration.rs
+++ b/crates/tetra-entities/src/cmce/subentities/cc_bs/procedures/restoration.rs
@@ -23,10 +23,19 @@ impl CcBsSubentity {
                 return;
             }
             call.active_timer_started = Some(self.dltime);
-            let grant = if pdu.request_to_transmit_send_data {
+            // Only grant when the floor is free or the sender already holds it (same decision as
+            // the U-TX DEMAND path). Granting while the peer is talking gives two simultaneous
+            // transmitters and a stale floor_holder the UL-inactivity watchdog never ceases.
+            // Duplex calls keep floor_holder = None, so they still always grant.
+            let grant = if !pdu.request_to_transmit_send_data {
+                TransmissionGrant::NotGranted
+            } else if call.floor_holder.is_none() || call.is_floor_held_by(sender.ssi) {
+                if call.is_simplex() {
+                    call.grant_floor(sender);
+                }
                 TransmissionGrant::Granted
             } else {
-                TransmissionGrant::NotGranted
+                TransmissionGrant::GrantedToOtherUser
             };
             call.complete_restore();
             self.send_d_call_restore(queue, sender, handle, link_id, endpoint_id, call_id, grant);
@@ -48,7 +57,24 @@ impl CcBsSubentity {
             };
 
             call.complete_restore();
+            let floor = (grant == TransmissionGrant::Granted).then_some(GroupFloorGrant {
+                call_id,
+                source_issi: sender.ssi,
+                dest_gssi: call.dest_gssi,
+                carrier_num: call.carrier_num,
+                ts: call.ts,
+                is_group: true,
+            });
             self.send_d_call_restore(queue, sender, handle, link_id, endpoint_id, call_id, grant);
+
+            // A restore that hands over the floor must arm UMAC's UL-inactivity timer exactly like
+            // every other grant path (see setup.rs / U-TX DEMAND): without the FloorGranted a
+            // restored talker that then goes silent pins the traffic slot until the absolute call
+            // time-out — forever for a duplex/Infinite call, so repeats exhaust the cell.
+            if let Some(floor) = floor {
+                self.send_d_tx_granted_facch(queue, call_id, floor.source_issi, floor.dest_gssi, floor.carrier_num, floor.ts);
+                self.notify_floor_granted(queue, floor, true, BrewNotification::IfGroupRoutable(floor.dest_gssi));
+            }
             return;
         }
 

--- a/crates/tetra-entities/src/cmce/subentities/cc_bs/procedures/setup.rs
+++ b/crates/tetra-entities/src/cmce/subentities/cc_bs/procedures/setup.rs
@@ -94,6 +94,20 @@ impl CcBsSubentity {
             return;
         }
 
+        // ETSI EN 300 392-2 clause 14: one call per group. A U-SETUP to a GSSI that already has an
+        // active call is LATE ENTRY, not a second call — the network-initiated path already treats
+        // it that way. Allocating a parallel call would burn a second traffic timeslot and leave
+        // one of the two circuits orphaned, since every GSSI-keyed lookup only ever finds one.
+        if let Some(active_call_id) = self
+            .active_calls
+            .iter()
+            .find(|(_, call)| call.dest_gssi == dest_gssi)
+            .map(|(call_id, _)| *call_id)
+        {
+            self.fsm_group_late_entry(queue, message, pdu, calling_party, active_call_id);
+            return;
+        }
+
         if is_emergency_priority(pdu.call_priority) {
             tracing::info!(
                 "CMCE: EMERGENCY group call set-up from ISSI {} to GSSI {} (priority {})",
@@ -309,6 +323,128 @@ impl CcBsSubentity {
                 dest_gssi,
                 carrier_num: circuit.carrier_num,
                 ts: circuit.ts,
+                is_group: true,
+            },
+            true,
+            BrewNotification::IfGroupRoutable(dest_gssi),
+        );
+    }
+
+    /// Late entry (ETSI EN 300 392-2 clause 14): attach a U-SETUP caller to the group call already
+    /// running on its GSSI instead of setting up a parallel one. No circuit is allocated — the
+    /// joiner is pointed at the existing call's traffic channel with a D-CONNECT.
+    fn fsm_group_late_entry(
+        &mut self,
+        queue: &mut MessageQueue,
+        message: &SapMsg,
+        pdu: &USetup,
+        calling_party: TetraAddress,
+        call_id: u16,
+    ) {
+        let Some(call) = self.active_calls.get(&call_id) else {
+            return;
+        };
+        let dest_gssi = call.dest_gssi;
+        let carrier_num = call.carrier_num;
+        let ts = call.ts;
+        let usage = call.usage;
+        let call_timeout = call.call_timeout;
+        // Hand the floor to the joiner only when nobody is speaking (call in hangtime), exactly as
+        // a U-TX DEMAND would; an ongoing speaker keeps it.
+        let grant_floor = !call.is_tx_active();
+
+        let SapMsgInner::LcmcMleUnitdataInd(prim) = &message.msg else {
+            panic!()
+        };
+        let ul_handle = prim.handle;
+        let ul_link_id = prim.link_id;
+        let ul_endpoint_id = prim.endpoint_id;
+
+        tracing::info!(
+            "CMCE: LATE ENTRY of ISSI {} into active call_id={} on GSSI {} ts={} (no second circuit, floor_granted={})",
+            calling_party.ssi,
+            call_id,
+            dest_gssi,
+            ts,
+            grant_floor
+        );
+
+        self.send_d_call_proceeding(queue, message, pdu, call_id, CallTimeoutSetupPhase::T10s, pdu.hook_method_selection);
+
+        let mut timeslots = [false; 4];
+        timeslots[ts as usize - 1] = true;
+
+        let d_connect = DConnect {
+            call_identifier: call_id,
+            call_time_out: call_timeout,
+            hook_method_selection: pdu.hook_method_selection,
+            simplex_duplex_selection: pdu.simplex_duplex_selection,
+            transmission_grant: if grant_floor {
+                TransmissionGrant::Granted
+            } else {
+                TransmissionGrant::GrantedToOtherUser
+            },
+            transmission_request_permission: false,
+            // The ongoing call keeps its owner; a late joiner never takes ownership.
+            call_ownership: false,
+            call_priority: None,
+            basic_service_information: None,
+            temporary_address: None,
+            notification_indicator: None,
+            facility: None,
+            proprietary: None,
+        };
+
+        tracing::info!("-> {:?}", d_connect);
+        let mut connect_sdu = BitBuffer::new_autoexpand(30);
+        d_connect.to_bitbuf(&mut connect_sdu).expect("Failed to serialize DConnect");
+        connect_sdu.seek(0);
+
+        queue.push_back(SapMsg {
+            sap: Sap::LcmcSap,
+            src: TetraEntity::Cmce,
+            dest: TetraEntity::Mle,
+            msg: SapMsgInner::LcmcMleUnitdataReq(LcmcMleUnitdataReq {
+                sdu: connect_sdu,
+                handle: ul_handle,
+                endpoint_id: ul_endpoint_id,
+                link_id: ul_link_id,
+                // Same class as the D-CONNECT in the normal group set-up path (FH FIX 2).
+                layer2service: Layer2Service::Unacknowledged,
+                pdu_prio: 0,
+                layer2_qos: 0,
+                stealing_permission: false,
+                stealing_repeats_flag: false,
+                chan_alloc: Some(CmceChanAllocReq {
+                    usage: Some(usage),
+                    alloc_type: ChanAllocType::Replace,
+                    carrier: Some(carrier_num),
+                    timeslots,
+                    ul_dl_assigned: UlDlAssignment::Both,
+                }),
+                main_address: calling_party,
+                tx_reporter: None,
+            }),
+        });
+
+        if !grant_floor {
+            return;
+        }
+
+        if let Some(call) = self.active_calls.get_mut(&call_id) {
+            call.grant_floor(calling_party.ssi, Some(calling_party));
+        }
+        self.send_d_tx_granted_facch(queue, call_id, calling_party.ssi, dest_gssi, carrier_num, ts);
+        // notify_umac = true for the same reason as the set-up path above: the joiner now holds the
+        // floor, so UMAC must arm its UL-inactivity timer or a silent joiner pins the slot.
+        self.notify_floor_granted(
+            queue,
+            GroupFloorGrant {
+                call_id,
+                source_issi: calling_party.ssi,
+                dest_gssi,
+                carrier_num,
+                ts,
                 is_group: true,
             },
             true,

--- a/crates/tetra-entities/src/cmce/subentities/sds_bs.rs
+++ b/crates/tetra-entities/src/cmce/subentities/sds_bs.rs
@@ -57,6 +57,30 @@ pub struct PendingSds {
 /// rather than arrive long after the sender's radio already declared it undelivered.
 const SDS_DEFER_DEADLINE: std::time::Duration = std::time::Duration::from_secs(10);
 
+/// A TETRA SSI is a 24-bit identity. `DSdsData::to_bitbuf` writes both addresses with
+/// `write_bits(ssi, 24)`, whose range assertion aborts the calling thread — and the entities all
+/// share one un-isolated stack thread, so a wider SSI takes the whole cell down.
+const MAX_TETRA_SSI: u32 = 0xFF_FFFF;
+
+/// Defence in depth for the control-originated SDS paths: the dashboard now range-checks SSIs at
+/// its own boundary, but *any* control client can submit a `SendSds`/`SendRawSdsType4`, so refuse
+/// an unserializable identity here too rather than letting it reach `write_bits` and panic. Same
+/// guard the MM DGNA funnel applies to GSSIs. 0 is the "no identity" sentinel, so it is out too.
+fn ssi_pair_is_valid(what: &str, source_ssi: u32, dest_ssi: u32) -> bool {
+    let ok = |ssi: u32| ssi != 0 && ssi <= MAX_TETRA_SSI;
+    if !ok(source_ssi) || !ok(dest_ssi) {
+        tracing::warn!(
+            "{}: refusing out-of-range SSI {} -> {} (must be 1..={})",
+            what,
+            source_ssi,
+            dest_ssi,
+            MAX_TETRA_SSI
+        );
+        return false;
+    }
+    true
+}
+
 /// SDS-TL delivery-report "delivery status" octet signalling a negative outcome (could not be
 /// delivered), sent to the originator when we give up on a deferred SDS. NOTE: confirm on-air that
 /// the field terminals (Motorola MXP600/MTP6750) render this as "not delivered" — it is
@@ -505,6 +529,10 @@ impl SdsBsSubentity {
             len_bits
         );
 
+        if !ssi_pair_is_valid("SDS", source_ssi, dest_ssi) {
+            return false;
+        }
+
         // SDS-TL Simple Text Message — format verificat din tetraflow-sds-bot:
         //   Byte 0: 0x82  — Protocol Identifier (SDS-TL text messaging)
         //   Byte 1: 0x04  — Message Type (Simple Text, cu TL-ACK request)
@@ -628,6 +656,10 @@ impl SdsBsSubentity {
             dest_is_group.then(|| "GSSI").unwrap_or("ISSI"),
             len_bits
         );
+
+        if !ssi_pair_is_valid("SDS raw Type-4", source_ssi, dest_ssi) {
+            return false;
+        }
 
         // The Type-4 length indicator is an 11-bit field (max 2047 bits = 255 bytes). A wider value
         // would overflow the field and panic the serializer (DSdsData::to_bitbuf). This raw path

--- a/crates/tetra-entities/src/health/registry.rs
+++ b/crates/tetra-entities/src/health/registry.rs
@@ -63,6 +63,11 @@ fn effective_radios_silent_secs(floor_secs: u64, periodic_registration_secs: u64
 /// Startup grace: don't flag Service Critical for the first few seconds while the stack boots.
 const SERVICE_STARTUP_GRACE_MS: u64 = 5_000;
 
+/// How long a caught panic keeps the Service domain Degraded. A cell that keeps ticking while
+/// swallowing panics is dropping PDUs — that must be visible, but a single transient catch
+/// shouldn't pin the station to Degraded forever.
+const CAUGHT_PANIC_DEGRADED_MS: u64 = 300_000;
+
 pub struct HealthRegistry {
     start: Instant,
     /// Millis-since-`start` at the last core tick; 0 = no tick observed yet.
@@ -74,6 +79,10 @@ pub struct HealthRegistry {
     last_radio_activity_ms: AtomicU64,
     dl_queue_depth: AtomicUsize,
     sds_queue_depth: AtomicUsize,
+    /// Panics caught at the entity-dispatch boundary (message router), since process start.
+    caught_panics: AtomicU64,
+    /// Millis-since-`start` of the most recent caught panic; 0 = none.
+    last_caught_panic_ms: AtomicU64,
     /// Most recent remediation action, human-readable. Written rarely (only when an action fires).
     last_action: Mutex<Option<String>>,
 }
@@ -96,6 +105,8 @@ impl HealthRegistry {
             last_radio_activity_ms: AtomicU64::new(0),
             dl_queue_depth: AtomicUsize::new(0),
             sds_queue_depth: AtomicUsize::new(0),
+            caught_panics: AtomicU64::new(0),
+            last_caught_panic_ms: AtomicU64::new(0),
             last_action: Mutex::new(None),
         }
     }
@@ -133,6 +144,16 @@ impl HealthRegistry {
     pub fn set_sds_queue_depth(&self, n: usize) {
         self.sds_queue_depth.store(n, Ordering::Relaxed);
     }
+    /// Note a panic caught at the entity-dispatch boundary (see `messagerouter::guard_entity`).
+    /// Cold path — only runs when a panic was actually caught.
+    pub fn note_caught_panic(&self) {
+        self.caught_panics.fetch_add(1, Ordering::Relaxed);
+        self.last_caught_panic_ms.store(self.now_ms().max(1), Ordering::Relaxed);
+    }
+    /// Total panics caught at the entity-dispatch boundary since process start.
+    pub fn caught_panics(&self) -> u64 {
+        self.caught_panics.load(Ordering::Relaxed)
+    }
     /// Record a remediation action (shown in the snapshot / dashboard / Telegram).
     pub fn record_action(&self, what: String) {
         if let Ok(mut g) = self.last_action.lock() {
@@ -166,6 +187,19 @@ impl HealthRegistry {
             (HealthLevel::Degraded, format!("core loop slow ({}ms since last tick)", age))
         } else {
             (HealthLevel::Ok, "ticking".to_string())
+        };
+        // A cell that keeps ticking only because the router is swallowing panics is not healthy:
+        // every catch is a dropped message. Fold that into the Service domain (no new domain, so
+        // existing consumers keep working) — Degraded while the last catch is recent, and the
+        // running total stays in the detail line afterwards.
+        let panics = self.caught_panics.load(Ordering::Relaxed);
+        let (svc, svc_detail) = if panics == 0 {
+            (svc, svc_detail)
+        } else {
+            let last = self.last_caught_panic_ms.load(Ordering::Relaxed);
+            let recent = last != 0 && self.now_ms().saturating_sub(last) < CAUGHT_PANIC_DEGRADED_MS;
+            let level = if recent { svc.worst(HealthLevel::Degraded) } else { svc };
+            (level, format!("{} ({} panics caught)", svc_detail, panics))
         };
         domains.push(DomainHealth {
             domain: HealthDomain::Service,

--- a/crates/tetra-entities/src/health/supervisor.rs
+++ b/crates/tetra-entities/src/health/supervisor.rs
@@ -7,8 +7,9 @@
 //! reads atomics only and never touches RF/CMCE/UMAC, so it cannot stall the stack.
 //! FlowStation-original work.
 
+use std::path::{Path, PathBuf};
 use std::thread;
-use std::time::{Duration, Instant};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use crate::net_telemetry::TelemetryEvent;
 use crate::net_telemetry::channel::TelemetrySink;
@@ -16,7 +17,13 @@ use crate::service_control::{self, ServiceAction};
 
 use super::registry::{HealthThresholds, registry};
 
-#[derive(Debug, Clone, Copy)]
+/// Panic-storm escalation: catching panics at the router boundary keeps the cell alive, but each
+/// catch is a dropped message. This many catches inside the window means the cell is not really
+/// serving, so take the same controlled (cooldown-limited) restart path as a core stall.
+const PANIC_STORM_BURST: u64 = 20;
+const PANIC_STORM_WINDOW: Duration = Duration::from_secs(60);
+
+#[derive(Debug, Clone)]
 pub struct HealthMonitorConfig {
     pub snapshot_interval: Duration,
     pub thresholds: HealthThresholds,
@@ -26,6 +33,9 @@ pub struct HealthMonitorConfig {
     pub restart_after_critical: Duration,
     /// Minimum spacing between restart requests (anti-reboot-loop).
     pub restart_cooldown: Duration,
+    /// Where to persist the last-restart timestamp so `restart_cooldown` survives the restart it
+    /// triggers. `None` = in-memory only (cooldown resets at every boot).
+    pub restart_state_path: Option<PathBuf>,
 }
 
 impl Default for HealthMonitorConfig {
@@ -36,8 +46,45 @@ impl Default for HealthMonitorConfig {
             restart_on_core_stall: false,
             restart_after_critical: Duration::from_secs(30),
             restart_cooldown: Duration::from_secs(600),
+            restart_state_path: None,
         }
     }
+}
+
+/// Age of the persisted last-restart stamp, or `None` if absent/unreadable/in the future.
+///
+/// The cooldown has to outlive the restart it triggers: the in-memory `last_restart` dies with
+/// the process, so a stall that reproduces at boot would otherwise restart every
+/// `restart_after_critical` forever. One line, unix epoch seconds.
+fn last_restart_age(path: &Path) -> Option<Duration> {
+    let secs: u64 = std::fs::read_to_string(path).ok()?.trim().parse().ok()?;
+    SystemTime::now().duration_since(UNIX_EPOCH + Duration::from_secs(secs)).ok()
+}
+
+fn store_last_restart(path: &Path) {
+    let secs = SystemTime::now().duration_since(UNIX_EPOCH).map(|d| d.as_secs()).unwrap_or(0);
+    if let Err(e) = std::fs::write(path, format!("{}\n", secs)) {
+        tracing::warn!("HEALTH: could not persist restart timestamp to {}: {}", path.display(), e);
+    }
+}
+
+/// Shared restart path for every watchdog trigger: cooldown check → log → persist → request.
+/// Returns true if a restart was actually requested.
+fn request_restart(reason: &str, last_restart: &mut Option<Instant>, cooldown: Duration, state_path: Option<&Path>) -> bool {
+    let now = Instant::now();
+    if last_restart.is_some_and(|t| now.duration_since(t) < cooldown) {
+        return false; // still in cooldown from a previous request
+    }
+
+    tracing::error!("HEALTH: {} — requesting service restart (watchdog)", reason);
+    registry().record_action(format!("restart_service ({})", reason));
+    if let Some(p) = state_path {
+        // Persist BEFORE requesting: the request tears this process down.
+        store_last_restart(p);
+    }
+    service_control::schedule_service_action(ServiceAction::Restart, Duration::ZERO);
+    *last_restart = Some(now);
+    true
 }
 
 /// Spawn the background health sampler. `sink` is a clone of the telemetry sink.
@@ -46,6 +93,24 @@ pub fn spawn_health_monitor(sink: TelemetrySink, cfg: HealthMonitorConfig) {
     let stall_critical_ms = cfg.thresholds.core_stall_critical_ms.max(1_000);
     let restart_after = cfg.restart_after_critical.max(Duration::from_secs(1));
     let cooldown = cfg.restart_cooldown.max(Duration::from_secs(1));
+    let state_path = cfg.restart_state_path.clone();
+
+    // Seed the anti-reboot-loop guard from disk: without this the FIRST restart request tears the
+    // process down and the fresh process starts with last_restart = None, so a stall that
+    // reproduces at boot reboots forever and the cooldown never applies.
+    let mut last_restart: Option<Instant> = None;
+    if let Some(age) = state_path.as_deref().and_then(last_restart_age)
+        && age < cooldown
+    {
+        tracing::warn!(
+            "Health monitor: restart {}s ago (persisted) — watchdog cooldown active for another {}s",
+            age.as_secs(),
+            cooldown.saturating_sub(age).as_secs()
+        );
+        // If the host rebooted since, Instant can't go that far back — fall back to "now", which
+        // is the conservative choice (full cooldown from startup).
+        last_restart = Some(Instant::now().checked_sub(age).unwrap_or_else(Instant::now));
+    }
 
     thread::Builder::new()
         .name("health-monitor".into())
@@ -56,7 +121,8 @@ pub fn spawn_health_monitor(sink: TelemetrySink, cfg: HealthMonitorConfig) {
                 if cfg.restart_on_core_stall { "ON" } else { "off" }
             );
             let mut stall_since: Option<Instant> = None;
-            let mut last_restart: Option<Instant> = None;
+            let mut panic_window_start = Instant::now();
+            let mut panic_window_base = registry().caught_panics();
             loop {
                 thread::sleep(interval);
 
@@ -67,6 +133,26 @@ pub fn spawn_health_monitor(sink: TelemetrySink, cfg: HealthMonitorConfig) {
                     continue;
                 }
 
+                // Panic storm: the router keeps the cell alive by dropping the offending
+                // messages, but past a burst that is a cell that answers nothing — restart it
+                // (same cooldown, so it can't reboot-loop).
+                let panics = registry().caught_panics();
+                let now = Instant::now();
+                if now.duration_since(panic_window_start) >= PANIC_STORM_WINDOW {
+                    panic_window_start = now;
+                    panic_window_base = panics;
+                } else if panics.saturating_sub(panic_window_base) >= PANIC_STORM_BURST {
+                    let reason = format!(
+                        "{} panics caught in {}s (entity dispatch)",
+                        panics - panic_window_base,
+                        PANIC_STORM_WINDOW.as_secs()
+                    );
+                    if request_restart(&reason, &mut last_restart, cooldown, state_path.as_deref()) {
+                        panic_window_start = now;
+                        panic_window_base = panics;
+                    }
+                }
+
                 // Software watchdog. Only the core-loop liveness drives a restart — a Degraded
                 // backhaul or congestion never reboots the station.
                 let age_ms = registry().tick_age_ms();
@@ -74,21 +160,40 @@ pub fn spawn_health_monitor(sink: TelemetrySink, cfg: HealthMonitorConfig) {
                     stall_since = None;
                     continue;
                 }
-                let now = Instant::now();
                 let since = *stall_since.get_or_insert(now);
                 if now.duration_since(since) < restart_after {
                     continue; // stalled, but not long enough yet
                 }
-                if last_restart.is_some_and(|t| now.duration_since(t) < cooldown) {
-                    continue; // still in cooldown from a previous request
-                }
 
                 let reason = format!("core loop stalled {}s", age_ms / 1000);
-                tracing::error!("HEALTH: {} — requesting service restart (watchdog)", reason);
-                registry().record_action(format!("restart_service ({})", reason));
-                service_control::schedule_service_action(ServiceAction::Restart, Duration::ZERO);
-                last_restart = Some(now);
+                request_restart(&reason, &mut last_restart, cooldown, state_path.as_deref());
             }
         })
         .expect("failed to spawn health-monitor thread");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn persisted_restart_stamp_round_trips() {
+        let path = std::env::temp_dir().join(format!("flowstation-health-restart-{}", std::process::id()));
+        let _ = std::fs::remove_file(&path);
+
+        // No file yet → no cooldown to honour.
+        assert!(last_restart_age(&path).is_none());
+
+        // A stamp written now reads back as a very small age → cooldown still in force after a
+        // restart, which is the whole point (the in-memory guard is gone by then).
+        store_last_restart(&path);
+        let age = last_restart_age(&path).expect("stamp should read back");
+        assert!(age < Duration::from_secs(5), "unexpected age {:?}", age);
+
+        // Garbage in the file must not be treated as "just restarted".
+        std::fs::write(&path, "not-a-timestamp").unwrap();
+        assert!(last_restart_age(&path).is_none());
+
+        let _ = std::fs::remove_file(&path);
+    }
 }

--- a/crates/tetra-entities/src/messagerouter.rs
+++ b/crates/tetra-entities/src/messagerouter.rs
@@ -1,12 +1,69 @@
+use std::any::Any;
 use std::collections::{HashMap, VecDeque};
-use std::sync::Arc;
+use std::panic::{AssertUnwindSafe, catch_unwind};
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, OnceLock};
 
 use tetra_config::bluestation::SharedConfig;
-use tetra_core::{TdmaTime, tetra_entities::TetraEntity};
+use tetra_core::{Sap, TdmaTime, tetra_entities::TetraEntity};
 use tetra_saps::SapMsg;
 
 use crate::TetraEntityTrait;
+
+/// Env escape hatch: `FLOWSTATION_PANIC_FATAL=1` restores the old fail-fast behaviour (the panic
+/// is re-raised and takes the process down) so a panic can't hide during development.
+static PANIC_FATAL: OnceLock<bool> = OnceLock::new();
+
+fn panic_is_fatal() -> bool {
+    *PANIC_FATAL.get_or_init(|| {
+        std::env::var_os("FLOWSTATION_PANIC_FATAL").is_some_and(|v| !v.is_empty() && v != "0")
+    })
+}
+
+fn panic_reason(payload: &(dyn Any + Send)) -> &str {
+    if let Some(s) = payload.downcast_ref::<&'static str>() {
+        s
+    } else if let Some(s) = payload.downcast_ref::<String>() {
+        s.as_str()
+    } else {
+        "<non-string panic payload>"
+    }
+}
+
+/// Blast-radius containment for one entity callback.
+///
+/// Entities run directly on the core loop with no unwind boundary, so any panic on the
+/// processing path used to exit the whole process (code 101) — one malformed PDU killed the
+/// cell. Catching here degrades that to a dropped message. The entity's internal state may be
+/// inconsistent afterwards, but a degraded entity beats a dead base station.
+///
+/// Bugs stay visible: the default panic hook has already printed the message + backtrace by the
+/// time we get control, we log loudly with the entity/SAP identity, and every catch is counted
+/// in the health registry so a cell quietly swallowing PDUs still surfaces as unhealthy.
+///
+/// No-panic path: `catch_unwind` only installs a landing pad, so normal ticks are unchanged and
+/// allocation-free.
+#[inline]
+fn guard_entity(entity: TetraEntity, what: &str, sap: Option<Sap>, f: impl FnOnce()) {
+    // AssertUnwindSafe: the entity and the message queue are &mut and can be left mid-update by
+    // the unwind — that is exactly the trade-off documented above, not an oversight.
+    let Err(payload) = catch_unwind(AssertUnwindSafe(f)) else {
+        return;
+    };
+
+    if panic_is_fatal() {
+        std::panic::resume_unwind(payload);
+    }
+
+    crate::health::registry().note_caught_panic();
+    tracing::error!(
+        "PANIC caught in entity {:?} during {} (sap {:?}): {} — message dropped, entity state may be inconsistent",
+        entity,
+        what,
+        sap,
+        panic_reason(&*payload)
+    );
+}
 
 #[derive(Default)]
 pub enum MessagePrio {
@@ -48,8 +105,9 @@ impl MessageQueue {
 
 pub struct MessageRouter {
     /// While currently unused by the MessageRouter, this may change in the future
-    /// As such, we provide the MessageRouter with a copy of the SharedConfig
-    _config: SharedConfig,
+    /// As such, we provide the MessageRouter with a copy of the SharedConfig.
+    /// `None` only in unit tests, which need a router without a full stack config.
+    _config: Option<SharedConfig>,
     entities: HashMap<TetraEntity, Box<dyn TetraEntityTrait>>,
     msg_queue: MessageQueue,
 
@@ -64,7 +122,18 @@ impl MessageRouter {
         Self {
             entities: HashMap::new(),
             msg_queue: MessageQueue { messages: VecDeque::new() },
-            _config: config,
+            _config: Some(config),
+            ts: TdmaTime::default(),
+        }
+    }
+
+    /// Router with no config, for unit tests that only exercise dispatch.
+    #[cfg(test)]
+    fn new_bare() -> Self {
+        Self {
+            entities: HashMap::new(),
+            msg_queue: MessageQueue { messages: VecDeque::new() },
+            _config: None,
             ts: TdmaTime::default(),
         }
     }
@@ -111,7 +180,10 @@ impl MessageRouter {
 
             // Check if the destination entity registered and deliver if found
             if let Some(entity) = self.entities.get_mut(dest) {
-                entity.rx_prim(&mut self.msg_queue, message);
+                let dest_id = *dest;
+                let sap = *message.get_sap();
+                let queue = &mut self.msg_queue;
+                guard_entity(dest_id, "rx_prim", Some(sap), move || entity.rx_prim(queue, message));
             } else {
                 tracing::warn!(
                     "deliver_message: entity {:?} not found for {:?}: {:?} -> {:?}",
@@ -140,8 +212,11 @@ impl MessageRouter {
         tracing::info!("--- tick dl {} ----------------------------", self.ts);
 
         // Call tick on all entities
+        let ts = self.ts;
         for entity in self.entities.values_mut() {
-            entity.tick_start(&mut self.msg_queue, self.ts);
+            let entity_id = entity.entity();
+            let queue = &mut self.msg_queue;
+            guard_entity(entity_id, "tick_start", None, move || entity.tick_start(queue, ts));
         }
     }
 
@@ -152,11 +227,16 @@ impl MessageRouter {
     pub fn tick_end(&mut self) {
         tracing::debug!("############################ end-of-tick ############################");
 
+        let ts = self.ts;
+
         // Llc should send down outstanding BL-ACKs
         let target = TetraEntity::Llc;
         if let Some(entity) = self.entities.get_mut(&target) {
             tracing::trace!("tick_end for entity {:?}", target);
-            entity.tick_end(&mut self.msg_queue, self.ts);
+            let queue = &mut self.msg_queue;
+            guard_entity(target, "tick_end", None, move || {
+                entity.tick_end(queue, ts);
+            });
         }
         self.deliver_all_messages();
 
@@ -164,7 +244,10 @@ impl MessageRouter {
         let target = TetraEntity::Umac;
         if let Some(entity) = self.entities.get_mut(&target) {
             tracing::trace!("tick_end for entity {:?}", target);
-            entity.tick_end(&mut self.msg_queue, self.ts);
+            let queue = &mut self.msg_queue;
+            guard_entity(target, "tick_end", None, move || {
+                entity.tick_end(queue, ts);
+            });
         }
         self.deliver_all_messages();
 
@@ -174,7 +257,10 @@ impl MessageRouter {
             if entity_id == TetraEntity::Llc || entity_id == TetraEntity::Umac {
                 continue;
             }
-            entity.tick_end(&mut self.msg_queue, self.ts);
+            let queue = &mut self.msg_queue;
+            guard_entity(entity_id, "tick_end", None, move || {
+                entity.tick_end(queue, ts);
+            });
         }
         self.deliver_all_messages();
 
@@ -219,5 +305,93 @@ impl MessageRouter {
                 }
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::AtomicUsize;
+
+    use tetra_saps::sapmsg::SapMsgInner;
+    use tetra_saps::tnmm::TnmmTestDemand;
+
+    use super::*;
+
+    /// Entity that panics on every message (and optionally on tick_start), like a decoder
+    /// tripping over a malformed PDU.
+    struct FlakyEntity {
+        id: TetraEntity,
+        seen: Arc<AtomicUsize>,
+        panic_on_rx: bool,
+        panic_on_tick: bool,
+    }
+
+    impl TetraEntityTrait for FlakyEntity {
+        fn entity(&self) -> TetraEntity {
+            self.id
+        }
+
+        fn rx_prim(&mut self, _queue: &mut MessageQueue, _message: SapMsg) {
+            self.seen.fetch_add(1, Ordering::SeqCst);
+            if self.panic_on_rx {
+                panic!("synthetic malformed PDU");
+            }
+        }
+
+        fn tick_start(&mut self, _queue: &mut MessageQueue, _ts: TdmaTime) {
+            if self.panic_on_tick {
+                panic!("synthetic tick_start panic");
+            }
+        }
+    }
+
+    fn test_msg(dest: TetraEntity) -> SapMsg {
+        SapMsg::new(
+            Sap::TnmmSap,
+            TetraEntity::User,
+            dest,
+            SapMsgInner::TnmmTestDemand(TnmmTestDemand { issi: 1 }),
+        )
+    }
+
+    /// A panicking entity must degrade to a dropped message, not to a dead cell: the loop keeps
+    /// running, the healthy entity still gets its message, and the catch is counted.
+    #[test]
+    fn panicking_entity_does_not_kill_the_loop() {
+        let bad_seen = Arc::new(AtomicUsize::new(0));
+        let good_seen = Arc::new(AtomicUsize::new(0));
+
+        let mut router = MessageRouter::new_bare();
+        router.register_entity(Box::new(FlakyEntity {
+            id: TetraEntity::Mm,
+            seen: bad_seen.clone(),
+            panic_on_rx: true,
+            panic_on_tick: true,
+        }));
+        router.register_entity(Box::new(FlakyEntity {
+            id: TetraEntity::Cmce,
+            seen: good_seen.clone(),
+            panic_on_rx: false,
+            panic_on_tick: false,
+        }));
+
+        // Counter is process-global; compare deltas.
+        let before = crate::health::registry().caught_panics();
+
+        // Two full ticks: tick_start panics once per tick, rx_prim once per delivered message.
+        for _ in 0..2 {
+            router.tick_start();
+            router.submit_message(test_msg(TetraEntity::Mm));
+            router.submit_message(test_msg(TetraEntity::Cmce));
+            router.deliver_all_messages();
+            router.tick_end();
+        }
+
+        // The loop survived and the healthy entity was served both times.
+        assert_eq!(good_seen.load(Ordering::SeqCst), 2);
+        assert_eq!(bad_seen.load(Ordering::SeqCst), 2);
+
+        // 2 × tick_start + 2 × rx_prim caught panics.
+        assert_eq!(crate::health::registry().caught_panics(), before + 4);
     }
 }

--- a/crates/tetra-entities/src/mm/components/client_state.rs
+++ b/crates/tetra-entities/src/mm/components/client_state.rs
@@ -119,9 +119,25 @@ fn may_attach(_issi: u32, _gssi: u32) -> bool {
     return true;
 }
 
+/// Safety cap on the per-ISSI registration-rate table so a churn of distinct forged ISSIs can't
+/// grow it without bound; lapsed windows are pruned once this many are held.
+const REGISTRATION_RATE_TABLE_CAP: usize = 8192;
+/// Window the per-ISSI registration counter is measured over.
+const REGISTRATION_RATE_WINDOW: std::time::Duration = std::time::Duration::from_secs(60);
+
 pub struct MmClientMgr {
     clients: HashMap<u32, MmClientProperties>,
     telemetry_sink: Option<TelemetrySink>,
+    /// Hard cap on `clients` (0 = unlimited). Uplink is unauthenticated, so any radio can claim
+    /// any of the 2^24 ISSIs: without a cap a registration flood grows this map (plus the
+    /// subscriber registry and the dashboard) until the cell is OOM-killed. See
+    /// `enforce_client_cap` / `at_capacity`.
+    max_clients: usize,
+    /// Per-ISSI accepted-registration counter: (window start, count in window). Bounds the churn
+    /// one source ISSI can inflict on the table even when it stays under the cap.
+    registration_rate: HashMap<u32, (std::time::Instant, u32)>,
+    /// Accepted registrations per ISSI per [`REGISTRATION_RATE_WINDOW`] (0 = disabled).
+    registrations_per_window: u32,
 }
 
 impl MmClientMgr {
@@ -133,7 +149,95 @@ impl MmClientMgr {
         MmClientMgr {
             clients: HashMap::new(),
             telemetry_sink,
+            max_clients: tetra_config::bluestation::DEFAULT_MAX_REGISTERED_CLIENTS,
+            registration_rate: HashMap::new(),
+            registrations_per_window: tetra_config::bluestation::DEFAULT_REGISTRATION_RATE_LIMIT_PER_MIN,
         }
+    }
+
+    /// Apply the operator's `[security]` bounds. Called by MmBs at construction and whenever the
+    /// config is swapped, so the caps are never left at the compiled-in defaults.
+    pub fn set_limits(&mut self, max_clients: usize, registrations_per_window: u32) {
+        self.max_clients = max_clients;
+        self.registrations_per_window = registrations_per_window;
+    }
+
+    /// Number of clients currently held. Exposed for the flood-bound regression test and logging.
+    pub fn client_count(&self) -> usize {
+        self.clients.len()
+    }
+
+    /// True when the registry is full and a *new* ISSI must not be admitted. Only meaningful
+    /// after `enforce_client_cap` has had its chance to make room.
+    pub fn at_capacity(&self) -> bool {
+        self.max_clients != 0 && self.clients.len() >= self.max_clients
+    }
+
+    /// Per-source-ISSI registration rate limit. Returns false when this registration must be
+    /// dropped; counts the attempt when it is accepted. A real radio registers a handful of times
+    /// a minute (T351 plus a post-PTT roaming update), so this only bites on a flood.
+    pub fn allow_registration(&mut self, issi: u32) -> bool {
+        if self.registrations_per_window == 0 {
+            return true;
+        }
+        let now = std::time::Instant::now();
+        // Prune lapsed windows before growing the table past its safety cap.
+        if self.registration_rate.len() >= REGISTRATION_RATE_TABLE_CAP {
+            self.registration_rate
+                .retain(|_, (start, _)| now.duration_since(*start) < REGISTRATION_RATE_WINDOW);
+        }
+        let entry = self.registration_rate.entry(issi).or_insert((now, 0));
+        if now.duration_since(entry.0) >= REGISTRATION_RATE_WINDOW {
+            *entry = (now, 0);
+        }
+        if entry.1 >= self.registrations_per_window {
+            return false;
+        }
+        entry.1 += 1;
+        true
+    }
+
+    /// LRU-style eviction so the registry stays bounded under an RF-unauthenticated registration
+    /// flood. Evicts the least-recently-heard clients that are demonstrably doing nothing:
+    ///   - no group affiliation (nothing for the coverage-return re-affiliation to restore), and
+    ///   - not in `protected` — the caller passes the ISSIs it knows are mid-call/PTT.
+    /// An affiliated or in-call radio is never evicted, however old. Returns the evicted ISSIs so
+    /// the caller can tear their subscriber-registry / Brew / dashboard entries down too.
+    ///
+    /// NB: a present but never-affiliated radio (e.g. a receive-only pager) is evictable under a
+    /// flood. It is re-admitted on its next registration or by reactive recovery — the alternative
+    /// is unbounded growth and an OOM-kill of the whole cell.
+    pub fn enforce_client_cap(&mut self, protected: &HashSet<u32>) -> Vec<u32> {
+        let mut evicted = Vec::new();
+        if self.max_clients == 0 || self.clients.len() < self.max_clients {
+            return evicted;
+        }
+        // Evict a batch (~6% of the cap, at least one) so the O(n) scan is amortised over many
+        // registrations rather than run for every PDU of a flood.
+        let batch = (self.max_clients / 16).max(1);
+        let target = self.max_clients.saturating_sub(batch).max(1);
+        let mut candidates: Vec<(std::time::Instant, u32)> = self
+            .clients
+            .values()
+            .filter(|c| c.groups.is_empty() && !protected.contains(&c.issi))
+            .map(|c| (c.last_uplink_time, c.issi))
+            .collect();
+        candidates.sort_unstable_by_key(|&(t, _)| t); // least recently heard first
+        for (_, issi) in candidates {
+            if self.clients.len() <= target {
+                break;
+            }
+            self.remove_client(issi);
+            evicted.push(issi);
+        }
+        if !evicted.is_empty() {
+            tracing::warn!(
+                "MM: client registry hit the {} cap — evicted {} idle unaffiliated client(s)",
+                self.max_clients,
+                evicted.len()
+            );
+        }
+        evicted
     }
 
     pub fn get_client_by_issi(&mut self, issi: u32) -> Option<&MmClientProperties> {
@@ -142,6 +246,20 @@ impl MmClientMgr {
 
     pub fn client_is_known(&self, issi: u32) -> bool {
         self.clients.contains_key(&issi)
+    }
+
+    /// True when `issi` is currently attached AND the request arrived on the same L2 handle the
+    /// registration used. This is the strongest binding available without air-interface
+    /// authentication (EN 300 392-7 TEA is not implemented, so the source SSI of an uplink PDU is
+    /// unverifiable): a teardown may only act on live state that this same link established.
+    /// The handle is inert in this stack today (MLE addresses by ISSI and hands up handle 0), so
+    /// in practice this is the "is actually registered" half — but it binds to the link the day
+    /// MLE carries a real one.
+    pub fn is_registered_on_handle(&self, issi: u32, handle: u32) -> bool {
+        self.clients
+            .get(&issi)
+            .map(|c| c.state == MmClientState::Attached && c.last_handle == handle)
+            .unwrap_or(false)
     }
 
     pub fn set_client_state(&mut self, issi: u32, state: MmClientState) -> Result<(), ClientMgrErr> {

--- a/crates/tetra-entities/src/mm/mm_bs.rs
+++ b/crates/tetra-entities/src/mm/mm_bs.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashMap, VecDeque};
+use std::collections::{HashMap, HashSet, VecDeque};
 use std::path::PathBuf;
 
 use crate::mm::components::recovery_cache::{RecoveryCache, TerminalRecord};
@@ -70,7 +70,24 @@ const REACTIVE_RECOVERY_COOLDOWN_CAP: usize = 4096;
 
 impl MmBs {
     pub fn new(config: SharedConfig, telemetry: Option<TelemetrySink>, control: Option<ControlEndpoint>) -> Self {
-        let client_mgr = MmClientMgr::new(telemetry.clone());
+        let mut client_mgr = MmClientMgr::new(telemetry.clone());
+        {
+            let cfg = config.config();
+            let sec = &cfg.security;
+            client_mgr.set_limits(sec.max_registered_clients, sec.registration_rate_limit_per_min);
+            // State the effective posture in the operator log. There is no way to read it off the
+            // TOML alone (an empty issi_whitelist means "open" under the legacy default), and the
+            // air interface is unauthenticated regardless — so say both, once, unmissably.
+            tracing::warn!(
+                "MM: access control posture: {} | air-interface authentication (EN 300 392-7 TEA) is NOT implemented — any radio can claim any ISSI; the whitelist is the only gate",
+                sec.access_control_posture()
+            );
+            if sec.honour_unauthenticated_detach {
+                tracing::warn!(
+                    "MM: honouring unauthenticated U-ITSI-DETACH / migration teardown (only from an ISSI registered on the same link) — set [security] honour_unauthenticated_detach = false to refuse it entirely"
+                );
+            }
+        }
         Self {
             config,
             telemetry,
@@ -345,6 +362,51 @@ impl MmBs {
         queue.push_back(msg);
     }
 
+    /// ISSI whitelist gate. The dashboard can override the config whitelist at runtime (the state
+    /// override takes precedence so edits apply without a restart); the configured
+    /// `whitelist_mode` governs how whichever list is effective is read — in particular whether an
+    /// empty list means "open network" or "deny all".
+    fn issi_allowed(&self, issi: u32) -> bool {
+        let state = self.config.state_read();
+        self.config.config().security.allows(issi, state.issi_whitelist_override.as_deref())
+    }
+
+    /// May an unauthenticated teardown (U-ITSI-DETACH, or the migrating-location-update release)
+    /// claiming `issi` on L2 `handle` be honoured?
+    ///
+    /// TETRA air-interface authentication (EN 300 392-7) is not implemented, so the source SSI of
+    /// an uplink PDU is unverifiable and ISSIs are observable on air — a forged detach carrying a
+    /// victim's ISSI would otherwise knock that radio off Brew, local call/SDS delivery and the
+    /// dashboard, and a replay keeps it off. Two gates remain available: the operator may refuse
+    /// to honour unauthenticated teardown at all, and the claimed ISSI must currently be
+    /// registered on the same L2 context its registration used.
+    fn teardown_authorized(&self, issi: u32, handle: u32, what: &str) -> bool {
+        if !self.config.config().security.honour_unauthenticated_detach {
+            tracing::warn!(
+                "MM: ignoring {} for ISSI {} — [security] honour_unauthenticated_detach = false",
+                what,
+                issi
+            );
+            return false;
+        }
+        if !self.client_mgr.is_registered_on_handle(issi, handle) {
+            tracing::warn!(
+                "MM: ignoring {} for ISSI {} — not registered on this L2 context (forged or replayed teardown?)",
+                what,
+                issi
+            );
+            return false;
+        }
+        true
+    }
+
+    /// ISSIs that must never be evicted to make room in the client registry: anything CMCE
+    /// currently has on a traffic channel (individual-call participants are keyed by ISSI in
+    /// `active_call_ts`, so a radio mid-call/PTT is protected).
+    fn call_protected_issis(&self) -> HashSet<u32> {
+        self.config.state_read().active_call_ts.keys().copied().collect()
+    }
+
     fn rx_u_itsi_detach(&mut self, _queue: &mut MessageQueue, mut message: SapMsg) {
         tracing::trace!("rx_u_itsi_detach");
         let SapMsgInner::LmmMleUnitdataInd(prim) = &mut message.msg else {
@@ -370,6 +432,17 @@ impl MmBs {
         }
 
         let ssi = prim.received_address.ssi;
+        // Access control BEFORE any state mutation: a non-whitelisted ISSI must never be able to
+        // touch the registry, Brew or the dashboard, not even to tear something down.
+        if !self.issi_allowed(ssi) {
+            tracing::warn!("MM: ISSI {} not in whitelist, ignoring UItsiDetach", ssi);
+            return;
+        }
+        // Unauthenticated teardown gate — see teardown_authorized.
+        if !self.teardown_authorized(ssi, prim.handle, "U-ITSI-DETACH") {
+            return;
+        }
+
         let detached_client = self.client_mgr.remove_client(ssi);
         if let Some(client) = detached_client {
             self.config.state_write().subscribers.deregister(ssi);
@@ -403,11 +476,34 @@ impl MmBs {
             }
         };
 
+        let issi = prim.received_address.ssi;
+        let handle = prim.handle;
+
+        // ISSI whitelist check â€” FIRST, ahead of every Brew/registry mutation below (including the
+        // migration release), so a non-whitelisted ISSI can never mutate state. It used to sit
+        // after the migration branch, which let a barred radio tear a victim down before the gate
+        // was ever consulted.
+        if !self.issi_allowed(issi) {
+            tracing::warn!("MM: ISSI {} not in whitelist, rejecting registration", issi);
+            // Access-control cause, NOT MigrationNotSupported: telling a barred radio "migration
+            // not supported" sends a conformant terminal hunting for another cell instead of
+            // staying off, and never shows the user an access-denied.
+            Self::send_d_location_update_reject_cause(
+                queue,
+                issi,
+                handle,
+                pdu.location_update_type,
+                pdu.address_extension,
+                RejectCause::ItsiAtsiUnknown,
+            );
+            return;
+        }
+
         // The terminal answered with a location update â€” stop the restart-recovery replay to it
         // regardless of how this update is handled below (migration reject, whitelist reject, or
         // normal registration). Hoisted above all early-returns so a migrating/rejected terminal
         // isn't replayed to forever. No-op when recovery is disabled / ISSI not pending.
-        self.recovery_confirm(prim.received_address.ssi);
+        self.recovery_confirm(issi);
 
         // Migration not supported: ETSI 16.4.1.1 case b) requires identity exchange via
         // D-LOCATION-UPDATE-PROCEEDING which we don't implement. Reject with cause
@@ -420,19 +516,33 @@ impl MmBs {
             // so we can't accept migration formally. But we MUST release the terminal from Brew
             // so the destination network can register it without identity conflict.
             // Send REJECT so terminal knows to try the other network, but first deregister from Brew.
-            let issi = prim.received_address.ssi;
-            tracing::info!("MM: ISSI {} migrating to another network â€” releasing from Brew", issi);
-            let detached = self.client_mgr.remove_client(issi);
-            if let Some(client) = detached {
-                self.config.state_write().subscribers.deregister(issi);
-                if !client.groups.is_empty() {
-                    let groups: Vec<u32> = client.groups.iter().copied().collect();
-                    self.emit_subscriber_update(queue, issi, groups, BrewSubscriberAction::Deaffiliate);
+            //
+            // The release is a teardown keyed purely off the (unauthenticated) source SSI, so it
+            // goes through the same gate as U-ITSI-DETACH: a forged migrating update carrying a
+            // victim's ISSI must not release that victim. The REJECT itself is always sent â€” it
+            // mutates nothing.
+            if self.teardown_authorized(issi, handle, "migrating location update") {
+                tracing::info!("MM: ISSI {} migrating to another network â€” releasing from Brew", issi);
+                let detached = self.client_mgr.remove_client(issi);
+                if let Some(client) = detached {
+                    self.config.state_write().subscribers.deregister(issi);
+                    if !client.groups.is_empty() {
+                        let groups: Vec<u32> = client.groups.iter().copied().collect();
+                        self.emit_subscriber_update(queue, issi, groups, BrewSubscriberAction::Deaffiliate);
+                    }
+                    self.emit_subscriber_update(queue, issi, Vec::new(), BrewSubscriberAction::Deregister);
                 }
-                self.emit_subscriber_update(queue, issi, Vec::new(), BrewSubscriberAction::Deregister);
+                self.recovery_mark_dirty();
             }
-            self.recovery_mark_dirty();
-            Self::send_d_location_update_reject(queue, issi, prim.handle, pdu.location_update_type, pdu.address_extension);
+            Self::send_d_location_update_reject_migration(queue, issi, handle, pdu.location_update_type, pdu.address_extension);
+            return;
+        }
+
+        // Per-source-ISSI registration rate limit. A flood cannot churn the registry (or the
+        // dashboard, or Brew) faster than this even while it stays under the size cap. Dropped
+        // silently: answering would itself be an amplifier.
+        if !self.client_mgr.allow_registration(issi) {
+            tracing::warn!("MM: ISSI {} exceeded the registration rate limit â€” dropping this location update", issi);
             return;
         }
 
@@ -457,33 +567,37 @@ impl MmBs {
         // If the terminal omits ESM from the PDU (common after T351 expiry),
         // reuse the previously granted mode so the terminal stays in EE mode.
         // We no longer filter out StayAlive â€” if that's what was granted before, keep it.
-        let prior_esm = self
-            .client_mgr
-            .get_client_by_issi(prim.received_address.ssi)
-            .map(|c| c.energy_saving_mode);
+        let prior_esm = self.client_mgr.get_client_by_issi(issi).map(|c| c.energy_saving_mode);
         let effective_esm_request = pdu.energy_saving_mode.or(prior_esm);
 
-        let esi = effective_esm_request.map(|esm| Self::grant_energy_saving(prim.received_address.ssi, esm));
+        let esi = effective_esm_request.map(|esm| Self::grant_energy_saving(issi, esm));
 
-        // Try to register the client
-        let issi = prim.received_address.ssi;
-        let handle = prim.handle;
-
-        // ISSI whitelist check â€” reject if whitelist is non-empty and ISSI not in it.
-        // The dashboard can override the config whitelist at runtime (state override takes
-        // precedence so edits apply without a restart); fall back to the config value when
-        // no override is set. An empty list (in either place) means "open network".
-        let issi_allowed = {
-            let state = self.config.state_read();
-            match &state.issi_whitelist_override {
-                Some(list) => list.is_empty() || list.contains(&issi),
-                None => self.config.config().security.is_issi_allowed(issi),
+        // Registry cap. A new ISSI may only be admitted once there is room: first make room by
+        // evicting idle unaffiliated clients (LRU, never a radio mid-call or with affiliations),
+        // and if the registry is still full refuse with Congestion rather than growing the heap
+        // until the cell is OOM-killed. Known ISSIs are unaffected â€” they re-register in place.
+        if !self.client_mgr.client_is_known(issi) {
+            let protected = self.call_protected_issis();
+            for evicted in self.client_mgr.enforce_client_cap(&protected) {
+                self.config.state_write().subscribers.deregister(evicted);
+                self.emit_subscriber_update(queue, evicted, Vec::new(), BrewSubscriberAction::Deregister);
             }
-        };
-        if !issi_allowed {
-            tracing::warn!("MM: ISSI {} not in whitelist, rejecting registration", issi);
-            Self::send_d_location_update_reject(queue, issi, handle, pdu.location_update_type, pdu.address_extension);
-            return;
+            if self.client_mgr.at_capacity() {
+                tracing::warn!(
+                    "MM: client registry full ({} clients) â€” refusing registration of ISSI {} with Congestion",
+                    self.client_mgr.client_count(),
+                    issi
+                );
+                Self::send_d_location_update_reject_cause(
+                    queue,
+                    issi,
+                    handle,
+                    pdu.location_update_type,
+                    pdu.address_extension,
+                    RejectCause::Congestion,
+                );
+                return;
+            }
         }
 
         // Restart recovery: this terminal answered (re-registered), so stop replaying
@@ -692,10 +806,15 @@ impl MmBs {
         // Registration / affiliation / EE state changed â€” persist for restart recovery (debounced).
         self.recovery_mark_dirty();
 
-        // Use PeriodicLocationUpdating accept type when periodic registration is enabled.
-        // This signals to the MS that it must re-register within the configured interval.
+        // Preserve the accepted location update type (EN 300 392-2 cl. 16.9.2.2): some radios key
+        // attach-completion off the accept type, so answering an ItsiAttach with
+        // PeriodicLocationUpdating leaves them believing the attach never completed. The periodic
+        // interval is not carried in D-LOCATION-UPDATE-ACCEPT anyway â€” it is signalled by the
+        // broadcast timers, and this stack re-attracts radios with an explicit
+        // D-LOCATION-UPDATE-COMMAND at T351 expiry (see tick_start), which is what the terminals
+        // in the field actually respond to.
         let periodic_secs = self.config.config().cell.periodic_registration_secs;
-        let accept_type = if periodic_secs > 0 {
+        let accept_type = if periodic_secs > 0 && pdu.location_update_type != LocationUpdateType::ItsiAttach {
             LocationUpdateType::PeriodicLocationUpdating
         } else {
             pdu.location_update_type
@@ -1019,14 +1138,7 @@ impl MmBs {
         // (rx_u_location_update_demand). Without this, an unknown ISSI can self-register
         // via the group-attach path below, bypassing the whitelist and growing the client
         // registry without bound.
-        let issi_allowed = {
-            let state = self.config.state_read();
-            match &state.issi_whitelist_override {
-                Some(list) => list.is_empty() || list.contains(&issi),
-                None => self.config.config().security.is_issi_allowed(issi),
-            }
-        };
-        if !issi_allowed {
+        if !self.issi_allowed(issi) {
             tracing::warn!("MM: ISSI {} not in whitelist, rejecting group attach/detach", issi);
             self.send_d_attach_detach_ack_reject(queue, issi, prim.handle);
             return;
@@ -1738,8 +1850,11 @@ impl MmBs {
         queue.push_back(msg);
     }
 
-    /// Sends a D-LOCATION UPDATE REJECT PDU (ETSI clause 16.9.2.9)
-    fn send_d_location_update_reject(
+    /// Sends a D-LOCATION UPDATE REJECT PDU (ETSI clause 16.9.2.9) with cause "Migration not
+    /// supported". Only for the genuine migration path â€” an access-control refusal must carry an
+    /// access-control cause instead (see `send_d_location_update_reject_cause`), or a barred radio
+    /// is told to go find another network.
+    fn send_d_location_update_reject_migration(
         queue: &mut MessageQueue,
         issi: u32,
         handle: u32,
@@ -1940,6 +2055,10 @@ impl TetraEntityTrait for MmBs {
     }
 
     fn set_config(&mut self, config: SharedConfig) {
+        // Re-apply the [security] registry bounds so a config swap can't leave the caps behind.
+        let sec = config.config();
+        self.client_mgr
+            .set_limits(sec.security.max_registered_clients, sec.security.registration_rate_limit_per_min);
         self.config = config;
     }
 
@@ -2073,6 +2192,25 @@ impl TetraEntityTrait for MmBs {
                     if let Some(sink) = &self.telemetry {
                         sink.send(crate::net_telemetry::TelemetryEvent::MsTimeoutDrop { issi });
                     }
+                }
+                // Confirmed gone and holding nothing worth preserving â€” FULLY remove it. Keeping
+                // every client forever is what let an RF-unauthenticated registration flood grow
+                // the registry without bound (each forged ISSI was a permanent entry). Only a
+                // client with no group affiliations (nothing for coverage-return re-affiliation to
+                // restore) and no call in flight is dropped; an affiliated or mid-call radio is
+                // still kept exactly as before.
+                let has_groups = self
+                    .client_mgr
+                    .get_client_by_issi(issi)
+                    .map(|c| !c.groups.is_empty())
+                    .unwrap_or(false);
+                let in_call = self.config.state_read().active_call_ts.contains_key(&issi);
+                if !has_groups && !in_call {
+                    tracing::info!("MM: ISSI {} confirmed gone with no groups or calls â€” removing from the client registry", issi);
+                    self.client_mgr.remove_client(issi);
+                    self.config.state_write().subscribers.deregister(issi);
+                    self.recovery_mark_dirty();
+                    continue;
                 }
                 self.client_mgr.reset_registration_timer(issi);
                 self.recovery_mark_dirty();

--- a/crates/tetra-entities/src/net_asterisk/audio.rs
+++ b/crates/tetra-entities/src/net_asterisk/audio.rs
@@ -1,6 +1,8 @@
 use std::ptr::NonNull;
 
 pub(crate) const PCMU_PAYLOAD_TYPE: u8 = 0;
+/// µ-law is one byte per sample at 8 kHz, so bytes and RTP timestamp ticks are the same unit.
+const PCMU_SAMPLES_PER_MS: usize = 8;
 
 const TETRA_PCM_SAMPLES_PER_FRAME: usize = 240;
 const TETRA_PCM_SAMPLES_PER_BLOCK: usize = TETRA_PCM_SAMPLES_PER_FRAME * 2;
@@ -98,6 +100,63 @@ impl AsteriskAudioTranscoder {
         }
 
         out
+    }
+}
+
+/// Cuts a µ-law stream into fixed-ptime RTP packets.
+///
+/// One TETRA block decodes to 60 ms of audio; shipping that as a single RTP packet is what
+/// FH-BUG-074 was - real trunks want 20 ms / 160 byte G.711. Whatever does not fill a whole
+/// packet is carried into the next block so the timestamps stay on the sample clock.
+pub(crate) struct RtpPacketizer {
+    ssrc: u32,
+    payload_bytes: usize,
+    seq: u16,
+    timestamp: u32,
+    pending: Vec<u8>,
+    marker: bool,
+}
+
+impl RtpPacketizer {
+    pub(crate) fn new(ssrc: u32, ptime_ms: u16) -> Self {
+        let payload_bytes = PCMU_SAMPLES_PER_MS * ptime_ms.max(1) as usize;
+        Self {
+            ssrc,
+            payload_bytes,
+            seq: 1,
+            timestamp: 0,
+            pending: Vec::with_capacity(payload_bytes * 4),
+            marker: true,
+        }
+    }
+
+    /// Arm the marker bit for the next packet, i.e. this is the start of a talkspurt.
+    pub(crate) fn mark_talkspurt(&mut self) {
+        self.marker = true;
+    }
+
+    pub(crate) fn push(&mut self, payload: &[u8]) -> Vec<Vec<u8>> {
+        self.pending.extend_from_slice(payload);
+        let mut packets = Vec::with_capacity(self.pending.len() / self.payload_bytes);
+        while self.pending.len() >= self.payload_bytes {
+            let chunk: Vec<u8> = self.pending.drain(..self.payload_bytes).collect();
+            packets.push(self.build(&chunk));
+        }
+        packets
+    }
+
+    fn build(&mut self, chunk: &[u8]) -> Vec<u8> {
+        let mut packet = Vec::with_capacity(12 + chunk.len());
+        packet.push(0x80);
+        packet.push(PCMU_PAYLOAD_TYPE | if self.marker { 0x80 } else { 0 });
+        packet.extend_from_slice(&self.seq.to_be_bytes());
+        packet.extend_from_slice(&self.timestamp.to_be_bytes());
+        packet.extend_from_slice(&self.ssrc.to_be_bytes());
+        packet.extend_from_slice(chunk);
+        self.marker = false;
+        self.seq = self.seq.wrapping_add(1);
+        self.timestamp = self.timestamp.wrapping_add(chunk.len() as u32);
+        packet
     }
 }
 
@@ -242,6 +301,48 @@ mod tests {
 
         let frames_again = split_tmd_block_to_codec_frames(&packed).unwrap();
         assert_eq!(frames, frames_again);
+    }
+
+    fn seq_of(packet: &[u8]) -> u16 {
+        u16::from_be_bytes([packet[2], packet[3]])
+    }
+
+    fn timestamp_of(packet: &[u8]) -> u32 {
+        u32::from_be_bytes([packet[4], packet[5], packet[6], packet[7]])
+    }
+
+    #[test]
+    fn packetizer_splits_a_60ms_block_into_three_20ms_packets() {
+        let mut packetizer = RtpPacketizer::new(0xdead_beef, 20);
+        let packets = packetizer.push(&vec![0x7fu8; TETRA_PCM_SAMPLES_PER_BLOCK]);
+
+        assert_eq!(packets.len(), 3);
+        for (idx, packet) in packets.iter().enumerate() {
+            assert_eq!(packet.len(), 12 + 160);
+            assert_eq!(packet[1] & 0x7f, PCMU_PAYLOAD_TYPE);
+            assert_eq!(seq_of(packet), 1 + idx as u16);
+            assert_eq!(timestamp_of(packet), idx as u32 * 160);
+            assert_eq!(u32::from_be_bytes([packet[8], packet[9], packet[10], packet[11]]), 0xdead_beef);
+        }
+        // marker only on the first packet of the talkspurt
+        assert_eq!(packets[0][1] & 0x80, 0x80);
+        assert_eq!(packets[1][1] & 0x80, 0);
+        assert_eq!(packets[2][1] & 0x80, 0);
+    }
+
+    #[test]
+    fn packetizer_carries_the_remainder_across_blocks() {
+        // 40 ms packets do not divide a 60 ms block, so the tail must survive to the next push.
+        let mut packetizer = RtpPacketizer::new(1, 40);
+        let first = packetizer.push(&vec![0u8; TETRA_PCM_SAMPLES_PER_BLOCK]);
+        assert_eq!(first.len(), 1);
+        assert_eq!(first[0].len(), 12 + 320);
+
+        let second = packetizer.push(&vec![0u8; TETRA_PCM_SAMPLES_PER_BLOCK]);
+        assert_eq!(second.len(), 2);
+        assert_eq!(seq_of(&second[0]), 2);
+        assert_eq!(timestamp_of(&second[0]), 320);
+        assert_eq!(timestamp_of(&second[1]), 640);
     }
 
     #[test]

--- a/crates/tetra-entities/src/net_asterisk/entity.rs
+++ b/crates/tetra-entities/src/net_asterisk/entity.rs
@@ -15,9 +15,14 @@ use uuid::Uuid;
 
 use crate::{MessageQueue, TetraEntityTrait};
 
-use super::audio::{AsteriskAudioTranscoder, PCMU_PAYLOAD_TYPE, rtp_payload};
+use super::audio::{AsteriskAudioTranscoder, PCMU_PAYLOAD_TYPE, RtpPacketizer, rtp_payload};
 
 const SIP_MAX_DATAGRAM: usize = 8192;
+/// RFC 3261 timer H: how long a cancelled INVITE may wait for its final response before we
+/// give up on it and free the RTP port.
+const CANCEL_REAP_AFTER: Duration = Duration::from_secs(32);
+/// Silence longer than this counts as a new talkspurt, so the next RTP packet gets a marker.
+const TALKSPURT_GAP: Duration = Duration::from_millis(100);
 
 #[derive(Clone, Debug)]
 struct DigestChallenge {
@@ -33,6 +38,8 @@ struct DigestChallenge {
 enum DialogState {
     Inviting,
     Ringing,
+    /// CANCEL sent, still waiting for the INVITE's final response (487, or a 2xx that raced us).
+    Cancelling,
     Established,
     Released,
 }
@@ -41,9 +48,8 @@ struct RtpSession {
     socket: UdpSocket,
     local_port: u16,
     remote: Option<SocketAddr>,
-    seq: u16,
-    timestamp: u32,
-    ssrc: u32,
+    packetizer: RtpPacketizer,
+    last_tx: Option<Instant>,
 }
 
 struct SipDialog {
@@ -55,6 +61,10 @@ struct SipDialog {
     local_tag: String,
     remote_tag: Option<String>,
     cseq: u32,
+    /// Top Via branch of the INVITE. CANCEL and non-2xx ACK belong to that same transaction.
+    invite_branch: String,
+    /// Contact of the answer, i.e. where in-dialog requests must actually go.
+    remote_target: Option<String>,
     auth: Option<DigestChallenge>,
     auth_retry_sent: bool,
     state: DialogState,
@@ -63,6 +73,7 @@ struct SipDialog {
     media_ready: Option<(u16, u16, u8)>,
     inbound: bool,
     request_context: Option<SipRequestContext>,
+    released_at: Option<Instant>,
 }
 
 #[derive(Debug)]
@@ -141,11 +152,85 @@ struct SipRequestContext {
     addr: SocketAddr,
 }
 
+/// Extra hosts allowed to speak SIP to us. Unresolvable entries are dropped rather than
+/// failing startup - a stale allowlist entry must not take the whole bridge down.
+fn resolve_allowed_peers(hosts: &[String]) -> Vec<IpAddr> {
+    let mut peers = Vec::new();
+    for host in hosts {
+        if let Ok(ip) = host.parse::<IpAddr>() {
+            peers.push(ip);
+            continue;
+        }
+        match (host.as_str(), 0u16).to_socket_addrs() {
+            Ok(addrs) => peers.extend(addrs.map(|addr| addr.ip())),
+            Err(err) => tracing::warn!("AsteriskEntity: allow_from entry '{}' did not resolve: {}", host, err),
+        }
+    }
+    peers
+}
+
+struct TeardownParams<'a> {
+    cancel: bool,
+    invite_uri: &'a str,
+    remote_target: Option<&'a str>,
+    via_host: &'a str,
+    via_port: u16,
+    invite_branch: &'a str,
+    fresh_branch: &'a str,
+    from_uri: &'a str,
+    local_tag: &'a str,
+    remote_tag: Option<&'a str>,
+    call_id: &'a str,
+    invite_cseq: u32,
+    contact: &'a str,
+}
+
+/// CANCEL and BYE look alike but belong to different transactions, and getting that wrong is
+/// FH-BUG-071: a CANCEL is part of the INVITE transaction (RFC 3261 §9.1), so Request-URI,
+/// To (still untagged, exactly as sent), Call-ID, From and the CSeq number must be identical
+/// to the INVITE's and the top Via branch must be the INVITE's branch - otherwise the proxy
+/// cannot match it and never stops ringing the callee. A BYE is a brand new transaction in an
+/// established dialog: fresh branch, next CSeq, negotiated To tag, sent to the remote target.
+fn build_teardown_request(p: &TeardownParams) -> String {
+    let method = if p.cancel { "CANCEL" } else { "BYE" };
+    let branch = if p.cancel { p.invite_branch } else { p.fresh_branch };
+    let cseq = if p.cancel { p.invite_cseq } else { p.invite_cseq.saturating_add(1) };
+    let request_uri = if p.cancel {
+        p.invite_uri
+    } else {
+        p.remote_target.unwrap_or(p.invite_uri)
+    };
+    let to = match (p.cancel, p.remote_tag) {
+        (false, Some(tag)) => format!("<{}>;tag={}", p.invite_uri, tag),
+        _ => format!("<{}>", p.invite_uri),
+    };
+    // A CANCEL is not a dialog-forming request, so it carries no Contact.
+    let contact_line = if p.cancel {
+        String::new()
+    } else {
+        format!("Contact: <{}>\r\n", p.contact)
+    };
+    format!(
+        "{} {} SIP/2.0\r\n\
+         Via: SIP/2.0/UDP {}:{};branch={};rport\r\n\
+         Max-Forwards: 70\r\n\
+         From: <{}>;tag={}\r\n\
+         To: {}\r\n\
+         Call-ID: {}\r\n\
+         CSeq: {} {}\r\n\
+         {}\
+         Content-Length: 0\r\n\r\n",
+        method, request_uri, p.via_host, p.via_port, branch, p.from_uri, p.local_tag, to, p.call_id, cseq, method, contact_line
+    )
+}
+
 pub struct AsteriskEntity {
     config: SharedConfig,
     asterisk_config: CfgAsterisk,
     sip_socket: UdpSocket,
     remote: SocketAddr,
+    allowed_peers: Vec<IpAddr>,
+    invite_rate: HashMap<IpAddr, (Instant, u32)>,
     dialogs: HashMap<Uuid, SipDialog>,
     rtp_by_ts: HashMap<(u16, u8), Uuid>,
     next_rtp_port: u16,
@@ -173,6 +258,8 @@ impl AsteriskEntity {
             .next()
             .ok_or_else(|| io::Error::new(io::ErrorKind::AddrNotAvailable, "asterisk remote address did not resolve"))?;
 
+        let allowed_peers = resolve_allowed_peers(&asterisk_config.allow_from);
+
         let entity = Self {
             config,
             next_rtp_port: asterisk_config.rtp_port_min,
@@ -180,6 +267,8 @@ impl AsteriskEntity {
             asterisk_config,
             sip_socket,
             remote,
+            allowed_peers,
+            invite_rate: HashMap::new(),
             dialogs: HashMap::new(),
             rtp_by_ts: HashMap::new(),
             branch_counter: 1,
@@ -218,7 +307,11 @@ impl AsteriskEntity {
             remote: self.remote_display(),
             rtp_port_range: self.rtp_range(),
             codec: self.asterisk_config.codec.clone(),
-            active_dialogs: self.dialogs.values().filter(|d| d.state != DialogState::Released).count(),
+            active_dialogs: self
+                .dialogs
+                .values()
+                .filter(|d| !matches!(d.state, DialogState::Released | DialogState::Cancelling))
+                .count(),
             last_rx: self.last_rx.clone(),
             last_tx: self.last_tx.clone(),
             last_error: self.last_error.clone(),
@@ -371,10 +464,14 @@ impl AsteriskEntity {
              t=0 0\r\n\
              m=audio {} RTP/AVP 0\r\n\
              a=rtpmap:0 PCMU/8000\r\n\
-             a=ptime:60\r\n\
-             a=maxptime:60\r\n\
+             a=ptime:{}\r\n\
+             a=maxptime:{}\r\n\
              a=sendrecv\r\n",
-            self.asterisk_config.contact_host, self.asterisk_config.contact_host, rtp_port
+            self.asterisk_config.contact_host,
+            self.asterisk_config.contact_host,
+            rtp_port,
+            self.asterisk_config.ptime_ms,
+            self.asterisk_config.ptime_ms
         )
     }
 
@@ -383,6 +480,10 @@ impl AsteriskEntity {
         let (rtp_port, auth) = self.dialogs.get(&uuid).map(|dialog| (dialog.rtp.local_port, dialog.auth.clone()))?;
         let request_uri = self.request_uri(&snapshot.number);
         let branch = self.next_branch();
+        // CANCEL and any non-2xx ACK have to run in this very transaction, so remember the branch.
+        if let Some(dialog) = self.dialogs.get_mut(&uuid) {
+            dialog.invite_branch = branch.clone();
+        }
         let body = self.build_sdp(rtp_port);
         let auth = auth
             .as_ref()
@@ -444,39 +545,28 @@ impl AsteriskEntity {
         let Some(dialog) = self.dialogs.get(&uuid).map(SipDialogSnapshot::from_dialog) else {
             return;
         };
+        let fresh_branch = self.next_branch();
+        let request = build_teardown_request(&TeardownParams {
+            cancel,
+            invite_uri: &self.request_uri(&dialog.number),
+            remote_target: dialog.remote_target.as_deref(),
+            via_host: &self.asterisk_config.contact_host,
+            via_port: self.asterisk_config.bind_port,
+            invite_branch: &dialog.invite_branch,
+            fresh_branch: &fresh_branch,
+            from_uri: &dialog.local_uri,
+            local_tag: &dialog.local_tag,
+            remote_tag: dialog.remote_tag.as_deref(),
+            call_id: &dialog.call_id_header,
+            invite_cseq: dialog.cseq,
+            contact: &self.contact_uri(),
+        });
         let method = if cancel { "CANCEL" } else { "BYE" };
-        let request_uri = self.request_uri(&dialog.number);
-        let branch = self.next_branch();
-        let to = if let Some(tag) = &dialog.remote_tag {
-            format!("<{}>;tag={}", request_uri, tag)
-        } else {
-            format!("<{}>", request_uri)
-        };
-        let cseq = if cancel { dialog.cseq } else { dialog.cseq.saturating_add(1) };
-        let request = format!(
-            "{} {} SIP/2.0\r\n\
-             Via: SIP/2.0/UDP {}:{};branch={};rport\r\n\
-             Max-Forwards: 70\r\n\
-             From: <{}>;tag={}\r\n\
-             To: {}\r\n\
-             Call-ID: {}\r\n\
-             CSeq: {} {}\r\n\
-             Contact: <{}>\r\n\
-             Content-Length: 0\r\n\r\n",
-            method,
-            request_uri,
-            self.asterisk_config.contact_host,
-            self.asterisk_config.bind_port,
-            branch,
-            dialog.local_uri,
-            dialog.local_tag,
-            to,
-            dialog.call_id_header,
-            cseq,
-            method,
-            self.contact_uri()
-        );
-        self.send_sip(request, format!("{} {}", method, uuid));
+        // Inbound dialogs answer back to whoever sent us the INVITE, not to the configured peer.
+        match dialog.peer_addr {
+            Some(addr) => self.send_sip_to(request, addr, format!("{} {}", method, uuid)),
+            None => self.send_sip(request, format!("{} {}", method, uuid)),
+        }
     }
 
     fn tagged_to(to: &str, tag: Option<&str>) -> String {
@@ -635,6 +725,18 @@ impl AsteriskEntity {
         })
     }
 
+    /// Remote target for in-dialog requests: the bare URI inside the peer's Contact header.
+    fn parse_contact_uri(header: Option<&str>) -> Option<String> {
+        let value = header?.trim();
+        let uri = if let Some(start) = value.find('<') {
+            let rest = &value[start + 1..];
+            rest.split_once('>')?.0
+        } else {
+            value.split(';').next()?.trim()
+        };
+        (!uri.is_empty() && uri.to_ascii_lowercase().starts_with("sip")).then(|| uri.to_string())
+    }
+
     fn sip_uri_user(value: &str) -> Option<String> {
         let trimmed = value.trim();
         let after_scheme = if let Some(idx) = trimmed.to_ascii_lowercase().find("sip:") {
@@ -713,9 +815,8 @@ impl AsteriskEntity {
                         socket,
                         local_port: port,
                         remote: None,
-                        seq: 1,
-                        timestamp: 0,
-                        ssrc,
+                        packetizer: RtpPacketizer::new(ssrc, self.asterisk_config.ptime_ms),
+                        last_tx: None,
                     });
                 }
                 Err(_) => {
@@ -726,10 +827,50 @@ impl AsteriskEntity {
         Err(io::Error::new(io::ErrorKind::AddrNotAvailable, "no RTP port available"))
     }
 
+    fn peer_allowed(&self, addr: SocketAddr) -> bool {
+        // Port is not pinned: Asterisk answers from whatever source port it likes.
+        addr.ip() == self.remote.ip() || self.allowed_peers.contains(&addr.ip())
+    }
+
+    /// Sliding-ish window per source. Each INVITE costs an RTP port, a codec and a CMCE setup,
+    /// so an unthrottled peer can exhaust the port pool and mass-ring the cell.
+    fn invite_rate_ok(&mut self, addr: SocketAddr) -> bool {
+        let limit = self.asterisk_config.max_invites_per_minute;
+        if limit == 0 {
+            return true;
+        }
+        let now = Instant::now();
+        let entry = self.invite_rate.entry(addr.ip()).or_insert((now, 0));
+        if now.duration_since(entry.0) >= Duration::from_secs(60) {
+            *entry = (now, 0);
+        }
+        entry.1 = entry.1.saturating_add(1);
+        entry.1 <= limit
+    }
+
+    fn pending_dialogs(&self) -> usize {
+        self.dialogs
+            .values()
+            .filter(|d| matches!(d.state, DialogState::Inviting | DialogState::Ringing))
+            .count()
+    }
+
     fn start_inbound_call(&mut self, queue: &mut MessageQueue, msg: &SipMessage, addr: SocketAddr) {
         let Some(ctx) = Self::request_context(msg, addr) else {
             return;
         };
+        if !self.invite_rate_ok(addr) {
+            tracing::warn!("AsteriskEntity: INVITE rate limit hit for {}, rejecting", addr);
+            let response = self.build_response(&ctx, 503, "Service Unavailable", Some("flowstation"), None);
+            self.send_sip_to(response, addr, "503 Service Unavailable");
+            return;
+        }
+        if self.pending_dialogs() >= self.asterisk_config.max_pending_dialogs {
+            tracing::warn!("AsteriskEntity: too many pending dialogs, rejecting INVITE from {}", addr);
+            let response = self.build_response(&ctx, 486, "Busy Here", Some("flowstation"), None);
+            self.send_sip_to(response, addr, "486 Busy Here");
+            return;
+        }
         let Some(destination) = self.inbound_destination_issi(msg) else {
             tracing::info!(
                 "AsteriskEntity: rejecting inbound INVITE without TETRA destination: {}",
@@ -799,6 +940,8 @@ impl AsteriskEntity {
             local_tag,
             remote_tag,
             cseq: 1,
+            invite_branch: String::new(),
+            remote_target: Self::parse_contact_uri(msg.header("Contact")),
             auth: None,
             auth_retry_sent: false,
             state: DialogState::Inviting,
@@ -807,6 +950,7 @@ impl AsteriskEntity {
             media_ready: None,
             inbound: true,
             request_context: Some(ctx.clone()),
+            released_at: None,
         };
         self.dialogs.insert(uuid, dialog);
 
@@ -925,6 +1069,8 @@ impl AsteriskEntity {
             local_tag: format!("flow{}", &brew_uuid.to_string()[..8]),
             remote_tag: None,
             cseq: 1,
+            invite_branch: String::new(),
+            remote_target: None,
             auth: None,
             auth_retry_sent: false,
             state: DialogState::Inviting,
@@ -933,6 +1079,7 @@ impl AsteriskEntity {
             media_ready: None,
             inbound: false,
             request_context: None,
+            released_at: None,
         };
         self.dialogs.insert(brew_uuid, dialog);
         self.send_setup_accept(queue, brew_uuid);
@@ -990,13 +1137,11 @@ impl AsteriskEntity {
     }
 
     fn release_dialog(&mut self, brew_uuid: Uuid, from_cmce: bool) {
-        let Some((cancel, media_ready, inbound)) = self.dialogs.get(&brew_uuid).map(|dialog| {
-            (
-                !matches!(dialog.state, DialogState::Established),
-                dialog.media_ready,
-                dialog.inbound,
-            )
-        }) else {
+        let Some((cancel, inbound)) = self
+            .dialogs
+            .get(&brew_uuid)
+            .map(|dialog| (!matches!(dialog.state, DialogState::Established), dialog.inbound))
+        else {
             return;
         };
         if from_cmce {
@@ -1006,11 +1151,30 @@ impl AsteriskEntity {
                 self.send_bye_or_cancel(brew_uuid, cancel);
             }
         }
-        if let Some((_, carrier_num, ts)) = media_ready {
-            self.rtp_by_ts.remove(&(carrier_num, ts));
+        // An outbound INVITE we just CANCELled is still alive at the far end until its final
+        // response arrives. Forgetting the dialog here loses that response - and if the callee
+        // answers in the meantime, the 200 OK matches nothing, never gets ACKed and the phone
+        // stays up forever (FH-BUG-071). Keep it until the INVITE transaction really ends.
+        if from_cmce && cancel && !inbound {
+            if let Some((_, carrier_num, ts)) = self.dialogs.get(&brew_uuid).and_then(|d| d.media_ready) {
+                self.rtp_by_ts.remove(&(carrier_num, ts));
+            }
+            if let Some(dialog) = self.dialogs.get_mut(&brew_uuid) {
+                dialog.media_ready = None;
+                dialog.state = DialogState::Cancelling;
+                dialog.released_at = Some(Instant::now());
+            }
+            return;
         }
+        self.drop_dialog(brew_uuid);
+    }
+
+    fn drop_dialog(&mut self, brew_uuid: Uuid) {
         if let Some(dialog) = self.dialogs.get_mut(&brew_uuid) {
             dialog.state = DialogState::Released;
+            if let Some((_, carrier_num, ts)) = dialog.media_ready.take() {
+                self.rtp_by_ts.remove(&(carrier_num, ts));
+            }
         }
         self.dialogs.remove(&brew_uuid);
     }
@@ -1019,7 +1183,7 @@ impl AsteriskEntity {
         let Some(uuid) = self.rtp_by_ts.get(&(prim.carrier_num, prim.ts)).copied() else {
             return;
         };
-        let mut send_result = None;
+        let mut send_error: Option<io::Error> = None;
         let mut drop_reason = None;
         'send: {
             let Some(dialog) = self.dialogs.get_mut(&uuid) else {
@@ -1038,25 +1202,31 @@ impl AsteriskEntity {
                 break 'send;
             };
 
-            let mut packet = Vec::with_capacity(12 + payload.len());
-            packet.push(0x80);
-            packet.push(PCMU_PAYLOAD_TYPE);
-            packet.extend_from_slice(&dialog.rtp.seq.to_be_bytes());
-            packet.extend_from_slice(&dialog.rtp.timestamp.to_be_bytes());
-            packet.extend_from_slice(&dialog.rtp.ssrc.to_be_bytes());
-            packet.extend_from_slice(&payload);
-            let result = dialog.rtp.socket.send_to(&packet, remote);
-            if result.is_ok() {
-                dialog.rtp.seq = dialog.rtp.seq.wrapping_add(1);
-                dialog.rtp.timestamp = dialog.rtp.timestamp.wrapping_add(payload.len().max(1) as u32);
+            // One TETRA block is 60 ms of audio; the packetizer cuts it into ptime-sized RTP
+            // packets and keeps whatever is left over for the next block (FH-BUG-074).
+            let now = Instant::now();
+            if dialog
+                .rtp
+                .last_tx
+                .map(|last| now.duration_since(last) > TALKSPURT_GAP)
+                .unwrap_or(true)
+            {
+                dialog.rtp.packetizer.mark_talkspurt();
             }
-            send_result = Some(result);
+            dialog.rtp.last_tx = Some(now);
+
+            for packet in dialog.rtp.packetizer.push(&payload) {
+                if let Err(err) = dialog.rtp.socket.send_to(&packet, remote) {
+                    send_error = Some(err);
+                    break;
+                }
+            }
         }
         if let Some(reason) = drop_reason {
             self.set_error(reason);
             return;
         }
-        if let Some(Err(err)) = send_result {
+        if let Some(err) = send_error {
             self.set_error(format!("RTP send failed uuid={} ts={}: {}", uuid, prim.ts, err));
         };
     }
@@ -1083,7 +1253,16 @@ impl AsteriskEntity {
                             );
                             continue;
                         }
-                        dialog.rtp.remote = Some(addr);
+                        // Only the SDP-negotiated peer may feed this call. Latching onto any
+                        // sender let anyone who found the port inject or steal audio mid-call;
+                        // a changed port from the same host is still allowed (symmetric RTP).
+                        match dialog.rtp.remote {
+                            Some(expected) if expected.ip() == addr.ip() => dialog.rtp.remote = Some(addr),
+                            _ => {
+                                tracing::trace!("AsteriskEntity: dropping RTP from unexpected source {} uuid={}", addr, dialog.uuid);
+                                continue;
+                            }
+                        }
                         for frame in dialog.audio.encode_pcmu_to_tmd(payload) {
                             downlink.push((carrier_num, ts, frame));
                         }
@@ -1115,6 +1294,12 @@ impl AsteriskEntity {
         for _ in 0..32 {
             match self.sip_socket.recv_from(&mut buf) {
                 Ok((len, addr)) => {
+                    // Anything that reaches this port could otherwise INVITE an arbitrary ISSI
+                    // or tear down a dialog by guessing its Call-ID.
+                    if !self.peer_allowed(addr) {
+                        tracing::debug!("AsteriskEntity: dropping SIP datagram from unexpected source {}", addr);
+                        continue;
+                    }
                     if let Some(msg) = SipMessage::parse(&buf[..len]) {
                         self.last_rx = Some(format!("{} from {}", msg.start_line, addr));
                         self.handle_sip_message(queue, msg, addr);
@@ -1134,17 +1319,13 @@ impl AsteriskEntity {
             match method {
                 "INVITE" => self.start_inbound_call(queue, &msg, addr),
                 "OPTIONS" => self.answer_request(&msg, addr, 200, "OK"),
-                "BYE" => {
+                "BYE" | "CANCEL" => {
                     self.answer_request(&msg, addr, 200, "OK");
                     if let Some(uuid) = self.find_dialog_by_call_id(msg.call_id()) {
-                        self.send_release_to_cmce(queue, uuid, 16);
-                        self.release_dialog(uuid, false);
-                    }
-                }
-                "CANCEL" => {
-                    self.answer_request(&msg, addr, 200, "OK");
-                    if let Some(uuid) = self.find_dialog_by_call_id(msg.call_id()) {
-                        self.send_release_to_cmce(queue, uuid, 16);
+                        // A dialog we already cancelled has been released towards CMCE.
+                        if self.dialogs.get(&uuid).is_some_and(|d| d.state != DialogState::Cancelling) {
+                            self.send_release_to_cmce(queue, uuid, 16);
+                        }
                         self.release_dialog(uuid, false);
                     }
                 }
@@ -1193,33 +1374,59 @@ impl AsteriskEntity {
         let Some(uuid) = self.find_dialog_by_call_id(msg.call_id()) else {
             return;
         };
+        // The radio already hung up and we CANCELled; CMCE has been told, so from here on we
+        // only have to close the SIP leg down cleanly.
+        let cancelling = self.dialogs.get(&uuid).is_some_and(|d| d.state == DialogState::Cancelling);
 
         match code {
             100 => {}
             180 | 183 => {
+                if cancelling {
+                    return;
+                }
+                let remote_rtp = self.parse_sdp_remote(&msg.body);
                 if let Some(dialog) = self.dialogs.get_mut(&uuid) {
                     dialog.state = DialogState::Ringing;
                     dialog.remote_tag = Self::parse_to_tag(msg.header("To"));
+                    // 183 carries early media; without this the answer SDP is our only source.
+                    if let Some(remote_rtp) = remote_rtp {
+                        dialog.rtp.remote = Some(remote_rtp);
+                    }
                 }
                 self.send_alert(queue, uuid);
             }
             200..=299 => {
                 let remote_rtp = self.parse_sdp_remote(&msg.body);
+                let remote_target = Self::parse_contact_uri(msg.header("Contact"));
                 let connect_call = {
                     let Some(dialog) = self.dialogs.get_mut(&uuid) else {
                         return;
                     };
                     dialog.remote_tag = Self::parse_to_tag(msg.header("To"));
+                    dialog.remote_target = remote_target.or(dialog.remote_target.take());
                     if let Some(remote_rtp) = remote_rtp {
                         dialog.rtp.remote = Some(remote_rtp);
                     }
-                    dialog.state = DialogState::Established;
+                    if !cancelling {
+                        dialog.state = DialogState::Established;
+                    }
                     dialog.call.clone()
                 };
+                // An ACK to a 2xx is its own transaction, so a fresh branch is correct here.
+                // Skipping it makes the far end retransmit the 200 OK forever (FH-BUG-071).
                 let ack_snapshot = self.dialogs.get(&uuid).map(SipDialogSnapshot::from_dialog);
-                if let Some(dialog_for_ack) = ack_snapshot {
-                    let ack_text = self.build_ack_from_snapshot(&dialog_for_ack);
+                if let Some(snapshot) = ack_snapshot {
+                    let branch = self.next_branch();
+                    let ack_text = self.build_ack(&snapshot, &branch, snapshot.cseq);
                     self.send_sip(ack_text, format!("ACK {}", uuid));
+                }
+                if cancelling {
+                    // The answer raced our CANCEL: the leg is up now, so ACK it and BYE it,
+                    // otherwise the callee stays connected with nobody on our side.
+                    tracing::info!("AsteriskEntity: 200 OK raced our CANCEL uuid={}, hanging up with BYE", uuid);
+                    self.send_bye_or_cancel(uuid, false);
+                    self.drop_dialog(uuid);
+                    return;
                 }
                 let connect_snapshot = self.dialogs.get(&uuid).map(SipDialogSnapshot::from_dialog);
                 if let Some(snapshot) = connect_snapshot {
@@ -1238,6 +1445,12 @@ impl AsteriskEntity {
                 }
             }
             401 | 407 => {
+                // ACK before bumping the CSeq: the ACK belongs to the challenged INVITE.
+                self.ack_non_2xx(uuid, msg, &format!("ACK auth {}", uuid));
+                if cancelling {
+                    self.drop_dialog(uuid);
+                    return;
+                }
                 if let Some(challenge) = Self::parse_challenge(msg) {
                     let mut should_retry = false;
                     if let Some(dialog) = self.dialogs.get_mut(&uuid)
@@ -1248,21 +1461,17 @@ impl AsteriskEntity {
                         dialog.cseq = dialog.cseq.saturating_add(1);
                         should_retry = true;
                     }
-                    let ack_snapshot = self.dialogs.get(&uuid).map(SipDialogSnapshot::from_dialog);
-                    if let Some(snapshot) = ack_snapshot {
-                        let ack_text = self.build_ack_from_snapshot(&snapshot);
-                        self.send_sip(ack_text, format!("ACK auth {}", uuid));
-                    }
                     if should_retry {
                         self.send_invite(uuid);
                     }
                 }
             }
             300..=699 => {
-                let ack_snapshot = self.dialogs.get(&uuid).map(SipDialogSnapshot::from_dialog);
-                if let Some(snapshot) = ack_snapshot {
-                    let ack_text = self.build_ack_from_snapshot(&snapshot);
-                    self.send_sip(ack_text, format!("ACK failure {}", uuid));
+                self.ack_non_2xx(uuid, msg, &format!("ACK failure {}", uuid));
+                if cancelling {
+                    // 487 for the CANCEL we sent - expected, CMCE already knows.
+                    self.drop_dialog(uuid);
+                    return;
                 }
                 self.set_error(format!("INVITE uuid={} failed with SIP {}", uuid, code));
                 self.send_release_to_cmce(queue, uuid, 34);
@@ -1282,6 +1491,24 @@ impl AsteriskEntity {
 
     fn maybe_periodic_sip(&mut self) {
         let now = Instant::now();
+
+        // A cancelled INVITE whose final response never showed up would otherwise pin its RTP port.
+        let stale: Vec<Uuid> = self
+            .dialogs
+            .iter()
+            .filter(|(_, d)| {
+                d.released_at
+                    .is_some_and(|released| now.duration_since(released) >= CANCEL_REAP_AFTER)
+            })
+            .map(|(uuid, _)| *uuid)
+            .collect();
+        for uuid in stale {
+            tracing::info!("AsteriskEntity: reaping cancelled dialog uuid={} with no final response", uuid);
+            self.drop_dialog(uuid);
+        }
+        self.invite_rate
+            .retain(|_, (seen, _)| now.duration_since(*seen) < Duration::from_secs(120));
+
         if self.asterisk_config.register
             && self
                 .last_register
@@ -1308,6 +1535,9 @@ struct SipDialogSnapshot {
     local_tag: String,
     remote_tag: Option<String>,
     cseq: u32,
+    invite_branch: String,
+    remote_target: Option<String>,
+    peer_addr: Option<SocketAddr>,
 }
 
 impl SipDialogSnapshot {
@@ -1321,14 +1551,19 @@ impl SipDialogSnapshot {
             local_tag: dialog.local_tag.clone(),
             remote_tag: dialog.remote_tag.clone(),
             cseq: dialog.cseq,
+            invite_branch: dialog.invite_branch.clone(),
+            remote_target: dialog.remote_target.clone(),
+            peer_addr: dialog.request_context.as_ref().map(|ctx| ctx.addr),
         }
     }
 }
 
 impl AsteriskEntity {
-    fn build_ack_from_snapshot(&mut self, dialog: &SipDialogSnapshot) -> String {
+    /// `branch`/`cseq` are the caller's business: an ACK to a 2xx is its own transaction and
+    /// gets a fresh branch, while an ACK to a non-2xx final response must repeat the INVITE's
+    /// branch and CSeq number (RFC 3261 §17.1.1.3) or the UAS keeps retransmitting.
+    fn build_ack(&self, dialog: &SipDialogSnapshot, branch: &str, cseq: u32) -> String {
         let request_uri = self.request_uri(&dialog.number);
-        let branch = self.next_branch();
         let to = if let Some(tag) = &dialog.remote_tag {
             format!("<{}>;tag={}", request_uri, tag)
         } else {
@@ -1352,9 +1587,20 @@ impl AsteriskEntity {
             dialog.local_tag,
             to,
             dialog.call_id_header,
-            dialog.cseq,
+            cseq,
             self.contact_uri()
         )
+    }
+
+    /// ACK a final response that ended the INVITE transaction (401/407, 3xx-6xx).
+    fn ack_non_2xx(&mut self, uuid: Uuid, msg: &SipMessage, summary: &str) {
+        let Some(mut snapshot) = self.dialogs.get(&uuid).map(SipDialogSnapshot::from_dialog) else {
+            return;
+        };
+        // The response carries a To tag we never saw before; the ACK has to echo it back.
+        snapshot.remote_tag = Self::parse_to_tag(msg.header("To")).or(snapshot.remote_tag);
+        let ack = self.build_ack(&snapshot, &snapshot.invite_branch, snapshot.cseq);
+        self.send_sip(ack, summary.to_string());
     }
 }
 
@@ -1408,5 +1654,62 @@ impl TetraEntityTrait for AsteriskEntity {
         self.poll_sip(queue);
         self.poll_rtp(queue);
         self.refresh_status();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn params(cancel: bool) -> TeardownParams<'static> {
+        TeardownParams {
+            cancel,
+            invite_uri: "sip:1001@pbx.local",
+            remote_target: Some("sip:1001@10.0.0.9:5060"),
+            via_host: "10.0.0.2",
+            via_port: 5062,
+            invite_branch: "z9hG4bKflow00000001",
+            fresh_branch: "z9hG4bKflow00000009",
+            from_uri: "sip:flowstation@pbx.local",
+            local_tag: "flowabcd",
+            remote_tag: Some("as1234"),
+            call_id: "flow-uuid@10.0.0.2",
+            invite_cseq: 2,
+            contact: "sip:flowstation@10.0.0.2:5062",
+        }
+    }
+
+    #[test]
+    fn cancel_stays_inside_the_invite_transaction() {
+        let request = build_teardown_request(&params(true));
+        assert!(request.starts_with("CANCEL sip:1001@pbx.local SIP/2.0\r\n"), "{}", request);
+        assert!(request.contains("branch=z9hG4bKflow00000001;"), "{}", request);
+        assert!(request.contains("\r\nCSeq: 2 CANCEL\r\n"), "{}", request);
+        // RFC 3261 §9.1: To is copied from the INVITE, which went out untagged.
+        assert!(request.contains("\r\nTo: <sip:1001@pbx.local>\r\n"), "{}", request);
+        assert!(!request.contains("Contact:"), "{}", request);
+    }
+
+    #[test]
+    fn bye_opens_a_new_transaction_towards_the_remote_target() {
+        let request = build_teardown_request(&params(false));
+        assert!(request.starts_with("BYE sip:1001@10.0.0.9:5060 SIP/2.0\r\n"), "{}", request);
+        assert!(request.contains("branch=z9hG4bKflow00000009;"), "{}", request);
+        assert!(request.contains("\r\nCSeq: 3 BYE\r\n"), "{}", request);
+        assert!(request.contains("\r\nFrom: <sip:flowstation@pbx.local>;tag=flowabcd\r\n"), "{}", request);
+        assert!(request.contains("\r\nTo: <sip:1001@pbx.local>;tag=as1234\r\n"), "{}", request);
+    }
+
+    #[test]
+    fn contact_uri_is_unwrapped_from_angle_brackets() {
+        assert_eq!(
+            AsteriskEntity::parse_contact_uri(Some("<sip:1001@10.0.0.9:5060>;expires=60")).as_deref(),
+            Some("sip:1001@10.0.0.9:5060")
+        );
+        assert_eq!(
+            AsteriskEntity::parse_contact_uri(Some("sip:1001@10.0.0.9;transport=udp")).as_deref(),
+            Some("sip:1001@10.0.0.9")
+        );
+        assert_eq!(AsteriskEntity::parse_contact_uri(Some("*")), None);
     }
 }

--- a/crates/tetra-entities/src/net_brew/entity.rs
+++ b/crates/tetra-entities/src/net_brew/entity.rs
@@ -7,7 +7,7 @@ use std::collections::{HashMap, HashSet};
 use std::thread;
 use std::time::{Duration, Instant};
 
-use crossbeam_channel::{Receiver, Sender, unbounded};
+use crossbeam_channel::{Receiver, Sender, bounded, unbounded};
 use tetra_saps::control::enums::sds_user_data::SdsUserData;
 use tetra_saps::control::sds::CmceSdsData;
 use uuid::Uuid;
@@ -25,10 +25,31 @@ use tetra_saps::{
     tmd::TmdCircuitDataReq,
 };
 
-use super::worker::{BrewCommand, BrewEvent, BrewWorker};
+use super::worker::{BREW_EVENT_CHANNEL_CAPACITY, BrewCommand, BrewEvent, BrewWorker};
 
 /// Hangtime before releasing group call circuit to allow reuse without re-signaling.
 const GROUP_CALL_HANGTIME_DEFAULT_SECS: u64 = 5;
+
+/// Upper bound on worker events handled in a single TDMA tick.
+///
+/// Everything here runs on the one entity thread with a hard tick budget: a core that
+/// streams faster than we consume must never be able to monopolise a tick (the watchdog
+/// restarts the cell on a core stall). Leftover events stay queued for the next tick —
+/// ~70 ticks/s means this is still ~4500 events/s, far above any legitimate load.
+pub(crate) const MAX_EVENTS_PER_TICK: usize = 64;
+
+/// Maximum concurrent inbound (Brew-originated) calls we will track.
+///
+/// Each one holds a CMCE circuit and a jitter buffer; without a cap a core sending
+/// GROUP_TX with ever-fresh UUIDs would leak timeslots until the cell has none left.
+const MAX_INBOUND_ACTIVE_CALLS: usize = 8;
+
+/// Release an inbound call whose media/keepalive has been silent this long.
+///
+/// GROUP_IDLE is the normal way a call ends, but a buggy or hostile core can simply stop
+/// talking — the entry (and the CMCE circuit behind it) would then live forever. Mirrors
+/// the 30s stale `pending_sds` reaper in the worker.
+const INBOUND_CALL_IDLE_TIMEOUT: Duration = Duration::from_secs(30);
 
 // ─── Active call tracking ─────────────────────────────────────────
 
@@ -53,6 +74,9 @@ struct ActiveCall {
     frame_count: u64,
     /// Last downlink TDMA time at which we told CMCE this call still had network media.
     last_media_activity_signal: Option<TdmaTime>,
+    /// Wall clock of the last GROUP_TX / voice frame seen for this call — drives the
+    /// inactivity reaper so a call the core never idles cannot leak its CMCE circuit.
+    last_network_activity: Instant,
 }
 
 /// Group call in hangtime with circuit still allocated.
@@ -167,8 +191,11 @@ impl BrewEntity {
     /// The transport is moved into a worker thread. Any [`NetworkTransport`]
     /// implementation can be used (WebSocket, QUIC, TCP, …).
     pub fn new<T: NetworkTransport + 'static>(config: SharedConfig, transport: T) -> Self {
-        // Create channels
-        let (event_sender, event_receiver) = unbounded::<BrewEvent>();
+        // Create channels. The worker→entity direction is BOUNDED (see
+        // BREW_EVENT_CHANNEL_CAPACITY): it is fed by the remote core, so it is the one an
+        // attacker controls. The entity→worker direction is driven by our own tick, so it
+        // is naturally rate limited and stays unbounded.
+        let (event_sender, event_receiver) = bounded::<BrewEvent>(BREW_EVENT_CHANNEL_CAPACITY);
         let (command_sender, command_receiver) = unbounded::<BrewCommand>();
 
         // Spawn worker thread with the provided transport
@@ -212,9 +239,12 @@ impl BrewEntity {
         self.telemetry_sink = Some(sink);
     }
 
-    /// Process all pending events from the worker thread
+    /// Process pending events from the worker thread, at most MAX_EVENTS_PER_TICK of them.
     fn process_events(&mut self, queue: &mut MessageQueue) {
-        while let Ok(event) = self.event_receiver.try_recv() {
+        let mut processed = 0usize;
+        while processed < MAX_EVENTS_PER_TICK {
+            let Ok(event) = self.event_receiver.try_recv() else { break };
+            processed += 1;
             match event {
                 BrewEvent::Connected { server_version } => {
                     tracing::debug!("BrewEntity: connected to TetraPack server (Brew v{})", server_version);
@@ -468,6 +498,50 @@ impl BrewEntity {
                 }
             }
         }
+
+        if processed == MAX_EVENTS_PER_TICK {
+            tracing::trace!("BrewEntity: hit the per-tick event cap, {} left for the next tick", processed);
+        }
+    }
+
+    /// Release inbound calls that have gone silent (no GROUP_TX/voice within the window).
+    ///
+    /// Without this a core that starts calls and never sends GROUP_IDLE — buggy, or hostile
+    /// with a fresh UUID per frame — leaks an `active_calls`/`dl_jitter` entry and the CMCE
+    /// timeslot behind it for every one of them.
+    fn reap_idle_calls(&mut self, queue: &mut MessageQueue) {
+        let stale: Vec<(Uuid, bool)> = self
+            .active_calls
+            .iter()
+            .filter(|(_, call)| call.last_network_activity.elapsed() >= INBOUND_CALL_IDLE_TIMEOUT)
+            .map(|(uuid, call)| (*uuid, call.dest_gssi == 0))
+            .collect();
+
+        for (uuid, is_circuit) in stale {
+            tracing::warn!(
+                "BrewEntity: reaping inbound call uuid={} — no network media for {}s",
+                uuid,
+                INBOUND_CALL_IDLE_TIMEOUT.as_secs()
+            );
+            if is_circuit {
+                // Individual/circuit call (registered by NetworkCircuitMediaReady, gssi 0):
+                // release it the same way an inbound CALL_RELEASE would.
+                queue.push_back(SapMsg {
+                    sap: Sap::Control,
+                    src: TetraEntity::Brew,
+                    dest: TetraEntity::Cmce,
+                    msg: SapMsgInner::CmceCallControl(CallControl::NetworkCircuitRelease { brew_uuid: uuid, cause: 0 }),
+                });
+                if self.connected {
+                    let _ = self.command_sender.send(BrewCommand::SendCallRelease { uuid, cause: 0 });
+                }
+                self.drop_network_circuit(uuid);
+            } else {
+                // Group call: take exactly the GROUP_IDLE path we never received, so the
+                // circuit still gets its normal hangtime reuse window.
+                self.handle_group_call_end(queue, uuid, 0);
+            }
+        }
     }
 
     fn queue_external_subscriber_update(
@@ -684,6 +758,8 @@ impl BrewEntity {
     fn handle_group_call_start(&mut self, queue: &mut MessageQueue, uuid: Uuid, source_issi: u32, dest_gssi: u32, priority: u8) {
         // Check if this call is already active (speaker change or repeated GROUP_TX)
         if let Some(call) = self.active_calls.get_mut(&uuid) {
+            // A repeated GROUP_TX is also a keepalive — it must hold off the idle reaper.
+            call.last_network_activity = Instant::now();
             // Only notify CMCE if the speaker actually changed
             if call.source_issi != source_issi {
                 tracing::info!(
@@ -727,6 +803,20 @@ impl BrewEntity {
             return;
         }
 
+        // Admission control: every tracked call pins a CMCE circuit and a jitter buffer, so a
+        // core that opens calls with ever-fresh UUIDs must not be able to exhaust them. Reuse
+        // of a hanging circuit is checked first below — this only gates genuinely new calls.
+        if !self.hanging_calls.contains_key(&dest_gssi) && self.active_calls.len() >= MAX_INBOUND_ACTIVE_CALLS {
+            tracing::warn!(
+                "BrewEntity: refusing GROUP_TX uuid={} gssi={} — {} inbound calls already active (cap {})",
+                uuid,
+                dest_gssi,
+                self.active_calls.len(),
+                MAX_INBOUND_ACTIVE_CALLS
+            );
+            return;
+        }
+
         // Check if there's a hanging call we can reuse
         if let Some(hanging) = self.hanging_calls.remove(&dest_gssi) {
             tracing::info!(
@@ -752,6 +842,7 @@ impl BrewEntity {
                 dest_gssi,
                 frame_count: hanging.frame_count,
                 last_media_activity_signal: None,
+                last_network_activity: Instant::now(),
             };
             self.active_calls.insert(uuid, call);
             self.dl_jitter
@@ -792,6 +883,7 @@ impl BrewEntity {
             dest_gssi,
             frame_count: 0,
             last_media_activity_signal: None,
+            last_network_activity: Instant::now(),
         };
         self.active_calls.insert(uuid, call);
         self.dl_jitter
@@ -910,6 +1002,7 @@ impl BrewEntity {
         };
 
         call.frame_count += 1;
+        call.last_network_activity = Instant::now();
         let frame_count = call.frame_count;
         const NETWORK_CALL_ACTIVITY_REFRESH_TS: i32 = 72; // ~1 second
         let should_refresh_activity = call.dest_gssi != 0
@@ -1195,6 +1288,8 @@ impl TetraEntityTrait for BrewEntity {
         self.drain_jitter_playout(queue);
         // Expire hanging calls that have exceeded hangtime
         self.expire_hanging_calls(queue);
+        // Release inbound calls the core stopped feeding without ever sending GROUP_IDLE
+        self.reap_idle_calls(queue);
     }
 
     fn rx_prim(&mut self, queue: &mut MessageQueue, message: SapMsg) {
@@ -1354,6 +1449,7 @@ impl TetraEntityTrait for BrewEntity {
                     dest_gssi: 0,
                     frame_count: 0,
                     last_media_activity_signal: None,
+                    last_network_activity: Instant::now(),
                 });
                 self.dl_jitter
                     .entry(brew_uuid)

--- a/crates/tetra-entities/src/net_brew/worker.rs
+++ b/crates/tetra-entities/src/net_brew/worker.rs
@@ -19,6 +19,24 @@ use super::protocol::*;
 
 // ─── Events passed from worker to entity ─────────────────────────
 
+/// Capacity of the worker→entity event channel.
+///
+/// The channel MUST stay bounded: the entity drains it from the single TDMA thread, so an
+/// unbounded queue lets a remote core (or an on-path attacker when `tls = false`) stream
+/// frames faster than one tick can drain and grow it until the box runs out of memory.
+/// Sized for roughly a second of worst-case traffic — the entity drains MAX_EVENTS_PER_TICK
+/// events per timeslot (see `entity.rs`), so it empties far faster than that.
+pub const BREW_EVENT_CHANNEL_CAPACITY: usize = 512;
+
+/// How long a *signalling* event may wait for room on a full event channel before being
+/// dropped. Blocking here is deliberate: it stops us reading the socket, which is what
+/// applies backpressure to the peer. Bounded so the worker still reaches its heartbeat.
+const EVENT_SEND_BACKPRESSURE: Duration = Duration::from_millis(100);
+
+/// Minimum spacing between "voice dropped" warnings — the condition is per-frame, the log
+/// must not become the next flood.
+const VOICE_DROP_WARN_INTERVAL: Duration = Duration::from_secs(5);
+
 /// Events the Brew worker sends to the BrewEntity
 #[derive(Debug)]
 pub enum BrewEvent {
@@ -187,6 +205,18 @@ pub enum BrewCommand {
     Disconnect,
 }
 
+/// Offer one event to the bounded entity channel. Returns the event back on failure.
+///
+/// Voice never waits: it is lossy by nature and a stalled entity must not stall the socket
+/// reader. Signalling waits up to `backpressure` for room — that pause is the point, it stops
+/// us draining the socket and lets TCP push back on the peer instead of us buffering for it.
+fn offer_event(sender: &Sender<BrewEvent>, event: BrewEvent, backpressure: Duration) -> Result<(), BrewEvent> {
+    if matches!(event, BrewEvent::VoiceFrame { .. }) {
+        return sender.try_send(event).map_err(|e| e.into_inner());
+    }
+    sender.send_timeout(event, backpressure).map_err(|e| e.into_inner())
+}
+
 // ─── Worker ───────────────────────────────────────────────────────
 
 /// Pending SDS header data (from CALL_STATE_SHORT_TRANSFER), awaiting matching FRAME_TYPE_SDS_TRANSFER
@@ -214,6 +244,10 @@ pub struct BrewWorker<T: NetworkTransport> {
     subscriber_groups: HashMap<u32, HashSet<u32>>,
     /// Pending SDS transfers keyed by UUID, awaiting matching SDS_TRANSFER frame
     pending_sds: HashMap<Uuid, PendingSds>,
+    /// Voice frames dropped because the entity channel was full, since the last warning
+    voice_dropped: u64,
+    /// When we last warned about dropped voice
+    last_voice_drop_warn: Option<Instant>,
 }
 
 impl<T: NetworkTransport> BrewWorker<T> {
@@ -227,6 +261,36 @@ impl<T: NetworkTransport> BrewWorker<T> {
             command_receiver,
             subscriber_groups: HashMap::new(),
             pending_sds: HashMap::new(),
+            voice_dropped: 0,
+            last_voice_drop_warn: None,
+        }
+    }
+
+    /// Hand an event to the entity over the bounded channel.
+    ///
+    /// Voice is lossy — a dropped ACELP frame is a click the jitter buffer hides — so it is
+    /// discarded immediately when the entity is behind. Signalling is not lossy: it waits a
+    /// short, bounded moment for room (which stops us draining the socket and pushes back on
+    /// the peer) and is only dropped if the entity is still stuck after that.
+    fn send_event(&mut self, event: BrewEvent) {
+        let lossy = matches!(event, BrewEvent::VoiceFrame { .. });
+        if offer_event(&self.event_sender, event, EVENT_SEND_BACKPRESSURE).is_err() {
+            if lossy {
+                self.voice_dropped += 1;
+                let due = self
+                    .last_voice_drop_warn
+                    .is_none_or(|last| last.elapsed() >= VOICE_DROP_WARN_INTERVAL);
+                if due {
+                    tracing::warn!(
+                        "BrewWorker: entity event channel full — dropped {} voice frames (core sending faster than the TDMA tick drains)",
+                        self.voice_dropped
+                    );
+                    self.voice_dropped = 0;
+                    self.last_voice_drop_warn = Some(Instant::now());
+                }
+            } else {
+                tracing::error!("BrewWorker: entity event channel still full after backpressure — dropped a signalling event");
+            }
         }
     }
 
@@ -247,9 +311,8 @@ impl<T: NetworkTransport> BrewWorker<T> {
             match self.transport.connect() {
                 Ok(()) => {
                     tracing::info!("BrewWorker: transport connected");
-                    let _ = self.event_sender.send(BrewEvent::Connected {
-                        server_version: self.transport.server_brew_version(),
-                    });
+                    let server_version = self.transport.server_brew_version();
+                    self.send_event(BrewEvent::Connected { server_version });
                 }
                 Err(e) => {
                     tracing::error!(
@@ -257,7 +320,7 @@ impl<T: NetworkTransport> BrewWorker<T> {
                         e,
                         self.brew_config.reconnect_delay
                     );
-                    let _ = self.event_sender.send(BrewEvent::Disconnected(e.to_string()));
+                    self.send_event(BrewEvent::Disconnected(e.to_string()));
                     std::thread::sleep(self.brew_config.reconnect_delay);
                     continue;
                 }
@@ -275,7 +338,7 @@ impl<T: NetworkTransport> BrewWorker<T> {
                         e,
                         self.brew_config.reconnect_delay
                     );
-                    let _ = self.event_sender.send(BrewEvent::Disconnected(e));
+                    self.send_event(BrewEvent::Disconnected(e));
                     std::thread::sleep(self.brew_config.reconnect_delay);
                 }
             }
@@ -572,7 +635,7 @@ impl<T: NetworkTransport> BrewWorker<T> {
                 BrewMessage::Subscriber(sub) => {
                     tracing::debug!("BrewWorker: subscriber event type={}", sub.msg_type);
                     // TODO FIXME we could check whether this call is indeed a brew ssi here
-                    let _ = self.event_sender.send(BrewEvent::SubscriberEvent {
+                    self.send_event(BrewEvent::SubscriberEvent {
                         msg_type: sub.msg_type,
                         issi: sub.number,
                         groups: sub.groups,
@@ -581,7 +644,7 @@ impl<T: NetworkTransport> BrewWorker<T> {
                 BrewMessage::Error(err) => {
                     tracing::warn!("BrewWorker: server error type={}: {} bytes", err.error_type, err.data.len());
                     // TODO FIXME we could check whether this call is indeed a brew ssi here
-                    let _ = self.event_sender.send(BrewEvent::ServerError {
+                    self.send_event(BrewEvent::ServerError {
                         error_type: err.error_type,
                         data: err.data,
                     });
@@ -612,7 +675,7 @@ impl<T: NetworkTransport> BrewWorker<T> {
                     );
                     // Detect server version from mnemonic presence (v1 includes 34-byte mnemonic)
                     if gt.mnemonic.is_some() {
-                        let _ = self.event_sender.send(BrewEvent::VersionDetected { version: 1 });
+                        self.send_event(BrewEvent::VersionDetected { version: 1 });
                     }
                     // Inbound admission (FH-FEAT-032 R3): a Brew-originated group call must NOT be
                     // gated by the outbound-only `whitelisted_ssis`; only `local_ssi_ranges` reject it.
@@ -620,7 +683,7 @@ impl<T: NetworkTransport> BrewWorker<T> {
                         tracing::warn!("BrewWorker: dropping GROUP_TX to inactive/local-only GSSI {}", gt.destination);
                         return;
                     };
-                    let _ = self.event_sender.send(BrewEvent::GroupCallStart {
+                    self.send_event(BrewEvent::GroupCallStart {
                         uuid: cc.identifier,
                         source_issi: gt.source,
                         dest_gssi: gt.destination,
@@ -633,7 +696,7 @@ impl<T: NetworkTransport> BrewWorker<T> {
                 let cause = if let BrewCallPayload::Cause(c) = cc.payload { c } else { 0 };
                 tracing::info!("BrewWorker: GROUP_IDLE uuid={} cause={}", cc.identifier, cause);
                 // TODO FIXME we could check whether this call is indeed a brew call here
-                let _ = self.event_sender.send(BrewEvent::GroupCallEnd {
+                self.send_event(BrewEvent::GroupCallEnd {
                     uuid: cc.identifier,
                     cause,
                 });
@@ -649,24 +712,24 @@ impl<T: NetworkTransport> BrewWorker<T> {
                         call.number,
                         call.duplex
                     );
-                    let _ = self.event_sender.send(BrewEvent::CircuitSetupRequest { uuid: cc.identifier, call });
+                    self.send_event(BrewEvent::CircuitSetupRequest { uuid: cc.identifier, call });
                 }
             }
             CALL_STATE_SETUP_ACCEPT => {
                 tracing::info!("BrewWorker: SETUP_ACCEPT uuid={}", cc.identifier);
-                let _ = self.event_sender.send(BrewEvent::CircuitSetupAccept { uuid: cc.identifier });
+                self.send_event(BrewEvent::CircuitSetupAccept { uuid: cc.identifier });
             }
             CALL_STATE_SETUP_REJECT => {
                 let cause = if let BrewCallPayload::Cause(c) = cc.payload { c } else { 0 };
                 tracing::info!("BrewWorker: SETUP_REJECT uuid={} cause={}", cc.identifier, cause);
-                let _ = self.event_sender.send(BrewEvent::CircuitSetupReject {
+                self.send_event(BrewEvent::CircuitSetupReject {
                     uuid: cc.identifier,
                     cause,
                 });
             }
             CALL_STATE_CALL_ALERT => {
                 tracing::info!("BrewWorker: CALL_ALERT uuid={}", cc.identifier);
-                let _ = self.event_sender.send(BrewEvent::CircuitCallAlert { uuid: cc.identifier });
+                self.send_event(BrewEvent::CircuitCallAlert { uuid: cc.identifier });
             }
             CALL_STATE_CONNECT_REQUEST => {
                 if let BrewCallPayload::CircularCall(call) = cc.payload {
@@ -677,9 +740,7 @@ impl<T: NetworkTransport> BrewWorker<T> {
                         call.destination,
                         call.duplex
                     );
-                    let _ = self
-                        .event_sender
-                        .send(BrewEvent::CircuitConnectRequest { uuid: cc.identifier, call });
+                    self.send_event(BrewEvent::CircuitConnectRequest { uuid: cc.identifier, call });
                 }
             }
             CALL_STATE_CONNECT_CONFIRM => {
@@ -694,7 +755,7 @@ impl<T: NetworkTransport> BrewWorker<T> {
                     grant,
                     permission
                 );
-                let _ = self.event_sender.send(BrewEvent::CircuitConnectConfirm {
+                self.send_event(BrewEvent::CircuitConnectConfirm {
                     uuid: cc.identifier,
                     grant,
                     permission,
@@ -712,7 +773,7 @@ impl<T: NetworkTransport> BrewWorker<T> {
                     grant,
                     permission
                 );
-                let _ = self.event_sender.send(BrewEvent::CircuitSimplexGranted {
+                self.send_event(BrewEvent::CircuitSimplexGranted {
                     uuid: cc.identifier,
                     grant,
                     permission,
@@ -730,7 +791,7 @@ impl<T: NetworkTransport> BrewWorker<T> {
                     grant,
                     permission
                 );
-                let _ = self.event_sender.send(BrewEvent::CircuitSimplexIdle {
+                self.send_event(BrewEvent::CircuitSimplexIdle {
                     uuid: cc.identifier,
                     grant,
                     permission,
@@ -740,11 +801,11 @@ impl<T: NetworkTransport> BrewWorker<T> {
                 let cause = if let BrewCallPayload::Cause(c) = cc.payload { c } else { 0 };
                 tracing::info!("BrewWorker: CALL_RELEASE uuid={} cause={}", cc.identifier, cause);
                 // Send both events — entity will handle whichever is relevant
-                let _ = self.event_sender.send(BrewEvent::GroupCallEnd {
+                self.send_event(BrewEvent::GroupCallEnd {
                     uuid: cc.identifier,
                     cause,
                 });
-                let _ = self.event_sender.send(BrewEvent::CircuitCallRelease {
+                self.send_event(BrewEvent::CircuitCallRelease {
                     uuid: cc.identifier,
                     cause,
                 });
@@ -780,7 +841,7 @@ impl<T: NetworkTransport> BrewWorker<T> {
             FRAME_TYPE_TRAFFIC_CHANNEL => {
                 // Forward ACELP voice frame to entity
                 // TODO FIXME we could check whether this call is indeed a brew call here
-                let _ = self.event_sender.send(BrewEvent::VoiceFrame {
+                self.send_event(BrewEvent::VoiceFrame {
                     uuid: frame.identifier,
                     length_bits: frame.length_bits,
                     data: frame.data,
@@ -824,7 +885,7 @@ impl<T: NetworkTransport> BrewWorker<T> {
                         pending.destination,
                         frame.data.len()
                     );
-                    let _ = self.event_sender.send(BrewEvent::SdsTransfer {
+                    self.send_event(BrewEvent::SdsTransfer {
                         uuid: frame.identifier,
                         source: pending.source,
                         destination: pending.destination,
@@ -842,7 +903,7 @@ impl<T: NetworkTransport> BrewWorker<T> {
             FRAME_TYPE_SDS_REPORT => {
                 let status = if frame.data.is_empty() { 0 } else { frame.data[0] };
                 tracing::debug!("BrewWorker: SDS_REPORT uuid={} status={}", frame.identifier, status);
-                let _ = self.event_sender.send(BrewEvent::SdsReport {
+                self.send_event(BrewEvent::SdsReport {
                     uuid: frame.identifier,
                     status,
                 });
@@ -851,5 +912,46 @@ impl<T: NetworkTransport> BrewWorker<T> {
                 tracing::debug!("BrewWorker: unhandled frame type {} uuid={}", ft, frame.identifier);
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crossbeam_channel::bounded;
+
+    fn voice() -> BrewEvent {
+        BrewEvent::VoiceFrame {
+            uuid: Uuid::nil(),
+            length_bits: 288,
+            data: vec![0u8; 36],
+        }
+    }
+
+    fn signalling() -> BrewEvent {
+        BrewEvent::GroupCallEnd {
+            uuid: Uuid::nil(),
+            cause: 0,
+        }
+    }
+
+    #[test]
+    fn full_channel_drops_voice_instead_of_growing() {
+        let (tx, rx) = bounded::<BrewEvent>(2);
+        assert!(offer_event(&tx, voice(), Duration::ZERO).is_ok());
+        assert!(offer_event(&tx, voice(), Duration::ZERO).is_ok());
+
+        // Third frame has nowhere to go — it is dropped and the queue does NOT grow.
+        assert!(offer_event(&tx, voice(), Duration::ZERO).is_err());
+        assert_eq!(rx.len(), 2);
+    }
+
+    #[test]
+    fn signalling_is_delivered_while_there_is_room() {
+        let (tx, rx) = bounded::<BrewEvent>(1);
+        assert!(offer_event(&tx, signalling(), Duration::ZERO).is_ok());
+        // Full: with no backpressure window it is reported as undelivered rather than queued.
+        assert!(offer_event(&tx, signalling(), Duration::ZERO).is_err());
+        assert_eq!(rx.len(), 1);
     }
 }

--- a/crates/tetra-entities/src/net_dapnet/mod.rs
+++ b/crates/tetra-entities/src/net_dapnet/mod.rs
@@ -3,9 +3,17 @@
 //! The receiver uses the DAPNET RWTH core transmitter TCP protocol. It does not transmit POCSAG;
 //! it only consumes incoming calls from the core feed, acknowledges them, normalizes the message,
 //! and forwards it through existing FlowStation paths.
+//!
+//! SECURITY — the RWTH core transmitter protocol is **plaintext TCP with no transport security**:
+//! `rwth_core_authkey` goes out in the clear on login and every inbound message is unauthenticated
+//! and MITM-able. The text it carries ends up in over-the-air SDS / Call-Out PDUs, so it is treated
+//! as hostile input here: lines are length-capped (`RWTH_LINE_MAX_BYTES`) and message text is
+//! stripped of control characters and truncated (`DAPNET_TEXT_MAX_CHARS`) before it can reach a
+//! PDU builder. Enabling `rwth_core_enabled` is an explicit opt-in to that exposure; the worker
+//! logs a warning on every connect so it cannot be enabled unnoticed.
 
 use std::collections::{HashSet, VecDeque};
-use std::io::{BufRead, BufReader, Write};
+use std::io::{BufRead, BufReader, Read, Write};
 use std::net::TcpStream;
 use std::thread;
 use std::time::Duration;
@@ -21,6 +29,13 @@ type CmdSender = crossbeam_channel::Sender<ControlCommand>;
 
 const TCP_READ_TIMEOUT: Duration = Duration::from_secs(30);
 const CALLOUT_TEXT_MAX_CHARS: usize = 80;
+/// Hard cap on one RWTH core protocol line. The feed is unauthenticated plaintext, so an
+/// unbounded `read_line` is an OOM handle for a hostile or MITM'd upstream. Real lines are a
+/// couple of hundred bytes; anything past this is a protocol violation and drops the connection.
+const RWTH_LINE_MAX_BYTES: usize = 4096;
+/// Hard cap on message text kept from the feed. It is forwarded into over-the-air SDS and
+/// Call-Out PDUs, so it is bounded here, once, before any of those paths can see it.
+const DAPNET_TEXT_MAX_CHARS: usize = 200;
 
 #[derive(Debug, Clone)]
 struct DapnetMessage {
@@ -174,6 +189,13 @@ impl DapnetWorker {
 
         let addr = format!("{}:{}", host, dapnet.rwth_core_port);
         tracing::info!("DAPNET: connecting to RWTH core {} as {}", addr, callsign);
+        // The RWTH core protocol has no TLS mode: the authkey and every message travel in the
+        // clear and the peer is unauthenticated. Say so on every connect — this feed can inject
+        // paging text into over-the-air SDS.
+        tracing::warn!(
+            "DAPNET: RWTH core link to {} is plaintext and unauthenticated — authkey is sent in the clear and inbound text reaches the air interface",
+            addr
+        );
         let mut stream = TcpStream::connect(&addr).map_err(|e| format!("connect {} failed: {}", addr, e))?;
         self.refresh_status(dapnet, "connected", None, None);
         if let Err(err) = stream.set_read_timeout(Some(TCP_READ_TIMEOUT)) {
@@ -187,16 +209,28 @@ impl DapnetWorker {
         let mut reader = BufReader::new(reader_stream);
         let mut logged_in = false;
 
+        // `line` lives across iterations on purpose: the read timeout can fire mid-line, and a
+        // fresh buffer each pass would silently drop the bytes already consumed. The remaining
+        // budget shrinks as it fills, so a peer that never sends a newline is cut off instead of
+        // being buffered without limit.
+        let mut line = String::new();
         loop {
-            let mut line = String::new();
-            match reader.read_line(&mut line) {
+            let remaining = RWTH_LINE_MAX_BYTES.saturating_sub(line.len());
+            if remaining == 0 {
+                return Err(format!("RWTH core line exceeded {} bytes", RWTH_LINE_MAX_BYTES));
+            }
+            match reader.by_ref().take(remaining as u64).read_line(&mut line) {
                 Ok(0) => return Err("RWTH core closed connection".to_string()),
                 Ok(_) => {
-                    let line = line.trim_end_matches(|c| c == '\r' || c == '\n');
-                    if line.is_empty() {
+                    if !line.ends_with('\n') {
+                        continue; // partial line — keep buffering (or hit the cap above)
+                    }
+                    let complete = line.trim_end_matches(|c| c == '\r' || c == '\n').to_string();
+                    line.clear();
+                    if complete.is_empty() {
                         continue;
                     }
-                    match self.handle_rwth_line(dapnet, &mut stream, line, &mut logged_in) {
+                    match self.handle_rwth_line(dapnet, &mut stream, &complete, &mut logged_in) {
                         Ok(()) => {}
                         Err(err) => return Err(err),
                     }
@@ -553,7 +587,13 @@ fn parse_rwth_message(line: &str) -> Result<DapnetMessage, String> {
     let speed = parts[1].parse::<u8>().ok();
     let ric = u32::from_str_radix(parts[2], 16).ok();
     let function = parts[3].parse::<u8>().ok();
-    let text = decode_dapnet_text(&normalize_text(parts[4]));
+    // This text is about to be forwarded verbatim into over-the-air SDS / Call-Out PDUs from an
+    // unauthenticated plaintext feed: normalize_text drops control characters, and the cap keeps
+    // an oversized paging message from reaching a PDU builder at all.
+    let (text, truncated) = truncate_chars(&decode_dapnet_text(&normalize_text(parts[4])), DAPNET_TEXT_MAX_CHARS);
+    if truncated {
+        tracing::warn!("DAPNET: message text truncated to {} chars", DAPNET_TEXT_MAX_CHARS);
+    }
     if text.is_empty() {
         return Err("empty message text".to_string());
     }
@@ -734,8 +774,8 @@ fn sanitize_log_line(line: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::{
-        dapnet_version, decode_dapnet_text, extract_callsign, format_plain_message, parse_rwth_message, prefixed_text,
-        resolve_sds_destination, ric_allowed, rwth_ack_line, truncate_chars,
+        DAPNET_TEXT_MAX_CHARS, dapnet_version, decode_dapnet_text, extract_callsign, format_plain_message, parse_rwth_message,
+        prefixed_text, resolve_sds_destination, ric_allowed, rwth_ack_line, truncate_chars,
     };
     use tetra_config::bluestation::CfgDapnet;
 
@@ -791,6 +831,13 @@ mod tests {
             "5357.0 EA5FIV von DL4MFF um 1933z"
         );
         assert_eq!(decode_dapnet_text("XTIME=1702220626"), "XTIME=1702220626");
+    }
+
+    #[test]
+    fn oversized_message_text_is_bounded_before_it_can_reach_the_air() {
+        let flood = "A".repeat(4000);
+        let msg = parse_rwth_message(&format!("#00 6:1:3EC:3:{flood}")).unwrap();
+        assert_eq!(msg.text.chars().count(), DAPNET_TEXT_MAX_CHARS);
     }
 
     #[test]

--- a/crates/tetra-entities/src/net_dashboard/server.rs
+++ b/crates/tetra-entities/src/net_dashboard/server.rs
@@ -30,6 +30,45 @@ const WS_CLIENT_QUEUE: usize = 256;
 /// thread count without bound. New upgrades past this are refused.
 const WS_MAX_CLIENTS: usize = 64;
 
+/// A TETRA SSI is a 24-bit identity. The PDU serializers write it with `write_bits(ssi, 24)`
+/// (MAC-RESOURCE, D-SDS-DATA) whose range assertion aborts the calling thread on a wider value —
+/// and every entity shares one un-isolated stack thread, so a single crafted dashboard request
+/// would take the whole cell down, then take it down again on every retry. The DGNA path already
+/// funnels through the same guard in MM; the dashboard is the highest-privilege plane, so it must
+/// reject at its own boundary too rather than trust what reaches the serializer.
+const MAX_TETRA_SSI: u32 = 0xFF_FFFF;
+
+/// True when `n` is a usable TETRA SSI: 24 bits wide, non-zero (0 is the "no identity" sentinel
+/// used across the call/SDS/DGNA paths).
+fn is_valid_ssi(n: u64) -> bool {
+    (1..=MAX_TETRA_SSI as u64).contains(&n)
+}
+
+/// Read `key` from a WS command body as a TETRA SSI. `None` when the field is missing, not a
+/// number, zero, or wider than 24 bits — every one of which the caller must refuse.
+fn json_ssi(v: &serde_json::Value, key: &str) -> Option<u32> {
+    v.get(key).and_then(|x| x.as_u64()).filter(|n| is_valid_ssi(*n)).map(|n| n as u32)
+}
+
+/// Report a refused SSI to the operator. The WS command channel has no per-command reply, so the
+/// log ring — which is broadcast to every connected browser — is where the rejection surfaces.
+fn reject_ws_ssi(state: &DashboardState, cmd: &str, field: &str, raw: Option<&serde_json::Value>) {
+    let raw = raw.map(|r| r.to_string()).unwrap_or_else(|| "missing".to_string());
+    tracing::warn!(
+        "Dashboard: refusing {} — {} {} out of range (must be 1..={})",
+        cmd,
+        field,
+        raw,
+        MAX_TETRA_SSI
+    );
+    if let Ok(mut s) = state.write() {
+        s.push_log(
+            "WARN",
+            format!("{cmd} rejected: {field} {raw} out of range (must be 1..={MAX_TETRA_SSI})"),
+        );
+    }
+}
+
 fn cp1252_byte(ch: char) -> Option<u8> {
     match ch {
         '\u{20AC}' => Some(0x80),
@@ -212,6 +251,93 @@ impl SessionStore {
 }
 
 type SharedSessionStore = Arc<Mutex<SessionStore>>;
+
+/// Failed-login tracking, shared across every dashboard connection.
+///
+/// The previous throttle was a `thread::sleep(500ms)` on the connection that failed — per-connection
+/// and nothing else. An attacker guessing in parallel paid nothing: each guess got its own thread
+/// and its own independent sleep, so throughput scaled with concurrency. A single hit hands over
+/// SDS, kick, DGNA, config, OTA and restart, so a failure has to cost across connections.
+///
+/// Counted per source IP: escalating delay first, then a hard lockout. The map is deliberately
+/// bounded — an attacker rotating source addresses must not be able to grow it without limit, that
+/// would just be a different DoS. Idle entries are pruned on access; if the map is still full the
+/// new address is simply not tracked (it still pays the base delay).
+struct LoginThrottle {
+    entries: HashMap<std::net::IpAddr, FailedLogins>,
+}
+
+struct FailedLogins {
+    count: u32,
+    last: Instant,
+}
+
+/// Consecutive failures tolerated before the address is locked out entirely.
+const LOGIN_LOCKOUT_AFTER: u32 = 5;
+/// First lockout length; doubles per further failure up to `LOGIN_LOCKOUT_MAX`.
+const LOGIN_LOCKOUT_BASE: std::time::Duration = std::time::Duration::from_secs(30);
+const LOGIN_LOCKOUT_MAX: std::time::Duration = std::time::Duration::from_secs(15 * 60);
+/// No failure for this long and the address starts from a clean slate (also the prune horizon —
+/// deliberately longer than `LOGIN_LOCKOUT_MAX` so pruning can never drop an active lockout).
+const LOGIN_FAIL_RESET: std::time::Duration = std::time::Duration::from_secs(30 * 60);
+/// Hard cap on tracked addresses. Sized well above any plausible operator count.
+const LOGIN_MAX_TRACKED_IPS: usize = 1024;
+/// Per-attempt delay ceiling. Each connection is its own thread, so the sleep must stay short
+/// enough that a flood of failures cannot pin threads — the lockout does the real work.
+const LOGIN_DELAY_MAX: std::time::Duration = std::time::Duration::from_secs(5);
+
+impl LoginThrottle {
+    fn new() -> Self {
+        Self { entries: HashMap::new() }
+    }
+
+    /// Lockout window earned by `count` consecutive failures, if any.
+    fn lockout(count: u32) -> Option<std::time::Duration> {
+        let over = count.checked_sub(LOGIN_LOCKOUT_AFTER)?;
+        let factor = 1u32.checked_shl(over.min(16)).unwrap_or(u32::MAX);
+        Some(LOGIN_LOCKOUT_BASE.saturating_mul(factor).min(LOGIN_LOCKOUT_MAX))
+    }
+
+    /// `Some(remaining)` while `ip` is locked out, `None` when it may attempt a login.
+    fn locked_for(&mut self, ip: &std::net::IpAddr) -> Option<std::time::Duration> {
+        self.prune();
+        let entry = self.entries.get(ip)?;
+        let lock = Self::lockout(entry.count)?;
+        let elapsed = entry.last.elapsed();
+        (elapsed < lock).then(|| lock - elapsed)
+    }
+
+    /// Record a failed attempt and return how long this connection should stall before replying.
+    fn record_failure(&mut self, ip: std::net::IpAddr) -> std::time::Duration {
+        self.prune();
+        let has_room = self.entries.len() < LOGIN_MAX_TRACKED_IPS;
+        let count = match self.entries.get_mut(&ip) {
+            Some(e) => {
+                e.count = e.count.saturating_add(1);
+                e.last = Instant::now();
+                e.count
+            }
+            None if has_room => {
+                self.entries.insert(ip, FailedLogins { count: 1, last: Instant::now() });
+                1
+            }
+            // Map full even after pruning — don't grow it; the base delay still applies.
+            None => 1,
+        };
+        LOGIN_DELAY_MAX.min(std::time::Duration::from_millis(500).saturating_mul(count))
+    }
+
+    /// A successful login clears the address' history.
+    fn clear(&mut self, ip: &std::net::IpAddr) {
+        self.entries.remove(ip);
+    }
+
+    fn prune(&mut self) {
+        self.entries.retain(|_, e| e.last.elapsed() < LOGIN_FAIL_RESET);
+    }
+}
+
+type SharedLoginThrottle = Arc<Mutex<LoginThrottle>>;
 
 /// 32 bytes of entropy → 64-char hex string. Uses the OS RNG via `getrandom`-style
 /// `/dev/urandom` read. Falls back to a time+pid mix if /dev/urandom is unavailable —
@@ -627,7 +753,7 @@ fn run_update(update: SharedUpdateState, config_path: String, source_dir_overrid
 
         // Backup config before touching anything.
         let backup_path = format!("{}.bak", config_path);
-        match std::fs::copy(&config_path, &backup_path) {
+        match atomic_copy(&config_path, &backup_path) {
             Ok(_) => log!(update, "Config backed up → {}", backup_path),
             Err(e) => log!(update, "WARNING: config backup failed: {} (continuing)", e),
         }
@@ -722,6 +848,8 @@ pub struct DashboardServer {
     public_overview: bool,
     /// In-memory session store backing the cookie auth.
     sessions: SharedSessionStore,
+    /// Cross-connection failed-login counter backing the brute-force lockout.
+    login_throttle: SharedLoginThrottle,
     /// Last time a ts_voice WS message was broadcast per carrier/timeslot.
     ts_last_broadcast: std::sync::Mutex<HashMap<(u16, u8), std::time::Instant>>,
     /// On-demand RadioID callsign resolver (ISSI → indicativ), cached locally.
@@ -746,6 +874,7 @@ impl DashboardServer {
             auth: None,
             public_overview: false,
             sessions: Arc::new(Mutex::new(SessionStore::new())),
+            login_throttle: Arc::new(Mutex::new(LoginThrottle::new())),
             ts_last_broadcast: std::sync::Mutex::new(HashMap::new()),
             radioid: crate::net_dashboard::radioid::RadioIdCache::new(radioid_path),
         }
@@ -796,6 +925,7 @@ impl DashboardServer {
         let public_overview = self.public_overview;
         let shared_config = self.shared_config.clone();
         let sessions = Arc::clone(&self.sessions);
+        let login_throttle = Arc::clone(&self.login_throttle);
         let radioid = self.radioid.clone();
 
         std::thread::Builder::new()
@@ -836,6 +966,7 @@ impl DashboardServer {
                     let auth = auth.clone();
                     let shared_config = shared_config.clone();
                     let sessions = Arc::clone(&sessions);
+                    let login_throttle = Arc::clone(&login_throttle);
                     let radioid = radioid.clone();
                     std::thread::Builder::new()
                         .name("dashboard-conn".into())
@@ -851,6 +982,7 @@ impl DashboardServer {
                                 auth,
                                 shared_config,
                                 sessions,
+                                login_throttle,
                                 radioid,
                                 public_overview,
                             )
@@ -1486,14 +1618,24 @@ fn parse_basic_auth(headers: &str) -> Option<(String, String)> {
 }
 
 /// Constant-time byte slice comparison to mitigate timing attacks.
-/// Returns true iff a == b in length and content.
-fn timing_safe_eq(a: &[u8], b: &[u8]) -> bool {
-    if a.len() != b.len() {
-        return false;
-    }
-    let mut diff: u8 = 0;
-    for (x, y) in a.iter().zip(b.iter()) {
-        diff |= x ^ y;
+/// Returns true iff `supplied == expected` in length and content.
+///
+/// Bailing out early on a length mismatch — as this used to — leaks the *expected* secret's length:
+/// an attacker times candidates of increasing length and reads off how long the dashboard password
+/// or the TPG2200 ActionURL token is before guessing a single byte of it. Instead we always walk
+/// the supplied input end to end, wrapping around `expected`, and fold the length difference into
+/// the accumulator. The work now depends only on the attacker's own input length, never on the
+/// secret's, and the result is still exact equality.
+fn timing_safe_eq(supplied: &[u8], expected: &[u8]) -> bool {
+    let mut diff: u32 = (supplied.len() ^ expected.len()) as u32;
+    let mut j = 0usize;
+    for x in supplied {
+        let y = expected.get(j).copied().unwrap_or(0);
+        diff |= (*x ^ y) as u32;
+        j += 1;
+        if j >= expected.len() {
+            j = 0;
+        }
     }
     diff == 0
 }
@@ -1588,10 +1730,13 @@ fn handle_connection(
     auth: Option<(String, String)>,
     shared_config: Option<tetra_config::bluestation::SharedConfig>,
     sessions: SharedSessionStore,
+    login_throttle: SharedLoginThrottle,
     radioid: crate::net_dashboard::radioid::RadioIdCache,
     public_overview: bool,
 ) {
     let _ = stream.set_read_timeout(Some(std::time::Duration::from_millis(500)));
+    // Captured before the stream is wrapped in a BufReader — the login throttle keys on it.
+    let peer_ip = stream.peer_addr().ok().map(|a| a.ip());
 
     // ── Read the first 4KB of headers into a buffer, peek first for routing ──
     // We need to both route on the request line AND read the Authorization header,
@@ -1682,6 +1827,26 @@ fn handle_connection(
             let _ = buf.read_exact(&mut body);
             let body_str = String::from_utf8_lossy(&body);
 
+            // Shared lockout, checked before the credentials are even looked at: an attacker
+            // opening N sockets in parallel used to sidestep the throttle entirely, because each
+            // connection only slept on itself.
+            if let Some(ip) = peer_ip {
+                let locked = login_throttle
+                    .lock()
+                    .unwrap_or_else(|e| e.into_inner())
+                    .locked_for(&ip);
+                if let Some(remaining) = locked {
+                    let secs = remaining.as_secs().max(1);
+                    tracing::warn!("Dashboard: login from {} locked out for another {}s", ip, secs);
+                    http_response(
+                        buf.into_inner(),
+                        429,
+                        &format!("Too many failed logins — try again in {}s", secs),
+                    );
+                    return;
+                }
+            }
+
             let (user, pass) = parse_login_body(&body_str);
             let ok = timing_safe_eq(user.as_bytes(), expected_user.as_bytes()) && timing_safe_eq(pass.as_bytes(), expected_pass.as_bytes());
 
@@ -1692,11 +1857,19 @@ fn handle_connection(
                 // the session store itself stays usable.
                 let token = sessions.lock().unwrap_or_else(|e| e.into_inner()).create();
                 tracing::info!("Dashboard: login OK (user: {})", user);
+                if let Some(ip) = peer_ip {
+                    login_throttle.lock().unwrap_or_else(|e| e.into_inner()).clear(&ip);
+                }
                 serve_login_success(buf.into_inner(), &token);
             } else {
                 tracing::warn!("Dashboard: login FAILED (user attempt: {})", user);
-                // Small artificial delay to limit brute-force throughput.
-                std::thread::sleep(std::time::Duration::from_millis(500));
+                // Escalating, cross-connection cost: the delay grows with the failure count for
+                // this source IP, and past LOGIN_LOCKOUT_AFTER the address is locked out above.
+                let delay = match peer_ip {
+                    Some(ip) => login_throttle.lock().unwrap_or_else(|e| e.into_inner()).record_failure(ip),
+                    None => std::time::Duration::from_millis(500),
+                };
+                std::thread::sleep(delay);
                 http_response(buf.into_inner(), 401, "Invalid credentials");
             }
             return;
@@ -1973,13 +2146,15 @@ fn handle_connection(
                 break;
             }
         }
-        let backup_path = format!("{}.bak", config_path);
-        match std::fs::copy(&backup_path, &config_path) {
-            Ok(_) => {
+        match restore_config_from_backup(&config_path) {
+            Ok(()) => {
                 tracing::info!("Dashboard: config restored from backup");
                 http_response(buf.into_inner(), 200, "OK")
             }
-            Err(e) => http_response(buf.into_inner(), 500, &e.to_string()),
+            Err((code, msg)) => {
+                tracing::warn!("Dashboard: config restore refused: {}", msg);
+                http_response(buf.into_inner(), code, &msg)
+            }
         }
     } else if req_line.contains("POST /api/config") {
         let mut buf = BufReader::new(stream);
@@ -2259,7 +2434,15 @@ fn handle_connection(
                     http_response(buf.into_inner(), 400, "text required, max 251 chars");
                 } else {
                     let protocol_id = v.get("protocol_id").and_then(|p| p.as_u64()).unwrap_or(220) as u8;
-                    let source_issi = v.get("source_issi").and_then(|s| s.as_u64()).unwrap_or(16777215) as u32;
+                    // The broadcast is serialized with write_bits(source_ssi, 24). `as u32` on the
+                    // raw JSON number let anything >= 2^24 through to that assertion, which aborts
+                    // the single stack thread — one POST would crash-loop the cell.
+                    let source_issi = v.get("source_issi").and_then(|s| s.as_u64()).unwrap_or(16_777_215);
+                    if !is_valid_ssi(source_issi) {
+                        http_response(buf.into_inner(), 400, "source_issi out of range (must be 1..=16777215)");
+                        return;
+                    }
+                    let source_issi = source_issi as u32;
                     let repeat_count = v.get("repeat_count").and_then(|r| r.as_u64()).unwrap_or(0) as u32;
                     tracing::info!("Dashboard: AddLiveSds text={:?} repeat={}", text, repeat_count);
                     send_control_cmd(
@@ -2543,10 +2726,10 @@ fn handle_ws_command(
 
     match cmd_type {
         Some("kick") => {
-            let issi = v.get("issi").and_then(|i| i.as_u64()).unwrap_or(0) as u32;
-            if issi == 0 {
+            let Some(issi) = json_ssi(&v, "issi") else {
+                reject_ws_ssi(state, "kick", "issi", v.get("issi"));
                 return;
-            }
+            };
             tracing::info!("Dashboard: kick ISSI {}", issi);
             if !send_cmd(ControlCommand::KickMs { issi }) {
                 tracing::warn!("Dashboard: no control dispatcher for kick");
@@ -2579,9 +2762,15 @@ fn handle_ws_command(
             s.push_log("INFO", "OTA update started — check /api/update/status for progress".to_string());
         }
         Some("sds") => {
-            let dest = v.get("dest_issi").and_then(|i| i.as_u64()).unwrap_or(0) as u32;
+            // The destination lands in D-SDS-DATA's 24-bit address field. `as u32` silently
+            // truncated a wider JSON value into an in-range-looking one only by accident — values
+            // between 2^24 and 2^32 reached write_bits and aborted the stack thread.
+            let Some(dest) = json_ssi(&v, "dest_issi") else {
+                reject_ws_ssi(state, "sds", "dest_issi", v.get("dest_issi"));
+                return;
+            };
             let msg_text = v.get("message").and_then(|m| m.as_str()).unwrap_or("").to_string();
-            if dest == 0 || msg_text.is_empty() {
+            if msg_text.is_empty() {
                 return;
             }
             tracing::info!("Dashboard: SDS to {} = {}", dest, msg_text);
@@ -2615,8 +2804,14 @@ fn handle_ws_command(
             s.push_log("INFO", format!("SDS sent to {}: {}", dest, msg_text));
         }
         Some("dgna") => {
-            let issi = v.get("issi").and_then(|i| i.as_u64()).unwrap_or(0) as u32;
-            let gssi = v.get("gssi").and_then(|i| i.as_u64()).unwrap_or(0) as u32;
+            let Some(issi) = json_ssi(&v, "issi") else {
+                reject_ws_ssi(state, "dgna", "issi", v.get("issi"));
+                return;
+            };
+            let Some(gssi) = json_ssi(&v, "gssi") else {
+                reject_ws_ssi(state, "dgna", "gssi", v.get("gssi"));
+                return;
+            };
             let mnemonic = v
                 .get("mnemonic")
                 .and_then(|m| m.as_str())
@@ -2645,9 +2840,6 @@ fn handle_ws_command(
             } else {
                 default_attachment_mode
             };
-            if issi == 0 || gssi == 0 {
-                return;
-            }
             let verb = if attach { "assign" } else { "deassign" };
             tracing::info!(
                 "Dashboard: DGNA {} GSSI {} on ISSI {} (mnemonic={:?}, attachment_mode={})",
@@ -2684,7 +2876,10 @@ fn handle_ws_command(
             );
         }
         Some("dgna_bulk") => {
-            let gssi = v.get("gssi").and_then(|i| i.as_u64()).unwrap_or(0) as u32;
+            let Some(gssi) = json_ssi(&v, "gssi") else {
+                reject_ws_ssi(state, "dgna_bulk", "gssi", v.get("gssi"));
+                return;
+            };
             let mnemonic = v
                 .get("mnemonic")
                 .and_then(|m| m.as_str())
@@ -2714,23 +2909,39 @@ fn handle_ws_command(
             } else {
                 default_attachment_mode
             };
-            if gssi == 0 {
-                return;
-            }
             let mut targets = Vec::<u32>::new();
             if all_radios {
-                let mut issis: Vec<u32> = state.read().unwrap().ms_map.keys().copied().collect();
+                let mut issis: Vec<u32> = state
+                    .read()
+                    .unwrap()
+                    .ms_map
+                    .keys()
+                    .copied()
+                    .filter(|i| is_valid_ssi(*i as u64))
+                    .collect();
                 issis.sort_unstable();
                 issis.dedup();
                 targets = issis;
             } else if let Some(arr) = v.get("targets").and_then(|t| t.as_array()) {
+                // Every target is addressed individually, so one out-of-range entry in the list is
+                // enough to panic the serializer. Drop the bad ones and tell the operator, rather
+                // than sending the good half and crashing on the rest.
+                let mut refused = 0usize;
                 for value in arr {
-                    let issi = value.as_u64().unwrap_or(0) as u32;
-                    if issi != 0 && !targets.contains(&issi) {
-                        targets.push(issi);
+                    match value.as_u64() {
+                        Some(n) if is_valid_ssi(n) => {
+                            let issi = n as u32;
+                            if !targets.contains(&issi) {
+                                targets.push(issi);
+                            }
+                        }
+                        _ => refused += 1,
                     }
                 }
                 targets.sort_unstable();
+                if refused > 0 {
+                    reject_ws_ssi(state, "dgna_bulk", "targets", v.get("targets"));
+                }
             }
             if targets.is_empty() {
                 return;
@@ -2773,10 +2984,10 @@ fn handle_ws_command(
             );
         }
         Some("emergency_clear") => {
-            let issi = v.get("issi").and_then(|i| i.as_u64()).unwrap_or(0) as u32;
-            if issi == 0 {
+            let Some(issi) = json_ssi(&v, "issi") else {
+                reject_ws_ssi(state, "emergency_clear", "issi", v.get("issi"));
                 return;
-            }
+            };
             tracing::info!("Dashboard: operator clearing emergency for ISSI {}", issi);
             // Route to CMCE: it clears the source SDS session (so the emergency does not re-arm on
             // the radio's next status re-send) and emits EmergencyCancel, which clears the banner
@@ -3764,7 +3975,8 @@ fn save_config_profile(config_path: &str, profile_name: &str, content: &str) -> 
         Err(e) => return Err(format!("config does not parse: {e}")),
     }
 
-    std::fs::write(&profile_path, content.as_bytes()).map_err(|e| format!("failed to write profile: {}", e))
+    let profile_path = profile_path.to_str().ok_or_else(|| "invalid profile path".to_string())?;
+    atomic_write(profile_path, &content).map_err(|e| format!("failed to write profile: {}", e))
 }
 
 /// GET /api/public — anonymous read-only overview (FH-FEAT-033). Projects ONLY non-sensitive,
@@ -3828,13 +4040,12 @@ fn activate_config_profile(config_path: &str, profile_name: &str) -> Result<(), 
 
     // Backup current config before switching
     let backup_path = format!("{}.bak", config_path);
-    if let Err(e) = std::fs::copy(config_path, &backup_path) {
+    if let Err(e) = atomic_copy(config_path, &backup_path) {
         tracing::warn!("Dashboard: failed to backup config before profile switch: {}", e);
     }
 
-    std::fs::copy(&profile_path, config_path)
-        .map(|_| ())
-        .map_err(|e| format!("failed to copy profile: {}", e))
+    // Atomic: the live config is either the old one or the profile, never a truncated mix.
+    atomic_write(config_path, &profile_content).map_err(|e| format!("failed to copy profile: {}", e))
 }
 
 fn serve_html(mut stream: TcpStream) {
@@ -3926,6 +4137,69 @@ fn unmask_config_secrets(body: &str, current: &str) -> String {
     out
 }
 
+/// Write `content` to `path` atomically: temp file in the SAME directory, flushed, then renamed
+/// over the target. `fs::write`/`fs::copy` truncate the destination first, so a crash (or a power
+/// cut — this is a base station) between truncate and write leaves a half-written config.toml that
+/// no longer parses, which aborts startup under systemd `Restart=` and crash-loops the cell. rename
+/// within one filesystem is atomic, so the config is either the old one or the new one, never half.
+fn atomic_write(path: &str, content: &str) -> std::io::Result<()> {
+    let target = std::path::Path::new(path);
+    let dir = match target.parent() {
+        Some(p) if !p.as_os_str().is_empty() => p.to_path_buf(),
+        _ => std::path::PathBuf::from("."),
+    };
+    let name = target.file_name().and_then(|n| n.to_str()).unwrap_or("config.toml");
+    let tmp = dir.join(format!(".{}.tmp{}", name, std::process::id()));
+
+    let write_tmp = || -> std::io::Result<()> {
+        let mut f = std::fs::File::create(&tmp)?;
+        f.write_all(content.as_bytes())?;
+        f.sync_all()
+    };
+    if let Err(e) = write_tmp() {
+        let _ = std::fs::remove_file(&tmp);
+        return Err(e);
+    }
+    if let Err(e) = std::fs::rename(&tmp, target) {
+        let _ = std::fs::remove_file(&tmp);
+        return Err(e);
+    }
+    Ok(())
+}
+
+/// Copy `src` over `dst` atomically (read + [`atomic_write`]), for the config backup/activate paths
+/// that used `fs::copy` — same truncate-then-write exposure as `fs::write`.
+fn atomic_copy(src: &str, dst: &str) -> std::io::Result<()> {
+    let content = std::fs::read_to_string(src)?;
+    atomic_write(dst, &content)
+}
+
+/// POST /api/config/restore — put `<config>.bak` back as the live config.
+///
+/// The backup is NOT trusted: it may be truncated (an old non-atomic write that was interrupted),
+/// or written by an earlier schema that no longer parses. Copying it over the live config and
+/// restarting — which is what this endpoint used to do, unconditionally — bricks the station with
+/// no way back. So dry-run parse + `validate()` first, exactly like `write_config_validated`, and
+/// snapshot the config we are about to replace to `<config>.prerestore` so the operator can undo.
+fn restore_config_from_backup(config_path: &str) -> Result<(), (u16, String)> {
+    let backup_path = format!("{}.bak", config_path);
+    let content = std::fs::read_to_string(&backup_path).map_err(|e| (500, format!("cannot read backup: {e}")))?;
+    match tetra_config::bluestation::parsing::from_toml_str(&content) {
+        Ok(cfg) => {
+            if let Err(e) = cfg.validate() {
+                return Err((400, format!("backup is invalid, refusing to restore: {e}")));
+            }
+        }
+        Err(e) => return Err((400, format!("backup does not parse, refusing to restore: {e}"))),
+    }
+    // Keep the config we are replacing — a restore is itself an operation the operator may regret.
+    let snapshot_path = format!("{}.prerestore", config_path);
+    if let Err(e) = atomic_copy(config_path, &snapshot_path) {
+        tracing::warn!("Dashboard: failed to snapshot config before restore: {}", e);
+    }
+    atomic_write(config_path, &content).map_err(|e| (500, e.to_string()))
+}
+
 /// Persist a posted config.toml after a dry-run parse + validate.
 ///
 /// Writing garbage here is what would brick the base station: the service restarts to apply config,
@@ -3953,10 +4227,10 @@ fn write_config_validated(config_path: &str, body: &str) -> Result<(), (u16, Str
     }
     // Back up the current config before overwriting (best-effort; a missing source is not fatal).
     let backup_path = format!("{}.bak", config_path);
-    if let Err(e) = std::fs::copy(config_path, &backup_path) {
+    if let Err(e) = atomic_copy(config_path, &backup_path) {
         tracing::warn!("Dashboard: failed to write config backup: {}", e);
     }
-    std::fs::write(config_path, body).map_err(|e| (500, e.to_string()))
+    atomic_write(config_path, body).map_err(|e| (500, e.to_string()))
 }
 
 fn serve_config_get(mut stream: TcpStream, config_path: &str) {
@@ -4358,8 +4632,14 @@ fn serve_tpg2200_action_url(
         http_response(stream, 403, "Forbidden");
         return;
     }
-    if action.dest_issi == 0 || action.source_issi == 0 {
-        http_response(stream, 500, "TPG2200 ActionURL not fully configured");
+    // Both identities go into D-SDS-DATA's 24-bit address fields. A misconfigured (or hand-edited)
+    // wider value would panic the stack thread on the first call-out, so refuse to send at all.
+    if !is_valid_ssi(action.dest_issi as u64) || !is_valid_ssi(action.source_issi as u64) {
+        http_response(
+            stream,
+            500,
+            "TPG2200 ActionURL not fully configured (source/dest ISSI must be 1..=16777215)",
+        );
         return;
     }
 
@@ -5560,10 +5840,14 @@ fn serve_dapnet_send(
 #[cfg(test)]
 mod tests {
     use super::{
-        DashboardServer, activate_config_profile, binary_built_from, is_masked_secret_key, mask_config_secrets,
-        normalize_mojibake_html, save_config_profile, write_config_validated,
+        DashboardServer, LoginThrottle, MAX_TETRA_SSI, UpdateState, activate_config_profile, binary_built_from,
+        handle_ws_command, is_masked_secret_key, mask_config_secrets, normalize_mojibake_html,
+        restore_config_from_backup, save_config_profile, timing_safe_eq, write_config_validated,
     };
+    use crate::net_control::commands::ControlCommand;
+    use crate::net_dashboard::state::DashboardStateInner;
     use crate::net_telemetry::TelemetryEvent;
+    use std::sync::{Arc, Mutex, RwLock};
 
     /// A minimal config.toml that parses + validates (mirrors tetra-config's own minimal fixture).
     const MINIMAL_CONFIG: &str = r#"
@@ -5809,6 +6093,152 @@ enabled = true
         assert!(
             !resolved.contains('\u{2022}') && !resolved.contains('\u{2026}'),
             "mask characters must not be persisted"
+        );
+    }
+
+    /// Drive `handle_ws_command` with a real command channel and report what reached CMCE.
+    fn run_ws_command(json: &str) -> Vec<ControlCommand> {
+        let (tx, rx) = crossbeam_channel::unbounded();
+        let state = Arc::new(RwLock::new(DashboardStateInner::new("/tmp/fs_ws_cmd_test.toml".to_string())));
+        let cmd_tx = Arc::new(Mutex::new(Some(tx)));
+        let update_state = Arc::new(Mutex::new(UpdateState::new()));
+        handle_ws_command(json, &state, &cmd_tx, &update_state, &None);
+        rx.try_iter().collect()
+    }
+
+    /// SHIP-BLOCKER regression: a TETRA SSI is 24 bits and the PDU serializers assert that range,
+    /// so an out-of-range `dest_issi` on the dashboard SDS path used to reach `write_bits(ssi, 24)`
+    /// and abort the single stack thread — one WS frame crash-looping the whole cell. It must be
+    /// refused at the dashboard boundary instead, and an in-range one must still go through.
+    #[test]
+    fn ws_sds_rejects_out_of_range_ssi() {
+        // 2^24 — the first value that no longer fits the 24-bit address field.
+        let over = MAX_TETRA_SSI as u64 + 1;
+        let sent = run_ws_command(&format!(r#"{{"type":"sds","dest_issi":{over},"message":"boom"}}"#));
+        assert!(sent.is_empty(), "out-of-range dest_issi must never reach CMCE, got {sent:?}");
+
+        // 2^32 + 1 — `as u32` would silently truncate this to a perfectly legal-looking ISSI 1.
+        let wrapped = 0x1_0000_0001u64;
+        let sent = run_ws_command(&format!(r#"{{"type":"sds","dest_issi":{wrapped},"message":"boom"}}"#));
+        assert!(sent.is_empty(), "wrapping dest_issi must be refused, not truncated");
+
+        // Zero (the "no identity" sentinel) stays refused too.
+        assert!(run_ws_command(r#"{"type":"sds","dest_issi":0,"message":"x"}"#).is_empty());
+
+        // The largest legal SSI is accepted and reaches CMCE unchanged.
+        let sent = run_ws_command(&format!(
+            r#"{{"type":"sds","dest_issi":{},"message":"hello"}}"#,
+            MAX_TETRA_SSI
+        ));
+        match sent.as_slice() {
+            [ControlCommand::SendSds { dest_ssi, .. }] => assert_eq!(*dest_ssi, MAX_TETRA_SSI),
+            other => panic!("expected one SendSds for a valid SSI, got {other:?}"),
+        }
+    }
+
+    /// The same 24-bit guard on the other privileged WS commands — each one addresses a radio or a
+    /// group and ends up in a serializer with the same assertion.
+    #[test]
+    fn ws_kick_and_dgna_reject_out_of_range_ssi() {
+        let over = MAX_TETRA_SSI as u64 + 1;
+        assert!(run_ws_command(&format!(r#"{{"type":"kick","issi":{over}}}"#)).is_empty());
+        assert!(run_ws_command(&format!(r#"{{"type":"dgna","issi":{over},"gssi":1000}}"#)).is_empty());
+        assert!(run_ws_command(&format!(r#"{{"type":"dgna","issi":1000,"gssi":{over}}}"#)).is_empty());
+        assert!(run_ws_command(&format!(r#"{{"type":"dgna_bulk","gssi":{over},"targets":[1000]}}"#)).is_empty());
+        // Out-of-range entries are dropped from a bulk target list; the valid ones still go.
+        let sent = run_ws_command(&format!(r#"{{"type":"dgna_bulk","gssi":1000,"targets":[{over},4242]}}"#));
+        match sent.as_slice() {
+            [ControlCommand::Dgna { issi, gssi, .. }] => {
+                assert_eq!((*issi, *gssi), (4242, 1000), "only the in-range target is regrouped");
+            }
+            other => panic!("expected one Dgna for the single valid target, got {other:?}"),
+        }
+    }
+
+    /// A `.bak` that does not parse (truncated by an interrupted write, or written by an older
+    /// schema) must NOT be copied over the live config: the restore endpoint used to do exactly
+    /// that and then restart, leaving an unbootable station with nothing to fall back to.
+    #[test]
+    fn config_restore_refuses_invalid_backup_and_preserves_live_config() {
+        let dir = std::env::temp_dir();
+        let pid = std::process::id();
+        let cfg = dir.join(format!("fs_restore_{pid}.toml"));
+        let cfg_str = cfg.to_str().unwrap().to_string();
+        std::fs::write(&cfg, MINIMAL_CONFIG).expect("seed active config");
+
+        // A truncated backup — parses as far as it goes, then stops mid-table.
+        std::fs::write(format!("{cfg_str}.bak"), "config_version = \"0.6\"\n[phy_io\n").expect("seed bad backup");
+        match restore_config_from_backup(&cfg_str) {
+            Err((400, _)) => {}
+            other => panic!("expected a 400 refusal for an unparseable backup, got {other:?}"),
+        }
+        assert_eq!(
+            std::fs::read_to_string(&cfg).unwrap(),
+            MINIMAL_CONFIG,
+            "live config must be untouched when the backup is refused"
+        );
+
+        // A good backup restores, and the config it replaced is snapshotted so the operator can undo.
+        let good = format!("{}\n# from backup\n", MINIMAL_CONFIG);
+        std::fs::write(format!("{cfg_str}.bak"), &good).expect("seed good backup");
+        restore_config_from_backup(&cfg_str).expect("valid backup restores");
+        assert_eq!(std::fs::read_to_string(&cfg).unwrap(), good, "valid backup is restored");
+        assert_eq!(
+            std::fs::read_to_string(format!("{cfg_str}.prerestore")).unwrap(),
+            MINIMAL_CONFIG,
+            "the replaced config is kept as a pre-restore snapshot"
+        );
+
+        let _ = std::fs::remove_file(&cfg);
+        let _ = std::fs::remove_file(format!("{cfg_str}.bak"));
+        let _ = std::fs::remove_file(format!("{cfg_str}.prerestore"));
+    }
+
+    /// Comparing credentials must not leak the *expected* secret's length via an early return.
+    #[test]
+    fn timing_safe_eq_is_exact_and_length_agnostic() {
+        assert!(timing_safe_eq(b"hunter2", b"hunter2"));
+        assert!(timing_safe_eq(b"", b""));
+        assert!(!timing_safe_eq(b"hunter2", b"hunter"), "a prefix is not a match");
+        assert!(!timing_safe_eq(b"hunter", b"hunter2"), "a shorter supplied value is not a match");
+        assert!(!timing_safe_eq(b"", b"secret"));
+        assert!(!timing_safe_eq(b"secret", b""));
+        // The wrap-around must not make a repeated candidate compare equal to a shorter secret.
+        assert!(!timing_safe_eq(b"abab", b"ab"));
+    }
+
+    /// Failed logins must cost across connections (the old per-connection sleep did nothing against
+    /// a parallel attacker), and the tracking map must stay bounded so it isn't a DoS of its own.
+    #[test]
+    fn login_throttle_locks_out_and_stays_bounded() {
+        use std::net::{IpAddr, Ipv4Addr};
+        let mut t = LoginThrottle::new();
+        let ip = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 7));
+
+        // Below the threshold: delay grows, but the address may keep trying.
+        for _ in 0..super::LOGIN_LOCKOUT_AFTER - 1 {
+            t.record_failure(ip);
+            assert!(t.locked_for(&ip).is_none(), "must not lock out before the threshold");
+        }
+        // Crossing it locks the address out for everyone, on every connection.
+        t.record_failure(ip);
+        let lock = t.locked_for(&ip).expect("must lock out at the threshold");
+        assert!(lock > std::time::Duration::from_secs(1));
+        // Further failures escalate.
+        t.record_failure(ip);
+        assert!(t.locked_for(&ip).unwrap() > lock, "backoff must escalate");
+        // A successful login wipes the history.
+        t.clear(&ip);
+        assert!(t.locked_for(&ip).is_none(), "success clears the lockout");
+
+        // Rotating source addresses cannot grow the map without bound.
+        for i in 0..(super::LOGIN_MAX_TRACKED_IPS as u32 + 500) {
+            t.record_failure(IpAddr::V4(Ipv4Addr::from(i)));
+        }
+        assert!(
+            t.entries.len() <= super::LOGIN_MAX_TRACKED_IPS,
+            "throttle map must stay capped, got {}",
+            t.entries.len()
         );
     }
 

--- a/crates/tetra-entities/src/net_telemetry/channel.rs
+++ b/crates/tetra-entities/src/net_telemetry/channel.rs
@@ -1,7 +1,25 @@
-use crossbeam_channel::{Receiver, RecvTimeoutError, Sender, unbounded};
+use crossbeam_channel::{Receiver, RecvTimeoutError, Sender, TrySendError, bounded};
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Duration;
 
 use crate::net_telemetry::events::TelemetryEvent;
+
+/// Queue depth per telemetry channel.
+///
+/// Telemetry is lossy by nature, so the queue is bounded: under an RF-driven event flood with a
+/// slow consumer (dashboard / Telegram / Snom / network worker) an unbounded queue grows toward
+/// OOM, and since the core thread never blocks on it the health watchdog never sees the growth.
+/// Deep enough to ride out several seconds of a stalled consumer at realistic event rates.
+pub const TELEMETRY_QUEUE_CAP: usize = 4096;
+
+/// Events dropped because a queue was full, process-wide. Never reset; read by operators (and
+/// the log line below) so telemetry loss is visible instead of silent.
+static DROPPED_EVENTS: AtomicU64 = AtomicU64::new(0);
+
+/// Total telemetry events dropped for lack of queue space since process start.
+pub fn dropped_events() -> u64 {
+    DROPPED_EVENTS.load(Ordering::Relaxed)
+}
 
 // ---------------------------------------------------------------------------
 // TelemetrySink  (cloneable, push‑only handle given to entities)
@@ -19,10 +37,23 @@ pub struct TelemetrySink {
 }
 
 impl TelemetrySink {
-    /// Push a telemetry event. Lock‑free. Fire‑and‑forget: silently drops if the receiver is gone.
+    /// Push a telemetry event. Lock‑free and never blocks — the core loop must not be paced by a
+    /// slow telemetry consumer. Fire‑and‑forget: silently drops if the receiver is gone, and
+    /// drops the newest event (counted) if the queue is full.
     #[inline]
     pub fn send(&self, event: TelemetryEvent) {
-        let _ = self.tx.send(event);
+        if let Err(TrySendError::Full(_)) = self.tx.try_send(event) {
+            let n = DROPPED_EVENTS.fetch_add(1, Ordering::Relaxed) + 1;
+            // Loud on the first loss, then every 1000th — enough for an operator to see
+            // "telemetry is lossy right now" without turning a flood into a log flood.
+            if n == 1 || n % 1000 == 0 {
+                tracing::warn!(
+                    "Telemetry queue full ({} slots) — consumer too slow, {} events dropped so far",
+                    TELEMETRY_QUEUE_CAP,
+                    n
+                );
+            }
+        }
     }
 }
 
@@ -69,9 +100,9 @@ impl TelemetrySource {
 // Channel constructor
 // ---------------------------------------------------------------------------
 
-/// Create a linked (sink, source) pair.
+/// Create a linked (sink, source) pair. Bounded — see [`TELEMETRY_QUEUE_CAP`].
 pub fn telemetry_channel() -> (TelemetrySink, TelemetrySource) {
-    let (tx, rx) = unbounded();
+    let (tx, rx) = bounded(TELEMETRY_QUEUE_CAP);
     (TelemetrySink { tx }, TelemetrySource { rx })
 }
 
@@ -110,5 +141,26 @@ mod tests {
 
         // No more items
         assert!(source.try_recv().is_none());
+    }
+
+    #[test]
+    fn full_queue_drops_newest_and_counts() {
+        let (sink, source) = telemetry_channel();
+        let before = dropped_events();
+
+        // Fill to capacity — nothing dropped yet.
+        for issi in 0..TELEMETRY_QUEUE_CAP as u32 {
+            sink.send(TelemetryEvent::MsRegistration { issi });
+        }
+        assert_eq!(dropped_events(), before, "queue should absorb exactly its capacity");
+
+        // Overflow: send() must not block and the extra events are dropped + counted.
+        for issi in 0..10u32 {
+            sink.send(TelemetryEvent::MsRegistration { issi });
+        }
+        assert_eq!(dropped_events(), before + 10);
+
+        // The oldest events survived (drop-newest policy).
+        assert!(matches!(source.try_recv(), Some(TelemetryEvent::MsRegistration { issi: 0 })));
     }
 }

--- a/crates/tetra-entities/src/network/transports/mod.rs
+++ b/crates/tetra-entities/src/network/transports/mod.rs
@@ -14,6 +14,37 @@ pub mod websocket;
 /// Basic TCP transport implementation
 pub mod tcp;
 
+/// Largest accepted length-prefixed message on the stream transports (TCP, QUIC reliable).
+pub(crate) const MAX_FRAME_BYTES: usize = 1024 * 1024;
+
+/// Pull every complete `u32-BE length + payload` frame out of `buf`, leaving any partial
+/// tail in place for the next read.
+///
+/// Stream reads split frames across calls whenever a message spans TCP segments. Consuming
+/// those partial bytes and then discarding them — what `read_exact` on a non-blocking socket
+/// does — desyncs the framing permanently, so the buffer has to survive between calls.
+/// An over-long length prefix means the stream is already desynced: the caller is told to
+/// drop the connection rather than try to resynchronise.
+pub(crate) fn drain_length_prefixed(buf: &mut Vec<u8>) -> Result<Vec<Vec<u8>>, String> {
+    let mut frames = Vec::new();
+    loop {
+        if buf.len() < 4 {
+            return Ok(frames);
+        }
+        let mut len_bytes = [0u8; 4];
+        len_bytes.copy_from_slice(&buf[..4]);
+        let payload_len = u32::from_be_bytes(len_bytes) as usize;
+        if payload_len > MAX_FRAME_BYTES {
+            return Err(format!("framing desync: message length {} bytes", payload_len));
+        }
+        if buf.len() < 4 + payload_len {
+            return Ok(frames); // incomplete — keep the tail buffered
+        }
+        frames.push(buf[4..4 + payload_len].to_vec());
+        buf.drain(..4 + payload_len);
+    }
+}
+
 /// Network transport abstraction for Entity-to-network external communications
 ///
 /// This trait defines a unified interface for both reliable (TCP, QUIC streams)
@@ -112,3 +143,42 @@ impl std::fmt::Display for NetworkError {
 }
 
 impl std::error::Error for NetworkError {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn framing_survives_a_split_read() {
+        let mut buf = Vec::new();
+        buf.extend_from_slice(&4u32.to_be_bytes());
+        buf.extend_from_slice(&[1, 2]); // only half the payload arrived
+
+        assert!(drain_length_prefixed(&mut buf).unwrap().is_empty());
+        assert_eq!(buf.len(), 6, "partial frame must stay buffered");
+
+        buf.extend_from_slice(&[3, 4]);
+        assert_eq!(drain_length_prefixed(&mut buf).unwrap(), vec![vec![1, 2, 3, 4]]);
+        assert!(buf.is_empty());
+    }
+
+    #[test]
+    fn framing_handles_several_frames_in_one_read() {
+        let mut buf = Vec::new();
+        buf.extend_from_slice(&2u32.to_be_bytes());
+        buf.extend_from_slice(&[9, 9]);
+        buf.extend_from_slice(&1u32.to_be_bytes());
+        buf.extend_from_slice(&[7]);
+        buf.extend_from_slice(&5u32.to_be_bytes()); // header of a frame that has not arrived
+
+        assert_eq!(drain_length_prefixed(&mut buf).unwrap(), vec![vec![9, 9], vec![7]]);
+        assert_eq!(buf.len(), 4);
+    }
+
+    #[test]
+    fn framing_rejects_an_absurd_length_prefix() {
+        let mut buf = Vec::new();
+        buf.extend_from_slice(&u32::MAX.to_be_bytes());
+        assert!(drain_length_prefixed(&mut buf).is_err());
+    }
+}

--- a/crates/tetra-entities/src/network/transports/quic.rs
+++ b/crates/tetra-entities/src/network/transports/quic.rs
@@ -3,9 +3,10 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use quinn::{Connection, Endpoint, RecvStream, SendStream, VarInt};
+#[cfg(test)]
 use rustls::pki_types::{CertificateDer, ServerName};
 
-use super::{NetworkAddress, NetworkError, NetworkMessage, NetworkTransport};
+use super::{MAX_FRAME_BYTES, NetworkAddress, NetworkError, NetworkMessage, NetworkTransport, drain_length_prefixed};
 
 /// Channel type for QUIC streams
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -23,7 +24,8 @@ pub struct QuicTransportConfig {
     pub server_addr: NetworkAddress,
     /// Connection timeout
     pub connect_timeout: Duration,
-    /// Skip certificate verification (testing only)
+    /// Skip certificate verification. TEST BUILDS ONLY — the all-accepting verifier is not
+    /// compiled into release binaries, so setting this outside `cfg(test)` fails the connect.
     pub skip_cert_verification: bool,
     /// Tokio runtime handle for async operations
     pub runtime: tokio::runtime::Handle,
@@ -40,7 +42,8 @@ impl QuicTransportConfig {
         }
     }
 
-    /// Create an insecure QUIC transport configuration (for testing)
+    /// Create an insecure QUIC transport configuration. Only usable in test builds — see
+    /// [`QuicTransportConfig::skip_cert_verification`].
     pub fn insecure(server_addr: NetworkAddress, runtime: tokio::runtime::Handle) -> Self {
         Self {
             server_addr,
@@ -68,6 +71,12 @@ pub struct QuicTransport {
     /// Cached reliable bi-directional stream for signalling
     reliable_send: Option<SendStream>,
     reliable_recv: Option<RecvStream>,
+    /// Bytes read from the reliable stream that do not yet form a complete frame. Kept across
+    /// calls: the read below is cancelled by its short timeout, and anything already consumed
+    /// would otherwise be dropped, desyncing the length-prefixed framing.
+    reliable_rx_buf: Vec<u8>,
+    /// Frames decoded but not yet handed to the caller (one `receive_reliable` = one message)
+    reliable_pending: std::collections::VecDeque<Vec<u8>>,
     /// Tokio runtime handle for async operations
     runtime: tokio::runtime::Runtime,
 }
@@ -127,6 +136,8 @@ impl QuicTransport {
             connect_timeout,
             reliable_send: None,
             reliable_recv: None,
+            reliable_rx_buf: Vec::new(),
+            reliable_pending: std::collections::VecDeque::new(),
             runtime,
         })
     }
@@ -165,7 +176,18 @@ impl QuicTransport {
             .map_err(|e| NetworkError::ConnectionFailed(format!("Failed to build QUIC config: {}", e)))?)
     }
 
+    /// Release builds must not be able to skip certificate validation at all: the
+    /// all-accepting verifier below is `cfg(test)`-only, so asking for it here fails loudly
+    /// instead of silently connecting to whoever answers.
+    #[cfg(not(test))]
+    fn configure_insecure_client() -> Result<quinn::crypto::rustls::QuicClientConfig, NetworkError> {
+        Err(NetworkError::ConnectionFailed(
+            "skip_cert_verification is only available in test builds".to_string(),
+        ))
+    }
+
     /// Configure insecure client (skip certificate verification - testing only)
+    #[cfg(test)]
     fn configure_insecure_client() -> Result<quinn::crypto::rustls::QuicClientConfig, NetworkError> {
         let mut crypto = rustls::ClientConfig::builder()
             .dangerous()
@@ -228,30 +250,40 @@ impl QuicTransport {
 
         match channel {
             QuicChannelType::Reliable => {
-                if let Some(ref mut recv) = self.reliable_recv {
-                    // Try to read length prefix with a short timeout so this
-                    // stays non-blocking when no data is available.
-                    let mut len_buf = [0u8; 4];
-                    match tokio::time::timeout(Duration::from_millis(10), recv.read_exact(&mut len_buf)).await {
-                        Ok(Ok(())) => {
-                            let len = u32::from_be_bytes(len_buf) as usize;
-
-                            if len > 1024 * 1024 {
-                                return Err(NetworkError::ReceiveFailed("Message too large".to_string()));
-                            }
-
-                            let mut payload = vec![0u8; len];
-                            match recv.read_exact(&mut payload).await {
-                                Ok(()) => Ok(Some(payload)),
-                                Err(_) => Ok(None), // Stream finished
-                            }
-                        }
-                        Ok(Err(_)) => Ok(None), // Stream finished or error
-                        Err(_) => Ok(None),     // Timeout — no data available
-                    }
-                } else {
-                    Ok(None)
+                // Anything already decoded goes out first.
+                if let Some(frame) = self.reliable_pending.pop_front() {
+                    return Ok(Some(frame));
                 }
+
+                // One bounded read into our own buffer. `read_exact` was used here before, but
+                // it is not cancel-safe: when the 10 ms timeout fired mid-message the bytes it
+                // had consumed were thrown away and the framing never recovered.
+                let mut chunk = vec![0u8; 8192];
+                let read = match self.reliable_recv.as_mut() {
+                    Some(recv) => match tokio::time::timeout(Duration::from_millis(10), recv.read(&mut chunk)).await {
+                        Ok(Ok(Some(n))) => Some(n),
+                        Ok(Ok(None)) => None,  // Stream finished
+                        Ok(Err(_)) => return Ok(None), // Stream error
+                        Err(_) => None,        // Timeout — nothing new this call
+                    },
+                    None => return Ok(None),
+                };
+                if let Some(n) = read {
+                    self.reliable_rx_buf.extend_from_slice(&chunk[..n]);
+                    if self.reliable_rx_buf.len() > 2 * MAX_FRAME_BYTES {
+                        self.reliable_rx_buf.clear();
+                        return Err(NetworkError::ReceiveFailed("reliable stream desynced, buffer reset".to_string()));
+                    }
+                }
+
+                match drain_length_prefixed(&mut self.reliable_rx_buf) {
+                    Ok(frames) => self.reliable_pending.extend(frames),
+                    Err(e) => {
+                        self.reliable_rx_buf.clear();
+                        return Err(NetworkError::ReceiveFailed(e));
+                    }
+                }
+                Ok(self.reliable_pending.pop_front())
             }
             QuicChannelType::Unreliable => {
                 // Receive datagram
@@ -270,6 +302,9 @@ impl QuicTransport {
             let _ = send.finish();
         }
         self.reliable_recv = None;
+        // Buffered bytes belong to the stream we just closed.
+        self.reliable_rx_buf.clear();
+        self.reliable_pending.clear();
     }
 }
 
@@ -383,10 +418,13 @@ impl Drop for QuicTransport {
     }
 }
 
-/// Certificate verifier that accepts any certificate (INSECURE - testing only)
+/// Certificate verifier that accepts any certificate (INSECURE - testing only).
+/// Deliberately `cfg(test)`: it must never exist in a shipped binary.
+#[cfg(test)]
 #[derive(Debug)]
 struct SkipServerVerification;
 
+#[cfg(test)]
 impl rustls::client::danger::ServerCertVerifier for SkipServerVerification {
     fn verify_server_cert(
         &self,

--- a/crates/tetra-entities/src/network/transports/tcp.rs
+++ b/crates/tetra-entities/src/network/transports/tcp.rs
@@ -2,7 +2,7 @@ use std::io::{Read, Write};
 use std::net::TcpStream;
 use std::time::{Duration, Instant};
 
-use super::{NetworkAddress, NetworkError, NetworkMessage, NetworkTransport};
+use super::{MAX_FRAME_BYTES, NetworkAddress, NetworkError, NetworkMessage, NetworkTransport, drain_length_prefixed};
 
 /// Configuration for creating a TCP transport
 #[derive(Debug, Clone)]
@@ -41,6 +41,10 @@ pub struct TcpTransport {
     server_addr: NetworkAddress,
     connect_timeout: Duration,
     read_timeout: Duration,
+    /// Bytes read from the socket that do not yet form a complete length-prefixed frame.
+    /// Must persist across `receive_reliable` calls — a message that spans TCP segments
+    /// would otherwise be half-consumed and dropped, desyncing the framing for good.
+    rx_buf: Vec<u8>,
 }
 
 impl TcpTransport {
@@ -50,6 +54,7 @@ impl TcpTransport {
             server_addr,
             connect_timeout,
             read_timeout,
+            rx_buf: Vec::new(),
         }
     }
 
@@ -69,6 +74,8 @@ impl TcpTransport {
 
     /// Closes the current TCP connection, if any.
     fn close_connection(&mut self) {
+        // Buffered bytes belong to the old connection's frame stream — never carry them over.
+        self.rx_buf.clear();
         if let Some(stream) = self.stream.take() {
             let _ = stream.shutdown(std::net::Shutdown::Both);
         }
@@ -148,55 +155,71 @@ impl NetworkTransport for TcpTransport {
     fn receive_reliable(&mut self) -> Vec<NetworkMessage> {
         let mut messages = Vec::new();
 
-        if let Some(ref mut stream) = self.stream {
-            tracing::debug!("TCP receive: checking for messages on connection");
-            // Set non-blocking mode for receiving
-            if let Err(e) = stream.set_nonblocking(true) {
-                tracing::error!("Failed to set non-blocking mode: {}", e);
-                return messages;
-            }
+        let Some(stream) = self.stream.as_mut() else {
+            return messages;
+        };
 
-            loop {
-                // Try to read message length
-                let mut len_bytes = [0u8; 4];
-                match stream.read_exact(&mut len_bytes) {
-                    Ok(()) => {
-                        let payload_len = u32::from_be_bytes(len_bytes) as usize;
-                        tracing::info!("Received message length: {} bytes", payload_len);
+        tracing::debug!("TCP receive: checking for messages on connection");
+        // Set non-blocking mode for receiving
+        if let Err(e) = stream.set_nonblocking(true) {
+            tracing::error!("Failed to set non-blocking mode: {}", e);
+            return messages;
+        }
 
-                        // Reasonable message size limit
-                        if payload_len > 1024 * 1024 {
-                            tracing::warn!("Message too large: {} bytes", payload_len);
-                            break;
-                        }
-
-                        // Read payload
-                        let mut payload = vec![0u8; payload_len];
-                        match stream.read_exact(&mut payload) {
-                            Ok(()) => {
-                                messages.push(NetworkMessage {
-                                    source: self.server_addr.clone(),
-                                    payload,
-                                    timestamp: Instant::now(),
-                                });
-                            }
-                            Err(_) => break, // Connection closed or error
-                        }
-                    }
-                    Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => {
-                        // No more data available
-                        tracing::debug!("TCP receive: no data available (would block)");
+        // Drain whatever the socket has into rx_buf; framing is decoded afterwards so a
+        // message split across segments is completed on a later call instead of being lost.
+        let mut chunk = [0u8; 8192];
+        let mut closed = false;
+        loop {
+            match stream.read(&mut chunk) {
+                Ok(0) => {
+                    tracing::debug!("TCP receive: peer closed the connection");
+                    closed = true;
+                    break;
+                }
+                Ok(n) => {
+                    self.rx_buf.extend_from_slice(&chunk[..n]);
+                    if self.rx_buf.len() > 2 * MAX_FRAME_BYTES {
+                        tracing::warn!("TCP receive: buffered {} bytes without a complete frame, resetting", self.rx_buf.len());
+                        self.rx_buf.clear();
+                        closed = true;
                         break;
                     }
-                    Err(e) => {
-                        tracing::debug!("TCP receive: error reading length header: {}", e);
-                        break; // Connection error
-                    }
+                }
+                Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => {
+                    tracing::debug!("TCP receive: no data available (would block)");
+                    break;
+                }
+                Err(e) => {
+                    tracing::debug!("TCP receive: read error: {}", e);
+                    closed = true;
+                    break;
                 }
             }
+        }
 
-            // Restore blocking mode
-            let _ = stream.set_nonblocking(false);
+        // Restore blocking mode
+        let _ = stream.set_nonblocking(false);
+
+        match drain_length_prefixed(&mut self.rx_buf) {
+            Ok(frames) => {
+                for payload in frames {
+                    messages.push(NetworkMessage {
+                        source: self.server_addr.clone(),
+                        payload,
+                        timestamp: Instant::now(),
+                    });
+                }
+            }
+            Err(e) => {
+                tracing::warn!("TCP receive: {} — dropping connection", e);
+                self.close_connection();
+                return messages;
+            }
+        }
+
+        if closed {
+            self.close_connection();
         }
 
         messages

--- a/crates/tetra-entities/src/network/transports/websocket.rs
+++ b/crates/tetra-entities/src/network/transports/websocket.rs
@@ -19,6 +19,18 @@ use super::{NetworkAddress, NetworkError, NetworkMessage, NetworkTransport};
 
 const DEFAULT_CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
 const DEFAULT_READ_TIMEOUT: Duration = Duration::from_secs(10);
+/// Write timeout on the live WebSocket stream. Without one a peer that stops reading blocks
+/// `send` forever inside the single-threaded worker, which then never reaches its heartbeat
+/// check and never reconnects. Failing fast lets the existing reconnect logic run.
+const DEFAULT_WRITE_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Maximum WebSocket frames drained per [`WebSocketTransport::receive_reliable`] call.
+///
+/// The worker only services its command channel *after* this returns, so an unbounded drain
+/// lets a continuously-sending peer starve outbound REGISTER / voice / CALL_RELEASE while
+/// `last_activity_at` keeps being refreshed — the link looks healthy but is one-way. Capping
+/// the batch hands the turn back to the worker; whatever is left is read on the next pass.
+const MAX_FRAMES_PER_RECEIVE: usize = 32;
 
 // ─── Configuration ────────────────────────────────────────────────
 
@@ -551,11 +563,13 @@ impl NetworkTransport for WebSocketTransport {
         match ws.get_ref() {
             MaybeTlsStream::Plain(stream) => {
                 let _ = stream.set_read_timeout(Some(Duration::from_millis(10)));
+                let _ = stream.set_write_timeout(Some(DEFAULT_WRITE_TIMEOUT));
                 let _ = stream.set_nodelay(true);
             }
             MaybeTlsStream::Rustls(tls_stream) => {
                 let tcp = tls_stream.get_ref();
                 let _ = tcp.set_read_timeout(Some(Duration::from_millis(10)));
+                let _ = tcp.set_write_timeout(Some(DEFAULT_WRITE_TIMEOUT));
                 let _ = tcp.set_nodelay(true);
             }
             _ => {}
@@ -621,7 +635,15 @@ impl NetworkTransport for WebSocketTransport {
             address: format!("{}:{}", self.config.host, self.config.port),
         };
 
+        let mut frames = 0usize;
         loop {
+            if frames >= MAX_FRAMES_PER_RECEIVE {
+                // Yield to the worker so queued commands (REGISTER, voice, CALL_RELEASE) go
+                // out; the rest of the peer's backlog is drained on the next call.
+                tracing::trace!("WebSocketTransport: frame budget reached, yielding to command servicing");
+                break;
+            }
+            frames += 1;
             match ws.read() {
                 Ok(Message::Binary(data)) => {
                     self.last_activity_at = Instant::now();

--- a/crates/tetra-entities/src/phy/components/phy_io_file.rs
+++ b/crates/tetra-entities/src/phy/components/phy_io_file.rs
@@ -65,6 +65,7 @@ impl PhyIoFile {
     pub fn read_block(&mut self, buffer: &mut [u8]) -> Result<(), PhyIoError> {
         let block_size = buffer.len();
         let mut bytes_read = 0;
+        let mut rewinds = 0;
 
         while bytes_read < block_size {
             match self.file.read(&mut buffer[bytes_read..]) {
@@ -77,6 +78,17 @@ impl PhyIoFile {
                         PhyIoFileMode::ReadRepeat => {
                             // Seek back to beginning and continue reading
                             self.file.seek(SeekFrom::Start(0))?;
+                            rewinds += 1;
+
+                            // A file holding at least one full block needs at most one rewind
+                            // per call. A second one means the file is shorter than a block --
+                            // an empty file being the obvious case, where read() returns Ok(0)
+                            // for ever and this loop spins the PHY thread with no way out.
+                            if rewinds > 1 {
+                                return Err(PhyIoError::Io(format!(
+                                    "input file is shorter than one {block_size}-byte block, cannot repeat it"
+                                )));
+                            }
 
                             // If we had a partial block, it means the file doesn't contain
                             // an integer number of blocks. In this case, discard the partial
@@ -274,6 +286,34 @@ mod tests {
         // Third read should also work
         assert!(reader.read_block(&mut buffer).is_ok());
         assert_eq!(buffer, [1, 2, 3, 4]);
+
+        // Cleanup
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn test_empty_file_repeat_bails_out() {
+        // An empty file used to rewind for ever and spin the PHY thread.
+        let (_filename, path) = create_temp_file(&[]);
+
+        let mut reader = PhyIoFile::new(&path, PhyIoFileMode::ReadRepeat).unwrap();
+        let mut buffer = [0u8; 8];
+
+        assert!(matches!(reader.read_block(&mut buffer), Err(PhyIoError::Io(_))));
+
+        // Cleanup
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn test_shorter_than_block_repeat_bails_out() {
+        // Same failure mode: a file that never contains a full block.
+        let (_filename, path) = create_temp_file(&[1u8, 2, 3]);
+
+        let mut reader = PhyIoFile::new(&path, PhyIoFileMode::ReadRepeat).unwrap();
+        let mut buffer = [0u8; 8];
+
+        assert!(matches!(reader.read_block(&mut buffer), Err(PhyIoError::Io(_))));
 
         // Cleanup
         let _ = std::fs::remove_file(&path);

--- a/crates/tetra-entities/src/phy/components/soapy_dev.rs
+++ b/crates/tetra-entities/src/phy/components/soapy_dev.rs
@@ -380,8 +380,17 @@ impl RxDsp {
                 self.rx_buffer_i = 0;
 
                 // Repeat reads until the correct number of samples has been skipped.
+                // samples_to_skip lands in [new, 2*new) but rx_buffer only holds
+                // new+overlap (= 4/3*new with Overlap::O1_4), so it can be larger than
+                // the buffer. We are only discarding samples here, so clamp each read to
+                // the buffer and let the loop take more than one pass.
+                debug_assert!(
+                    !self.rx_buffer.is_empty(),
+                    "rx_buffer must be non-empty, otherwise skipping never makes progress"
+                );
                 while samples_to_skip > 0 {
-                    let result = sdr.receive(&mut self.rx_buffer[0..samples_to_skip as usize])?;
+                    let skip_now = (samples_to_skip as usize).min(self.rx_buffer.len());
+                    let result = sdr.receive(&mut self.rx_buffer[0..skip_now])?;
                     samples_to_skip -= result.len as SampleCount;
                 }
             } else {

--- a/crates/tetra-entities/src/phy/components/soapyio.rs
+++ b/crates/tetra-entities/src/phy/components/soapyio.rs
@@ -35,6 +35,13 @@ pub struct SoapyIo {
     /// is unacceptably slow or not supported.
     use_get_hardware_time: bool,
 
+    /// Number of recoverable RX stream errors (overflow / timeout) since start,
+    /// and the next time we are allowed to warn about them. These are an everyday
+    /// event on a loaded RPi + LimeSDR over USB, so logging every one would flood
+    /// the journal and cost more time than the overflow itself.
+    rx_recoverable_errors: u64,
+    rx_recoverable_next_log: std::time::Instant,
+
     dev: soapysdr::Device,
     /// Receive stream. None if receiving is disabled.
     rx: Option<soapysdr::RxStream<StreamType>>,
@@ -45,6 +52,48 @@ pub struct SoapyIo {
 /// Soapy/Lime timestamps can occasionally jitter by a single sample.
 /// Treat tiny deltas as contiguous to avoid triggering large block realignments downstream.
 const RX_TIMESTAMP_JITTER_TOLERANCE_SAMPLES: SampleCount = 1;
+
+/// How many times a read is retried after a SOAPY_SDR_OVERFLOW before giving up.
+/// An overflow returns immediately (it does not wait out the timeout), so retrying
+/// is cheap, and it only means the driver's buffer filled and some samples were
+/// dropped -- the stream itself is still alive.
+const RX_OVERFLOW_RETRIES: u32 = 4;
+
+/// Minimum interval between warnings about recoverable RX errors.
+const RX_RECOVERABLE_LOG_INTERVAL: std::time::Duration = std::time::Duration::from_secs(5);
+
+/// Lowest sample rate we accept from the device readback. The DSP derives its
+/// FCFB size from it (fft_size = fs/500) and soapy_time divides by it, so a
+/// degenerate readback (0, or a driver that does not implement the getter)
+/// turns into a zero-size rustfft panic or a failed assert far from the cause.
+/// A single 25 kHz TETRA carrier cannot live below this anyway.
+const MIN_SAMPLE_RATE: f64 = 100e3;
+
+/// Overflow and timeout mean "samples were lost" or "nothing arrived in time",
+/// not "the device is gone": the caller can resync and carry on with the next tick.
+/// Anything else (corruption, stream error, an unplugged radio) is a real failure.
+fn is_recoverable_rx_error(code: soapysdr::ErrorCode) -> bool {
+    matches!(code, soapysdr::ErrorCode::Overflow | soapysdr::ErrorCode::Timeout)
+}
+
+/// Reject a nonsensical sample rate right after the device readback, where we
+/// still know which direction it came from, instead of letting it blow up
+/// downstream in the FFT planner or a timing assert.
+fn check_sample_rate(direction: &str, fs: f64) -> Result<(), soapysdr::Error> {
+    if !fs.is_finite() || fs < MIN_SAMPLE_RATE {
+        let message = format!(
+            "SDR reported an unusable {direction} sample rate of {fs} Hz (minimum {MIN_SAMPLE_RATE} Hz). \
+             The driver may not support the configured rate or may not implement the rate readback; \
+             set an explicit sample rate the hardware supports in [phy_io.soapysdr]."
+        );
+        tracing::error!("{}", message);
+        return Err(soapysdr::Error {
+            code: soapysdr::ErrorCode::Other,
+            message,
+        });
+    }
+    Ok(())
+}
 
 /// It is annoying to repeat error handling so do that in a macro.
 /// ? could be used but then it could not print which SoapySDR call failed.
@@ -109,6 +158,14 @@ impl SoapyIo {
                 dev.set_sample_rate(soapysdr::Direction::Tx, tx_ch, sdr_settings.fs)
             );
             tx_fs = soapycheck!("get TX sample rate", dev.sample_rate(soapysdr::Direction::Tx, tx_ch));
+        }
+
+        // Validate the readbacks before anything derives FFT sizes or timing from them.
+        if rx_enabled {
+            check_sample_rate("RX", rx_fs)?;
+        }
+        if tx_enabled {
+            check_sample_rate("TX", tx_fs)?;
         }
 
         if rx_enabled {
@@ -184,19 +241,57 @@ impl SoapyIo {
             rx_next_count: 0,
             prev_time_ns: -1,
             use_get_hardware_time: sdr_settings.use_get_hardware_time,
+            rx_recoverable_errors: 0,
+            rx_recoverable_next_log: std::time::Instant::now(),
             dev,
             rx,
             tx,
         })
     }
 
+    /// Log a recoverable RX stream error, rate-limited so a burst of overflows
+    /// cannot flood the log (or steal time from the PHY thread doing so).
+    fn note_recoverable_rx_error(&mut self, what: &str, count: u64) {
+        self.rx_recoverable_errors += count;
+        let now = std::time::Instant::now();
+        if now >= self.rx_recoverable_next_log {
+            self.rx_recoverable_next_log = now + RX_RECOVERABLE_LOG_INTERVAL;
+            tracing::warn!(
+                "SoapySDR: recoverable RX {} ({} total since start). Samples were lost, the stream continues.",
+                what,
+                self.rx_recoverable_errors
+            );
+        } else {
+            tracing::debug!("SoapySDR: recoverable RX {}", what);
+        }
+    }
+
     pub fn receive(&mut self, buffer: &mut [StreamType]) -> Result<RxResult, RxTxDevError> {
         if let Some(rx) = &mut self.rx {
-            // RX is enabled
-            match rx.read(&mut [buffer], 1000000) {
-                Ok(len) => {
+            // RX is enabled.
+            // An overflow ('O') is routine on a loaded RPi + LimeSDR: the driver's buffer
+            // filled and some samples were dropped, but the device is fine and the read
+            // returns immediately, so retry it a few times rather than losing the timeslot.
+            // Whatever was dropped shows up as a timestamp jump in the read that succeeds,
+            // and the lost-sample resync in receive_block takes it from there.
+            let mut overflows = 0u32;
+            let read = loop {
+                match rx.read(&mut [&mut *buffer], 1000000) {
+                    // Read the timestamp here, while the stream is still borrowed.
+                    Ok(len) => break Ok((len, rx.time_ns())),
+                    Err(err) if err.code == soapysdr::ErrorCode::Overflow && overflows < RX_OVERFLOW_RETRIES => {
+                        overflows += 1;
+                    }
+                    Err(err) => break Err(err),
+                }
+            };
+            if overflows > 0 {
+                self.note_recoverable_rx_error("overflow", overflows as u64);
+            }
+
+            match read {
+                Ok((len, time)) => {
                     // Get timestamp, set initial time if not yet set
-                    let time = rx.time_ns();
                     // rust-soapysdr does not let us if a timestamp was available
                     // so we have to guess by checking whether it has changed from its previous value.
                     let timestamp_available = time != self.prev_time_ns;
@@ -241,7 +336,16 @@ impl SoapyIo {
 
                     Ok(RxResult { len, count })
                 }
-                Err(_) => Err(RxTxDevError::RxReadError),
+                Err(err) => {
+                    // Still recoverable at the caller level -- it skips this tick and
+                    // resyncs on the next one. Only a genuine device problem is loud.
+                    if is_recoverable_rx_error(err.code) {
+                        self.note_recoverable_rx_error(&format!("{:?} (retries exhausted)", err.code), 1);
+                    } else {
+                        tracing::error!("SoapySDR: RX read failed: {}", err);
+                    }
+                    Err(RxTxDevError::RxReadError)
+                }
             }
         } else {
             // RX is disabled

--- a/crates/tetra-entities/src/phy/phy_bs.rs
+++ b/crates/tetra-entities/src/phy/phy_bs.rs
@@ -33,6 +33,26 @@ pub struct PhyBs<D: RxTxDev> {
     rxtxdev: D,
 
     tick: u64,
+
+    /// Next time a device/file error may be logged at warn level. These fire per
+    /// timeslot (~70/s), so an unfiltered warning would bury the journal.
+    err_log_next: std::time::Instant,
+}
+
+/// Minimum interval between warnings about a failing timeslot.
+const ERR_LOG_INTERVAL: std::time::Duration = std::time::Duration::from_secs(5);
+
+/// True if a recurring error may be logged at warn level now. Callers log at debug
+/// otherwise, so nothing is lost when tracing is turned up. Takes the deadline by
+/// reference rather than &mut self so it can be called while the RX/TX device is borrowed.
+fn may_warn(next: &mut std::time::Instant) -> bool {
+    let now = std::time::Instant::now();
+    if now >= *next {
+        *next = now + ERR_LOG_INTERVAL;
+        true
+    } else {
+        false
+    }
 }
 
 impl<D: RxTxDev> PhyBs<D> {
@@ -68,6 +88,7 @@ impl<D: RxTxDev> PhyBs<D> {
             ul_input_file,
             rxtxdev,
             tick: 0,
+            err_log_next: std::time::Instant::now(),
         }
     }
 
@@ -184,7 +205,15 @@ impl<D: RxTxDev> PhyBs<D> {
     fn build_dl_burst(&mut self, prim: tetra_saps::tp::TpUnitdataReqSlot) -> Option<[u8; TIMESLOT_TYPE4_BITS]> {
         let mut dl_burst = [0u8; TIMESLOT_TYPE4_BITS];
         if let Some(dl_input_file) = &mut self.dl_input_file {
-            dl_input_file.read_block(&mut dl_burst).expect("Failed to read dl_input_file data");
+            if let Err(e) = dl_input_file.read_block(&mut dl_burst) {
+                // Replay is a testing mode; a bad input file must not take the cell down.
+                if may_warn(&mut self.err_log_next) {
+                    tracing::warn!("PHY: failed to read dl_input_file ({:?}), dropping burst", e);
+                } else {
+                    tracing::debug!("PHY: failed to read dl_input_file ({:?}), dropping burst", e);
+                }
+                return None;
+            }
             return Some(dl_burst);
         }
 
@@ -273,7 +302,21 @@ impl<D: RxTxDev> PhyBs<D> {
             }
         }
 
-        let rx = self.rxtxdev.rxtx_timeslot(&tx_slots).expect("Got error from rxtx_timeslot");
+        // A failed timeslot must never unwind: everything runs on one thread with no
+        // catch_unwind, so a panic here kills the whole cell and systemd crash-loops it.
+        // An RX overflow on a loaded RPi + LimeSDR is an everyday event -- drop this
+        // timeslot's RX and let the next tick resync. TX has already been queued above.
+        let rx = match self.rxtxdev.rxtx_timeslot(&tx_slots) {
+            Ok(rx) => rx,
+            Err(e) => {
+                if may_warn(&mut self.err_log_next) {
+                    tracing::warn!(ts=%self.dltime, "rxtx_timeslot failed ({:?}), skipping this timeslot", e);
+                } else {
+                    tracing::debug!(ts=%self.dltime, "rxtx_timeslot failed ({:?}), skipping this timeslot", e);
+                }
+                return;
+            }
+        };
 
         for rx_slot in rx {
             if let Some(rx_slot) = rx_slot {

--- a/crates/tetra-entities/src/umac/subcomp/bs_defrag.rs
+++ b/crates/tetra-entities/src/umac/subcomp/bs_defrag.rs
@@ -1,11 +1,17 @@
 use std::collections::HashMap;
 
-use tetra_core::{BitBuffer, TdmaTime, TetraAddress, Todo};
+use tetra_core::{BitBuffer, TdmaTime, TetraAddress, Todo, multiframes};
 
 use crate::umac::subcomp::defrag::{DefragBuffer, DefragBufferState};
 
 const DEFRAG_BUF_MAX_LEN: usize = 4096;
-const DEFRAG_TS_BEFORE_TIMEOUT: i32 = 10 * 4; // TODO check documentation. 10 frames.
+/// One multiframe. A granting delay may push the next fragment up to 13 opportunities
+/// (~13 frames) out, so anything shorter can drop a legitimately slow burst mid-reassembly.
+const DEFRAG_TS_BEFORE_TIMEOUT: i32 = multiframes!(1);
+/// Max concurrent reassembly contexts per timeslot. The uplink schedule is 18 frames deep,
+/// so a handful of MSes can legitimately be reassembling at once; the cap only bounds the
+/// map against an MS (or attacker) starting bursts it never finishes.
+const DEFRAG_MAX_CONTEXTS_PER_TS: usize = 32;
 
 /// Defragmenter suitable for BS use
 /// Maintains a set of DefragBuffers per timeslot, indexed by SSI.
@@ -27,14 +33,18 @@ impl BsDefrag {
         }
     }
 
+    /// Drops reassembly contexts that have gone quiet. Called every tick from the UMAC.
     pub fn age_buffers(&mut self, t: TdmaTime) {
         for map in &mut self.buffers {
-            for buffer in map.values_mut() {
-                if buffer.state != DefragBufferState::Inactive && t.diff(buffer.t_last) > DEFRAG_TS_BEFORE_TIMEOUT {
-                    tracing::info!("defrag_buffer for {} timed out", buffer.t_last.t);
-                    buffer.reset();
+            // Remove the key, don't just reset the buffer: uplink SSIs are attacker-chosen,
+            // so leaving a reset entry behind still lets the map grow without bound.
+            map.retain(|ssi, buffer| {
+                let stale = t.diff(buffer.t_last) > DEFRAG_TS_BEFORE_TIMEOUT;
+                if stale {
+                    tracing::debug!("defrag_buffer for ssi {} last seen {} timed out, dropping", ssi, buffer.t_last);
                 }
-            }
+                !stale
+            });
         }
     }
 
@@ -78,6 +88,17 @@ impl BsDefrag {
             buf.num_frags,
             buf.buffer.dump_bin()
         );
+
+        // Bound the number of concurrent contexts per timeslot, evicting the least recently
+        // fed one. Aging alone is not enough: a flood of starts with a rotating SSI can add
+        // thousands of entries within a single timeout window.
+        while self.buffers[ts].len() >= DEFRAG_MAX_CONTEXTS_PER_TS {
+            let Some(oldest) = self.buffers[ts].iter().max_by_key(|(_, b)| t.diff(b.t_last)).map(|(k, _)| *k) else {
+                break;
+            };
+            tracing::warn!("defrag_buffer: ts {} at capacity, evicting oldest context ssi {}", t.t, oldest);
+            self.buffers[ts].remove(&oldest);
+        }
 
         self.buffers[ts].insert(ssi, buf);
     }

--- a/crates/tetra-entities/src/umac/subcomp/bs_sched.rs
+++ b/crates/tetra-entities/src/umac/subcomp/bs_sched.rs
@@ -36,6 +36,10 @@ pub const MACSCHED_TX_AHEAD: usize = 1;
 // We schedule up to this many frames ahead
 pub const MACSCHED_NUM_FRAMES: usize = 18;
 
+/// Largest granting delay representable in the 4-bit basic slot granting delay field
+/// (EN 300 392-2 cl. 21.5.6); 14 and 15 are reserved codes.
+pub const MAX_GRANTING_DELAY_OPPORTUNITIES: usize = 13;
+
 const NULL_PDU_LEN_BITS: usize = 16;
 
 pub const SCH_HD_CAP: usize = 124;
@@ -464,6 +468,19 @@ impl BsChannelScheduler {
 
         // If found, reserve the slots and return a BasicSlotgrant + optional usage_marker.
         if let Some((skips, grant_timestamps)) = grant_op {
+            // Granting delay is a 4-bit field with valid N of 1..13 (EN 300 392-2 cl. 21.5.6):
+            // 14/15 are reserved codes and >=16 truncates. Telling the MS a wrong transmit time
+            // is worse than not granting, so defer -- the MS repeats its capacity request.
+            if skips > MAX_GRANTING_DELAY_OPPORTUNITIES {
+                tracing::warn!(
+                    "ul_process_cap_req: grant for {} would need a granting delay of {} opportunities (max {}), deferring",
+                    addr,
+                    skips,
+                    MAX_GRANTING_DELAY_OPPORTUNITIES
+                );
+                return None;
+            }
+
             // For multi-slot full grants, allocate a usage marker. We do this
             // BEFORE reserving so the marker can be embedded in the schedule.
             // Single-slot or half-slot grants don't need a marker — the MS

--- a/crates/tetra-entities/src/umac/umac_bs.rs
+++ b/crates/tetra-entities/src/umac/umac_bs.rs
@@ -51,7 +51,8 @@ pub struct UmacBs {
     endpoint_id: u32,
 
     /// Subcomponents
-    defrag: BsDefrag,
+    /// Uplink reassembly contexts. Public access is used only by testing code
+    pub defrag: BsDefrag,
     /// Pending STCH MAC-DATA spanning block1+block2 (length_ind=0b111110), keyed by timeslot.
     pending_stch: Option<PendingStch>,
     // event_label_store: EventLabelStore,
@@ -1054,7 +1055,8 @@ impl UmacBs {
             return;
         };
         if let Some(_aie_info) = self.defrag.get_aie_info(slot_owner, msg_dltime) {
-            unimplemented!("rx_mac_end_ul: Encryption not supported");
+            unimplemented_log!("rx_mac_end_ul: Encryption not supported");
+            return;
         }
 
         // Insert last fragment and retrieve finalized block
@@ -1181,7 +1183,8 @@ impl UmacBs {
             return;
         };
         if let Some(_aie_info) = self.defrag.get_aie_info(slot_owner, msg_dltime) {
-            unimplemented!("rx_mac_end_hu: Encryption not supported");
+            unimplemented_log!("rx_mac_end_hu: Encryption not supported");
+            return;
         }
 
         // Insert last fragment and retrieve finalized block
@@ -2126,7 +2129,7 @@ impl TetraEntityTrait for UmacBs {
                 self.rx_tlmb_prim(queue, message);
             }
             Sap::TlmcSap => {
-                unimplemented!();
+                unimplemented_log!("rx_prim: TLMC SAP not implemented -- dropping message");
             }
             Sap::Control => {
                 self.rx_control(queue, message);
@@ -2141,6 +2144,11 @@ impl TetraEntityTrait for UmacBs {
     fn tick_start(&mut self, queue: &mut MessageQueue, ts: TdmaTime) {
         self.dltime = ts;
         self.refresh_system_wide_services();
+
+        // Expire stale uplink reassembly contexts. Without this the defrag map only ever
+        // grows: entries are added per uplink SSI on a fragmentation start and removed only
+        // by a matching MAC-END, which an MS (or an attacker) is free to never send.
+        self.defrag.age_buffers(ts);
 
         if self.channel_scheduler.cur_dltime != ts && self.channel_scheduler.cur_dltime == (TdmaTime { t: 0, f: 0, m: 0, h: 0 }) {
             // Upon start of the system, we need to set the dl time for the channel scheduler

--- a/crates/tetra-entities/tests/test_cmce_bs.rs
+++ b/crates/tetra-entities/tests/test_cmce_bs.rs
@@ -12,9 +12,9 @@ use tetra_pdus::cmce::enums::{
 };
 use tetra_pdus::cmce::fields::basic_service_information::BasicServiceInformation;
 use tetra_pdus::cmce::pdus::{
-    d_connect::DConnect, d_connect_acknowledge::DConnectAcknowledge, d_release::DRelease, d_setup::DSetup, d_tx_ceased::DTxCeased,
-    d_tx_granted::DTxGranted, u_connect::UConnect, u_disconnect::UDisconnect, u_setup::USetup, u_tx_ceased::UTxCeased,
-    u_tx_demand::UTxDemand,
+    d_call_restore::DCallRestore, d_connect::DConnect, d_connect_acknowledge::DConnectAcknowledge, d_release::DRelease, d_setup::DSetup,
+    d_tx_ceased::DTxCeased, d_tx_granted::DTxGranted, u_call_restore::UCallRestore, u_connect::UConnect, u_disconnect::UDisconnect,
+    u_setup::USetup, u_tx_ceased::UTxCeased, u_tx_demand::UTxDemand,
 };
 use tetra_saps::control::brew::{BrewSubscriberAction, MmSubscriberUpdate};
 use tetra_saps::control::call_control::{CallControl, NetworkCircuitCall};
@@ -321,6 +321,27 @@ fn build_u_disconnect_msg(sender_issi: u32, call_id: u16) -> SapMsg {
 
     let mut sdu = BitBuffer::new_autoexpand(80);
     u_disconnect.to_bitbuf(&mut sdu).expect("Failed to serialize UDisconnect");
+    sdu.seek(0);
+    lcmc_ind(sender_issi, sdu)
+}
+
+/// Helper: build a U-CALL RESTORE for `call_id`, optionally asking for the floor.
+fn build_u_call_restore_msg(sender_issi: u32, call_id: u16, other_party_ssi: u32, request_to_transmit: bool) -> SapMsg {
+    let u_call_restore = UCallRestore {
+        call_identifier: call_id,
+        request_to_transmit_send_data: request_to_transmit,
+        other_party_type_identifier: 1, // SSI
+        other_party_short_number_address: None,
+        other_party_ssi: Some(other_party_ssi as u64),
+        other_party_extension: None,
+        basic_service_information: None,
+        facility: None,
+        dm_ms_address: None,
+        proprietary: None,
+    };
+
+    let mut sdu = BitBuffer::new_autoexpand(80);
+    u_call_restore.to_bitbuf(&mut sdu).expect("Failed to serialize UCallRestore");
     sdu.seek(0);
     lcmc_ind(sender_issi, sdu)
 }
@@ -2441,4 +2462,131 @@ mod ss_dgna_tests {
             "an SS-DGNA ASSIGN ACK must be consumed, not answered with D-CMCE-FUNCTION-NOT-SUPPORTED"
         );
     }
+}
+
+/// Regression: a group U-CALL RESTORE that asks for the floor flips the call back to Transmitting,
+/// so it must also tell UMAC (FloorGranted) — that is what arms the UL-inactivity watchdog. Without
+/// it a restored talker that goes silent pins the traffic timeslot until the absolute call time-out
+/// (never, for a duplex/Infinite call), and repeats exhaust every traffic channel on the cell.
+#[test]
+fn test_group_call_restore_grant_notifies_umac_floor_grant() {
+    debug::setup_logging_verbose();
+
+    let dltime = TdmaTime { h: 0, m: 1, f: 1, t: 1 };
+    let mut test = ComponentTest::new(StackMode::Bs, Some(dltime));
+    test.populate_entities(
+        vec![TetraEntity::Cmce],
+        vec![TetraEntity::Mle, TetraEntity::Umac, TetraEntity::Brew],
+    );
+
+    register_subscriber(&mut test, TEST_ISSI, TEST_GSSI);
+
+    test.submit_message(build_u_setup_msg(TEST_ISSI, TEST_GSSI));
+    test.run_stack(Some(1));
+    let setup_msgs = test.dump_sinks();
+    let call_id = first_d_setup_call_id(&setup_msgs, TEST_GSSI);
+
+    // The talking MS restores the call after a break and asks to keep transmitting.
+    test.submit_message(build_u_call_restore_msg(TEST_ISSI, call_id, TEST_GSSI, true));
+    test.run_stack(Some(1));
+    let msgs = test.dump_sinks();
+
+    let (mut sdu, _) = find_lcmc_req(&msgs, TEST_ISSI, CmcePduTypeDl::DCallRestore).expect("Expected D-CALL RESTORE to the restoring MS");
+    let d_call_restore = DCallRestore::from_bitbuf(&mut sdu).expect("Failed to parse DCallRestore");
+    assert_eq!(d_call_restore.call_identifier, call_id);
+    assert_eq!(
+        d_call_restore.transmission_grant,
+        TransmissionGrant::Granted.into_raw() as u8,
+        "the restoring speaker should get the floor back"
+    );
+
+    assert!(
+        msgs.iter().any(|msg| msg.dest == TetraEntity::Umac
+            && matches!(
+                &msg.msg,
+                SapMsgInner::CmceCallControl(CallControl::FloorGranted { source_issi, dest_gssi, .. })
+                    if *source_issi == TEST_ISSI && *dest_gssi == TEST_GSSI
+            )),
+        "a group call restore that grants the floor must send FloorGranted to UMAC, else the UL-inactivity timer never arms"
+    );
+}
+
+/// Regression: an individual simplex U-CALL RESTORE must not hand the floor to a party while the
+/// peer still holds it — two simultaneous transmitters and a stale floor holder the UL-inactivity
+/// watchdog would never cease.
+#[test]
+fn test_individual_restore_does_not_steal_floor_from_peer() {
+    debug::setup_logging_verbose();
+
+    let calling_issi = 1000001;
+    let called_issi = 1000002;
+    // After connect the calling MS holds the floor (see the initial-floor test above).
+    let (mut test, call_id, _msgs) = connected_simplex_individual_call(calling_issi, called_issi);
+
+    // The other party restores and asks to transmit while the caller is still talking.
+    test.submit_message(build_u_call_restore_msg(called_issi, call_id, calling_issi, true));
+    test.run_stack(Some(1));
+    let msgs = test.dump_sinks();
+
+    let (mut sdu, _) =
+        find_lcmc_req(&msgs, called_issi, CmcePduTypeDl::DCallRestore).expect("Expected D-CALL RESTORE to the restoring MS");
+    let d_call_restore = DCallRestore::from_bitbuf(&mut sdu).expect("Failed to parse DCallRestore");
+    assert_eq!(d_call_restore.call_identifier, call_id);
+    assert_eq!(
+        d_call_restore.transmission_grant,
+        TransmissionGrant::GrantedToOtherUser.into_raw() as u8,
+        "restoring while the peer holds the floor must not grant transmission"
+    );
+}
+
+/// Regression: a second U-SETUP to a GSSI that already has an active call is LATE ENTRY
+/// (ETSI EN 300 392-2 clause 14, one call per group), not a second call. Allocating a parallel
+/// call burns another scarce traffic timeslot and orphans one of the two GSSI-keyed circuits.
+#[test]
+fn test_second_group_setup_to_active_gssi_is_late_entry() {
+    debug::setup_logging_verbose();
+
+    let dltime = TdmaTime { h: 0, m: 1, f: 1, t: 1 };
+    let mut test = ComponentTest::new(StackMode::Bs, Some(dltime));
+    test.populate_entities(
+        vec![TetraEntity::Cmce],
+        vec![TetraEntity::Mle, TetraEntity::Umac, TetraEntity::Brew],
+    );
+
+    let joiner_issi = TEST_ISSI + 1;
+    register_subscriber(&mut test, TEST_ISSI, TEST_GSSI);
+    register_subscriber(&mut test, joiner_issi, TEST_GSSI);
+
+    test.submit_message(build_u_setup_msg(TEST_ISSI, TEST_GSSI));
+    test.run_stack(Some(1));
+    let setup_msgs = test.dump_sinks();
+    let call_id = first_d_setup_call_id(&setup_msgs, TEST_GSSI);
+    let free_slots_after_first = test.config.state_read().timeslot_alloc.free_count();
+
+    // Second U-SETUP from another member of the same, already-active group.
+    test.submit_message(build_u_setup_msg(joiner_issi, TEST_GSSI));
+    test.run_stack(Some(1));
+    let msgs = test.dump_sinks();
+
+    assert_eq!(
+        test.config.state_read().timeslot_alloc.free_count(),
+        free_slots_after_first,
+        "late entry must not allocate a second traffic timeslot for the same GSSI"
+    );
+    let opened = msgs
+        .iter()
+        .filter(|m| matches!(&m.msg, SapMsgInner::CmceCallControl(CallControl::Open(_))))
+        .count();
+    assert_eq!(opened, 0, "late entry must not open a second circuit");
+
+    // The joiner is attached to the ongoing call: same call_id, and it does not own the call.
+    let (mut sdu, _) = find_lcmc_req(&msgs, joiner_issi, CmcePduTypeDl::DConnect).expect("Expected D-CONNECT to the late joiner");
+    let d_connect = DConnect::from_bitbuf(&mut sdu).expect("Failed to parse DConnect");
+    assert_eq!(d_connect.call_identifier, call_id, "the joiner must be attached to the ongoing call");
+    assert!(!d_connect.call_ownership, "a late joiner does not take call ownership");
+    assert_eq!(
+        d_connect.transmission_grant,
+        TransmissionGrant::GrantedToOtherUser,
+        "the ongoing speaker keeps the floor"
+    );
 }

--- a/crates/tetra-entities/tests/test_mm_bs.rs
+++ b/crates/tetra-entities/tests/test_mm_bs.rs
@@ -11,6 +11,7 @@ use tetra_pdus::mm::enums::location_update_type::LocationUpdateType;
 use tetra_pdus::mm::enums::mm_pdu_type_dl::MmPduTypeDl;
 use tetra_pdus::mm::pdus::d_attach_detach_group_identity::DAttachDetachGroupIdentity;
 use tetra_pdus::mm::pdus::d_mm_status::DMmStatus;
+use tetra_pdus::mm::pdus::u_itsi_detach::UItsiDetach;
 use tetra_pdus::mm::pdus::u_location_update_demand::ULocationUpdateDemand;
 use tetra_saps::control::brew::BrewSubscriberAction;
 use tetra_saps::lmm::LmmMleUnitdataInd;
@@ -26,8 +27,14 @@ use crate::common::ComponentTest;
 /// (RoamingLocationUpdating) as if it arrived from `issi`. After this the MS is "known" and
 /// eligible for DGNA.
 fn register_terminal(test: &mut ComponentTest, issi: u32) {
+    submit_location_update(test, issi, 0, LocationUpdateType::RoamingLocationUpdating);
+}
+
+/// Submit a U-LOCATION-UPDATE-DEMAND of `lu_type` as if it arrived from `issi` on L2 `handle`.
+/// The handle is what a teardown is bound to, so tests can forge a mismatched L2 context.
+fn submit_location_update(test: &mut ComponentTest, issi: u32, handle: u32, lu_type: LocationUpdateType) {
     let demand = ULocationUpdateDemand {
-        location_update_type: LocationUpdateType::RoamingLocationUpdating,
+        location_update_type: lu_type,
         request_to_append_la: false,
         cipher_control: false,
         ciphering_parameters: None,
@@ -47,7 +54,7 @@ fn register_terminal(test: &mut ComponentTest, issi: u32) {
     sdu.seek(0);
     let prim = LmmMleUnitdataInd {
         sdu,
-        handle: 0,
+        handle,
         received_address: TetraAddress {
             ssi_type: SsiType::Issi,
             ssi: issi,
@@ -60,6 +67,66 @@ fn register_terminal(test: &mut ComponentTest, issi: u32) {
         msg: SapMsgInner::LmmMleUnitdataInd(prim),
     });
     test.run_stack(Some(2));
+}
+
+/// Submit a U-ITSI-DETACH claiming to come from `issi` on L2 `handle`. Uplink is unauthenticated,
+/// so this is exactly what an attacker can put on the air with a victim's (on-air observable) ISSI.
+fn submit_itsi_detach(test: &mut ComponentTest, issi: u32, handle: u32) {
+    let detach = UItsiDetach {
+        address_extension: None,
+        proprietary: None,
+    };
+    let mut sdu = BitBuffer::new_autoexpand(16);
+    detach.to_bitbuf(&mut sdu).expect("serialize U-ITSI-DETACH");
+    sdu.seek(0);
+    let prim = LmmMleUnitdataInd {
+        sdu,
+        handle,
+        received_address: TetraAddress {
+            ssi_type: SsiType::Issi,
+            ssi: issi,
+        },
+    };
+    test.submit_message(SapMsg {
+        sap: Sap::LmmSap,
+        src: TetraEntity::Mle,
+        dest: TetraEntity::Mm,
+        msg: SapMsgInner::LmmMleUnitdataInd(prim),
+    });
+    test.run_stack(Some(2));
+}
+
+/// Pull (addressed ISSI, reject cause) of the first D-LOCATION-UPDATE-REJECT out of a batch of
+/// captured MLE messages. Decoded by hand off the fixed leading fields (pdu type / location update
+/// type / reject cause) â€” the PDU's own `from_bitbuf` is an `unimplemented!()` stub.
+fn find_location_update_reject(msgs: &[SapMsg]) -> Option<(u32, u8)> {
+    let want = MmPduTypeDl::DLocationUpdateReject.into_raw();
+    for m in msgs {
+        if let SapMsgInner::LmmMleUnitdataReq(ref req) = m.msg {
+            let mut sdu = BitBuffer::from_bitstr(&req.sdu.to_bitstr());
+            if sdu.read_field(4, "pdu_type").is_ok_and(|t| t == want) {
+                sdu.read_field(3, "location_update_type").ok()?;
+                let cause = sdu.read_field(5, "reject_cause").ok()? as u8;
+                return Some((req.address.ssi, cause));
+            }
+        }
+    }
+    None
+}
+
+/// True if the batch carries a Deregister or Deaffiliate for `issi` â€” i.e. MM tore that
+/// subscriber down toward CMCE/Brew.
+fn tore_down(msgs: &[SapMsg], issi: u32) -> bool {
+    msgs.iter().any(|m| match &m.msg {
+        SapMsgInner::MmSubscriberUpdate(u) => {
+            u.issi == issi
+                && matches!(
+                    u.action,
+                    BrewSubscriberAction::Deregister | BrewSubscriberAction::Deaffiliate
+                )
+        }
+        _ => false,
+    })
 }
 
 /// Pull the first MM->CMCE `CmceSsDgnaAssign` SAP request out of a batch of captured messages.
@@ -212,6 +279,302 @@ fn test_reactive_recovery_rate_limits_repeat_bursts() {
     assert!(
         find_location_update_command(&test.dump_sinks()).is_none(),
         "a repeat burst inside the cooldown must not re-key the same ISSI"
+    );
+}
+
+/// Forged teardown: a U-ITSI-DETACH whose source is NOT registered must not tear anything down.
+/// ISSIs are observable on air and the uplink is unauthenticated, so a detach carrying someone
+/// else's ISSI is trivially forgeable; honouring it knocked the claimed radio off Brew, local
+/// call/SDS delivery and the dashboard, and a replay kept it off.
+#[test]
+fn test_forged_itsi_detach_for_unregistered_source_is_ignored() {
+    debug::setup_logging_verbose();
+    const VICTIM: u32 = 2260801;
+    const STRANGER: u32 = 2260802;
+
+    let mut test = ComponentTest::new(StackMode::Bs, Some(TdmaTime::default()));
+    test.populate_entities(vec![], vec![TetraEntity::Mle, TetraEntity::Cmce]);
+    let mm = MmBs::new(test.get_shared_config(), None, None);
+    test.register_entity(mm);
+
+    register_terminal(&mut test, VICTIM);
+    let _ = test.dump_sinks();
+
+    // A detach claiming an ISSI that never registered here.
+    submit_itsi_detach(&mut test, STRANGER, 0);
+    let msgs = test.dump_sinks();
+    assert!(!tore_down(&msgs, STRANGER), "a detach from an unregistered source must not tear anything down");
+    assert!(
+        test.config.state_read().subscribers.is_registered(VICTIM),
+        "the registered radio must be untouched"
+    );
+}
+
+/// The teardown is bound to the L2 context the registration used: a detach arriving on a different
+/// handle than the one the radio registered on is refused.
+#[test]
+fn test_itsi_detach_on_mismatched_l2_context_is_ignored() {
+    debug::setup_logging_verbose();
+    const VICTIM: u32 = 2260803;
+
+    let mut test = ComponentTest::new(StackMode::Bs, Some(TdmaTime::default()));
+    test.populate_entities(vec![], vec![TetraEntity::Mle, TetraEntity::Cmce]);
+    let mm = MmBs::new(test.get_shared_config(), None, None);
+    test.register_entity(mm);
+
+    submit_location_update(&mut test, VICTIM, 7, LocationUpdateType::RoamingLocationUpdating);
+    let _ = test.dump_sinks();
+    assert!(test.config.state_read().subscribers.is_registered(VICTIM), "precondition: registered");
+
+    submit_itsi_detach(&mut test, VICTIM, 0); // registered on handle 7, detach claims handle 0
+    let msgs = test.dump_sinks();
+    assert!(!tore_down(&msgs, VICTIM), "a detach on a foreign L2 context must not tear the radio down");
+    assert!(
+        test.config.state_read().subscribers.is_registered(VICTIM),
+        "the victim must stay registered"
+    );
+}
+
+/// The operator kill-switch: with `honour_unauthenticated_detach = false` even a well-formed
+/// detach from the registered radio itself is refused, because it cannot be authenticated.
+#[test]
+fn test_itsi_detach_refused_when_disabled_by_config() {
+    debug::setup_logging_verbose();
+    const VICTIM: u32 = 2260804;
+
+    let mut config = ComponentTest::get_default_test_config(StackMode::Bs);
+    config.security.honour_unauthenticated_detach = false;
+    let mut test = ComponentTest::from_config(config, Some(TdmaTime::default()));
+    test.populate_entities(vec![], vec![TetraEntity::Mle, TetraEntity::Cmce]);
+    let mm = MmBs::new(test.get_shared_config(), None, None);
+    test.register_entity(mm);
+
+    register_terminal(&mut test, VICTIM);
+    let _ = test.dump_sinks();
+
+    submit_itsi_detach(&mut test, VICTIM, 0);
+    let msgs = test.dump_sinks();
+    assert!(!tore_down(&msgs, VICTIM), "detach must not be honoured when the operator disabled it");
+    assert!(test.config.state_read().subscribers.is_registered(VICTIM));
+}
+
+/// A migrating U-LOCATION-UPDATE-DEMAND from a non-whitelisted ISSI must be rejected BEFORE any
+/// Brew/registry mutation. The whitelist check used to sit after the migration release, so a
+/// barred radio could still knock a registered subscriber down with a forged migration.
+#[test]
+fn test_migration_from_non_whitelisted_issi_tears_nothing_down() {
+    debug::setup_logging_verbose();
+    const ALLOWED: u32 = 2260805;
+    const BARRED: u32 = 2260806;
+
+    let mut config = ComponentTest::get_default_test_config(StackMode::Bs);
+    config.security.issi_whitelist = vec![ALLOWED, BARRED];
+    let mut test = ComponentTest::from_config(config, Some(TdmaTime::default()));
+    test.populate_entities(vec![], vec![TetraEntity::Mle, TetraEntity::Cmce]);
+    let mm = MmBs::new(test.get_shared_config(), None, None);
+    test.register_entity(mm);
+
+    register_terminal(&mut test, ALLOWED);
+    let _ = test.dump_sinks();
+
+    // Drop BARRED from the whitelist at runtime, then have it claim a migration.
+    test.config.state_write().issi_whitelist_override = Some(vec![ALLOWED]);
+    submit_location_update(&mut test, BARRED, 0, LocationUpdateType::MigratingLocationUpdating);
+    let msgs = test.dump_sinks();
+
+    assert!(!tore_down(&msgs, BARRED), "a barred ISSI must not mutate any state");
+    let (_, cause) = find_location_update_reject(&msgs).expect("a barred ISSI must be rejected");
+    assert_eq!(
+        cause,
+        tetra_pdus::mm::enums::reject_cause::RejectCause::ItsiAtsiUnknown as u8,
+        "the whitelist branch must win over the migration branch and use an access-control cause"
+    );
+    assert!(test.config.state_read().subscribers.is_registered(ALLOWED));
+}
+
+/// A whitelist-denied registration must carry an access-control cause, NOT "migration not
+/// supported" (12). The latter tells a conformant terminal it may attach to a DIFFERENT network,
+/// so a barred radio goes hunting for another cell instead of staying off, and the user never sees
+/// an access-denied.
+#[test]
+fn test_whitelist_reject_uses_access_control_cause() {
+    debug::setup_logging_verbose();
+    const ALLOWED: u32 = 2260807;
+    const BARRED: u32 = 2260808;
+
+    let mut config = ComponentTest::get_default_test_config(StackMode::Bs);
+    config.security.issi_whitelist = vec![ALLOWED];
+    let mut test = ComponentTest::from_config(config, Some(TdmaTime::default()));
+    test.populate_entities(vec![], vec![TetraEntity::Mle]);
+    let mm = MmBs::new(test.get_shared_config(), None, None);
+    test.register_entity(mm);
+
+    register_terminal(&mut test, BARRED);
+    let msgs = test.dump_sinks();
+
+    let (issi, cause) = find_location_update_reject(&msgs)
+        .unwrap_or_else(|| panic!("a non-whitelisted registration must be rejected, got {} msgs", msgs.len()));
+    assert_eq!(issi, BARRED);
+    assert_ne!(
+        cause,
+        tetra_pdus::mm::enums::reject_cause::RejectCause::MigrationNotSupported as u8,
+        "a barred radio must not be told migration is unsupported"
+    );
+    assert_eq!(
+        cause,
+        tetra_pdus::mm::enums::reject_cause::RejectCause::ItsiAtsiUnknown as u8
+    );
+    assert!(
+        !test.config.state_read().subscribers.is_registered(BARRED),
+        "a barred radio must never enter the subscriber registry"
+    );
+}
+
+/// The genuine migration path keeps "migration not supported" (12) so a real migrating terminal
+/// still knows to try the other network.
+#[test]
+fn test_migration_reject_keeps_migration_cause() {
+    debug::setup_logging_verbose();
+    const ROAMER: u32 = 2260809;
+
+    let mut test = ComponentTest::new(StackMode::Bs, Some(TdmaTime::default()));
+    test.populate_entities(vec![], vec![TetraEntity::Mle, TetraEntity::Cmce]);
+    let mm = MmBs::new(test.get_shared_config(), None, None);
+    test.register_entity(mm);
+
+    register_terminal(&mut test, ROAMER);
+    let _ = test.dump_sinks();
+
+    submit_location_update(&mut test, ROAMER, 0, LocationUpdateType::MigratingLocationUpdating);
+    let msgs = test.dump_sinks();
+
+    let (issi, cause) = find_location_update_reject(&msgs).expect("a migrating update must be rejected");
+    assert_eq!(issi, ROAMER);
+    assert_eq!(
+        cause,
+        tetra_pdus::mm::enums::reject_cause::RejectCause::MigrationNotSupported as u8
+    );
+}
+
+/// SHIP-BLOCKER regression: the client registry must stay bounded under an RF-unauthenticated
+/// registration flood. An attacker cycles the source ISSI across the 24-bit space; every distinct
+/// value used to add a permanent client + subscriber + dashboard entry, so days of uptime meant
+/// unbounded heap growth and an OOM-kill of the whole cell. A radio holding a group affiliation
+/// must survive the flood untouched.
+#[test]
+fn test_registration_flood_does_not_grow_the_registry() {
+    debug::setup_logging_verbose();
+    const MEMBER: u32 = 2260810;
+    const MEMBER_GSSI: u32 = 42;
+    const CAP: usize = 8;
+
+    let mut config = ComponentTest::get_default_test_config(StackMode::Bs);
+    config.security.max_registered_clients = CAP;
+    let mut test = ComponentTest::from_config(config, Some(TdmaTime::default()));
+    test.populate_entities(vec![], vec![TetraEntity::Mle, TetraEntity::Cmce]);
+    let (dispatcher, endpoint) = make_control_link();
+    let mm = MmBs::new(test.get_shared_config(), None, Some(endpoint));
+    test.register_entity(mm);
+
+    // A legitimate, affiliated member of the fleet.
+    register_terminal(&mut test, MEMBER);
+    dispatcher.send(ControlCommand::Dgna {
+        issi: MEMBER,
+        gssi: MEMBER_GSSI,
+        mnemonic: None,
+        attachment_mode: 0,
+        attach: true,
+    });
+    test.run_stack(Some(2));
+    let _ = test.dump_sinks();
+
+    // Flood: 200 distinct forged source ISSIs, each registering once.
+    for i in 0..200u32 {
+        register_terminal(&mut test, 3_000_000 + i);
+        let _ = test.dump_sinks();
+    }
+
+    let state = test.config.state_read();
+    let registered = state.subscribers.all_registered_issis().count();
+    assert!(
+        registered <= CAP,
+        "the registry must stay bounded by the {CAP} cap under a flood, holds {registered}"
+    );
+    assert!(
+        state.subscribers.is_registered(MEMBER),
+        "an affiliated member must never be evicted to make room for a flood"
+    );
+    assert!(
+        state.subscribers.attached_groups_of(MEMBER).contains(&MEMBER_GSSI),
+        "the member's affiliation must survive the flood"
+    );
+}
+
+/// The per-source-ISSI rate limit: one ISSI cannot churn the registry by re-registering in a loop.
+/// Beyond the configured budget the location update is dropped silently (answering would itself be
+/// an amplifier), so no ACCEPT comes back.
+#[test]
+fn test_registration_rate_limit_drops_repeat_flood_from_one_issi() {
+    debug::setup_logging_verbose();
+    const NOISY: u32 = 2260811;
+
+    let mut config = ComponentTest::get_default_test_config(StackMode::Bs);
+    config.security.registration_rate_limit_per_min = 3;
+    let mut test = ComponentTest::from_config(config, Some(TdmaTime::default()));
+    test.populate_entities(vec![], vec![TetraEntity::Mle]);
+    let mm = MmBs::new(test.get_shared_config(), None, None);
+    test.register_entity(mm);
+
+    // Burn the budget.
+    for _ in 0..3 {
+        register_terminal(&mut test, NOISY);
+        let _ = test.dump_sinks();
+    }
+    // The next one must produce no downlink at all.
+    register_terminal(&mut test, NOISY);
+    let msgs = test.dump_sinks();
+    assert!(
+        !msgs
+            .iter()
+            .any(|m| matches!(m.msg, SapMsgInner::LmmMleUnitdataReq(_))),
+        "a registration past the rate limit must be dropped, got {} downlink msg(s)",
+        msgs.len()
+    );
+}
+
+/// ETSI EN 300 392-2 cl. 16.9.2.2: the accept must preserve the accepted location update type.
+/// Answering an ItsiAttach with PeriodicLocationUpdating leaves radios that key attach-completion
+/// off the accept type believing the attach never completed.
+#[test]
+fn test_itsi_attach_accept_preserves_accept_type() {
+    debug::setup_logging_verbose();
+    const ATTACHER: u32 = 2260812;
+
+    let mut config = ComponentTest::get_default_test_config(StackMode::Bs);
+    config.cell.periodic_registration_secs = 300;
+    let mut test = ComponentTest::from_config(config, Some(TdmaTime::default()));
+    test.populate_entities(vec![], vec![TetraEntity::Mle]);
+    let mm = MmBs::new(test.get_shared_config(), None, None);
+    test.register_entity(mm);
+
+    submit_location_update(&mut test, ATTACHER, 0, LocationUpdateType::ItsiAttach);
+    let msgs = test.dump_sinks();
+
+    let want = MmPduTypeDl::DLocationUpdateAccept.into_raw();
+    let accept_type = msgs.iter().find_map(|m| {
+        let SapMsgInner::LmmMleUnitdataReq(ref req) = m.msg else {
+            return None;
+        };
+        let mut sdu = BitBuffer::from_bitstr(&req.sdu.to_bitstr());
+        if !sdu.read_field(4, "pdu_type").is_ok_and(|t| t == want) {
+            return None;
+        }
+        sdu.read_field(3, "location_update_accept_type").ok()
+    });
+    assert_eq!(
+        accept_type,
+        Some(LocationUpdateType::ItsiAttach.into_raw()),
+        "an ItsiAttach must be accepted as an ItsiAttach"
     );
 }
 

--- a/crates/tetra-entities/tests/test_umac_bs.rs
+++ b/crates/tetra-entities/tests/test_umac_bs.rs
@@ -4,6 +4,9 @@ use tetra_config::bluestation::StackMode;
 use tetra_core::Direction;
 use tetra_core::tetra_entities::TetraEntity;
 use tetra_core::{BitBuffer, Layer2Service, PhyBlockNum, Sap, SsiType, TdmaTime, TetraAddress, debug};
+use tetra_entities::umac::umac_bs::UmacBs;
+use tetra_pdus::umac::enums::basic_slotgrant_granting_delay::BasicSlotgrantGrantingDelay;
+use tetra_pdus::umac::enums::reservation_requirement::ReservationRequirement;
 use tetra_pdus::umac::pdus::mac_access::MacAccess;
 use tetra_pdus::umac::pdus::mac_resource::MacResource;
 use tetra_pdus::umac::pdus::mac_u_signal::MacUSignal;
@@ -988,4 +991,131 @@ fn test_stealing_large_sdu_fragments_without_panic() {
     test.run_stack(Some(8));
 
     tracing::info!("stealing large SDU fragmented across STCH half-slots without panic");
+}
+
+/// Number of reassembly contexts currently held by the BS defragmenter, across all timeslots.
+fn defrag_context_count(test: &mut ComponentTest) -> usize {
+    let umac = test
+        .router
+        .get_entity(TetraEntity::Umac)
+        .expect("umac registered")
+        .as_any_mut()
+        .downcast_mut::<UmacBs>()
+        .expect("entity is UmacBs");
+    umac.defrag.buffers.iter().map(|map| map.len()).sum()
+}
+
+/// Builds a MAC-ACCESS fragmentation start (no MAC-END will ever follow) for `ssi`,
+/// padded out to a SCH/HU block.
+fn frag_start_access(ssi: u32) -> SapMsg {
+    let addr = TetraAddress {
+        ssi,
+        ssi_type: SsiType::Issi,
+    };
+    let mut uplink = BitBuffer::new_autoexpand(92);
+    MacAccess {
+        fill_bits: false,
+        encrypted: false,
+        addr: Some(addr),
+        event_label: None,
+        length_ind: None,
+        frag_flag: Some(true),
+        reservation_req: Some(ReservationRequirement::Req1Subslot),
+    }
+    .to_bitbuf(&mut uplink);
+    uplink.write_bits(0, 56);
+    uplink.seek(0);
+
+    SapMsg {
+        sap: Sap::TmvSap,
+        src: TetraEntity::Lmac,
+        dest: TetraEntity::Umac,
+        msg: SapMsgInner::TmvUnitdataInd(TmvUnitdataInd {
+            carrier_num: MAIN_CARRIER,
+            pdu: uplink,
+            block_num: PhyBlockNum::Block1,
+            logical_channel: LogicalChannel::SchHu,
+            crc_pass: true,
+            scrambling_code: 864282631,
+            rssi_dbfs: f32::NEG_INFINITY,
+        }),
+    }
+}
+
+#[test]
+fn test_defrag_map_is_bounded_under_frag_start_flood() {
+    // An MS can start a fragmented uplink burst with any 24-bit SSI and never send the
+    // MAC-END. The defrag map must stay bounded and must drop the stale contexts again.
+    debug::setup_logging_verbose();
+
+    let dltime = TdmaTime { h: 0, m: 1, f: 1, t: 3 }; // uplink message time is ts1 (MCCH)
+    let mut test = ComponentTest::new(StackMode::Bs, Some(dltime));
+    test.populate_entities(vec![TetraEntity::Umac], vec![TetraEntity::Lmac]);
+
+    for i in 0..200u32 {
+        test.submit_message(frag_start_access(2200000 + i));
+    }
+    test.run_stack(Some(1));
+
+    let held = defrag_context_count(&mut test);
+    assert!(
+        held > 0 && held <= 32,
+        "defrag map must be capped per timeslot, holds {} contexts after 200 unfinished starts",
+        held
+    );
+
+    // Nothing more arrives: every context must age out and have its map key removed.
+    test.run_stack(Some(100));
+    assert_eq!(
+        defrag_context_count(&mut test),
+        0,
+        "stale reassembly contexts must be removed, not just reset"
+    );
+}
+
+#[test]
+fn test_granting_delay_never_encodes_reserved_or_truncated_code() {
+    // The granting delay is a 4-bit field, valid N 1..13 (EN 300 392-2 cl. 21.5.6).
+    // Fill the uplink schedule so the required delay runs past 13 and check that the BS
+    // never emits 14/15 (reserved) or a value that truncates.
+    debug::setup_logging_verbose();
+
+    let dltime = TdmaTime { h: 0, m: 1, f: 1, t: 1 };
+    let mut test = ComponentTest::new(StackMode::Bs, Some(dltime));
+    test.populate_entities(vec![TetraEntity::Umac], vec![TetraEntity::Lmac]);
+    test.run_stack(Some(1)); // let the scheduler adopt the current time
+
+    let umac = test
+        .router
+        .get_entity(TetraEntity::Umac)
+        .expect("umac registered")
+        .as_any_mut()
+        .downcast_mut::<UmacBs>()
+        .expect("entity is UmacBs");
+
+    let mut deferred = false;
+    for i in 0..18u32 {
+        let addr = TetraAddress {
+            ssi: 2300000 + i,
+            ssi_type: SsiType::Issi,
+        };
+        match umac
+            .channel_scheduler
+            .ul_process_cap_req(1, addr, &ReservationRequirement::Req1Slot)
+        {
+            Some((grant, _)) => match grant.granting_delay {
+                BasicSlotgrantGrantingDelay::CapAllocAtNextOpportunity => {}
+                BasicSlotgrantGrantingDelay::DelayNOpportunities(n) => {
+                    assert!((1..=13).contains(&n), "granting delay {} is outside the encodable range", n);
+                }
+                other => panic!("reserved granting delay code emitted: {}", other),
+            },
+            None => deferred = true,
+        }
+    }
+
+    assert!(
+        deferred,
+        "a request needing a delay beyond the 4-bit field must be deferred, not encoded"
+    );
 }

--- a/crates/tetra-pdus/src/umac/enums/basic_slotgrant_granting_delay.rs
+++ b/crates/tetra-pdus/src/umac/enums/basic_slotgrant_granting_delay.rs
@@ -28,7 +28,12 @@ impl BasicSlotgrantGrantingDelay {
     pub fn into_raw(self) -> u64 {
         match self {
             BasicSlotgrantGrantingDelay::CapAllocAtNextOpportunity => 0,
-            BasicSlotgrantGrantingDelay::DelayNOpportunities(n) => n as u64,
+            BasicSlotgrantGrantingDelay::DelayNOpportunities(n) => {
+                // 4-bit field: 14/15 are the reserved codes and >=16 truncates to a wrong
+                // delay, so an out-of-range N must never reach the air.
+                debug_assert!((1..=13).contains(&n), "granting delay N out of range: {}", n);
+                n.clamp(1, 13) as u64
+            }
             BasicSlotgrantGrantingDelay::AllocStartsAtOpportunityInFr18 => 14,
             BasicSlotgrantGrantingDelay::WaitForAnotherSlotgrantMessage => 15,
         }

--- a/crates/tetra-pdus/src/umac/pdus/mac_access.rs
+++ b/crates/tetra-pdus/src/umac/pdus/mac_access.rs
@@ -1,6 +1,6 @@
 use core::fmt;
 
-use tetra_core::{BitBuffer, SsiType, TetraAddress, pdu_parse_error::PduParseErr};
+use tetra_core::{BitBuffer, SsiType, TetraAddress, expect_failed, expect_value, pdu_parse_error::PduParseErr};
 
 use crate::umac::{enums::reservation_requirement::ReservationRequirement, fields::EventLabel};
 
@@ -33,9 +33,10 @@ pub struct MacAccess {
 
 impl MacAccess {
     pub fn from_bitbuf(buf: &mut BitBuffer) -> Result<Self, PduParseErr> {
-        // required constant mac_pdu_type
+        // required constant mac_pdu_type. Uplink is attacker-controlled, so return an error
+        // rather than asserting -- a panic here takes down the whole cell.
         let mac_pdu_type = buf.read_field(1, "mac_pdu_type")?;
-        assert!(mac_pdu_type == 0);
+        expect_value!(mac_pdu_type, 0)?;
         let fill_bits = buf.read_field(1, "fill_bits")? != 0;
         let encrypted = buf.read_field(1, "encrypted")? != 0;
 
@@ -67,7 +68,7 @@ impl MacAccess {
                 (Some(address), None)
             }
             _ => {
-                panic!();
+                return expect_failed!(addr_type as u64, "addr_type");
             }
         };
 

--- a/crates/tetra-pdus/src/umac/pdus/mac_end_hu.rs
+++ b/crates/tetra-pdus/src/umac/pdus/mac_end_hu.rs
@@ -1,7 +1,7 @@
 use core::fmt;
 
-use tetra_core::BitBuffer;
 use tetra_core::pdu_parse_error::PduParseErr;
+use tetra_core::{BitBuffer, expect_value};
 
 use crate::umac::enums::reservation_requirement::ReservationRequirement;
 
@@ -20,9 +20,9 @@ pub struct MacEndHu {
 
 impl MacEndHu {
     pub fn from_bitbuf(buf: &mut BitBuffer) -> Result<Self, PduParseErr> {
-        // required constant mac_pdu_type
+        // required constant mac_pdu_type. Uplink is attacker-controlled -- error out, never panic.
         let mac_pdu_type = buf.read_field(1, "mac_pdu_type")?;
-        assert!(mac_pdu_type == 1);
+        expect_value!(mac_pdu_type, 1)?;
         let fill_bits = buf.read_field(1, "fill_bits")? != 0;
 
         let length_ind_or_cap_req = buf.read_field(1, "length_ind_or_cap_req")?;

--- a/crates/tetra-pdus/src/umac/pdus/mac_end_ul.rs
+++ b/crates/tetra-pdus/src/umac/pdus/mac_end_ul.rs
@@ -19,12 +19,11 @@ pub struct MacEndUl {
 
 impl MacEndUl {
     pub fn from_bitbuf(buf: &mut BitBuffer) -> Result<Self, PduParseErr> {
-        // required constant mac_pdu_type
+        // required constants. Uplink is attacker-controlled -- error out, never panic.
         let mac_pdu_type = buf.read_field(2, "mac_pdu_type")?;
-        assert!(mac_pdu_type == 1);
-        // required constant pdu_subtype
+        expect_value!(mac_pdu_type, 1)?;
         let pdu_subtype = buf.read_field(1, "pdu_subtype")?;
-        assert!(pdu_subtype == 1);
+        expect_value!(pdu_subtype, 1)?;
         let fill_bits = buf.read_field(1, "fill_bits")? != 0;
         let length_ind_cap_req = buf.read_field(6, "length_ind_cap_req")?;
         let (length_ind, reservation_req) = if length_ind_cap_req == 0 {

--- a/crates/tetra-pdus/src/umac/pdus/mac_frag_ul.rs
+++ b/crates/tetra-pdus/src/umac/pdus/mac_frag_ul.rs
@@ -1,7 +1,7 @@
 use core::fmt;
 
-use tetra_core::BitBuffer;
 use tetra_core::pdu_parse_error::PduParseErr;
+use tetra_core::{BitBuffer, expect_value};
 
 /// Clause 21.4.2.4 MAC-FRAG (uplink)
 #[derive(Debug, Clone)]
@@ -12,12 +12,11 @@ pub struct MacFragUl {
 
 impl MacFragUl {
     pub fn from_bitbuf(buf: &mut BitBuffer) -> Result<Self, PduParseErr> {
-        // required constant mac_pdu_type
+        // required constants. Uplink is attacker-controlled -- error out, never panic.
         let mac_pdu_type = buf.read_field(2, "mac_pdu_type")?;
-        assert!(mac_pdu_type == 1);
-        // required constant pdu_subtype
+        expect_value!(mac_pdu_type, 1)?;
         let pdu_subtype = buf.read_field(1, "pdu_subtype")?;
-        assert!(pdu_subtype == 0);
+        expect_value!(pdu_subtype, 0)?;
         let fill_bits = buf.read_field(1, "fill_bits")? != 0;
 
         Ok(MacFragUl { fill_bits })

--- a/crates/tetra-pdus/src/umac/pdus/mac_u_blck.rs
+++ b/crates/tetra-pdus/src/umac/pdus/mac_u_blck.rs
@@ -1,7 +1,7 @@
 use core::fmt;
 
-use tetra_core::BitBuffer;
 use tetra_core::pdu_parse_error::PduParseErr;
+use tetra_core::{BitBuffer, expect_value};
 
 /// Clause 21.4.2.5 MAC-U-BLCK
 #[derive(Debug, Clone)]
@@ -18,12 +18,11 @@ pub struct MacUBlck {
 
 impl MacUBlck {
     pub fn from_bitbuf(buf: &mut BitBuffer) -> Result<Self, PduParseErr> {
-        // required constant mac_pdu_type
+        // required constants. Uplink is attacker-controlled -- error out, never panic.
         let mac_pdu_type = buf.read_field(2, "mac_pdu_type")?;
-        assert!(mac_pdu_type == 3);
-        // required constant supp_pdu_subtype
+        expect_value!(mac_pdu_type, 3)?;
         let supp_pdu_subtype = buf.read_field(1, "supp_pdu_subtype")?;
-        assert!(supp_pdu_subtype == 0);
+        expect_value!(supp_pdu_subtype, 0)?;
         let fill_bits = buf.read_field(1, "fill_bits")? != 0;
         let encrypted = buf.read_field(1, "encrypted")? != 0;
         let event_label = buf.read_field(10, "event_label")? as u16;

--- a/crates/tetra-pdus/src/umac/pdus/mac_u_signal.rs
+++ b/crates/tetra-pdus/src/umac/pdus/mac_u_signal.rs
@@ -1,7 +1,7 @@
 use core::fmt;
 
-use tetra_core::BitBuffer;
 use tetra_core::pdu_parse_error::PduParseErr;
+use tetra_core::{BitBuffer, expect_value};
 
 /// Clause 21.4.5 MAC-U-SIGNAL
 #[derive(Debug, Clone)]
@@ -12,9 +12,9 @@ pub struct MacUSignal {
 
 impl MacUSignal {
     pub fn from_bitbuf(buf: &mut BitBuffer) -> Result<Self, PduParseErr> {
-        // required constant mac_pdu_type
+        // required constant mac_pdu_type. Uplink is attacker-controlled -- error out, never panic.
         let mac_pdu_type = buf.read_field(2, "mac_pdu_type")?;
-        assert!(mac_pdu_type == 3);
+        expect_value!(mac_pdu_type, 3)?;
         let second_half_stolen = buf.read_field(1, "second_half_stolen")? != 0;
 
         Ok(MacUSignal { second_half_stolen })


### PR DESCRIPTION
v0.4.0 hardening. Closes the reachable panics and unbounded state from an audit, plus
the two SIP bugs off the tracker. 10 commits, one per subsystem.

## Tracker bugs

**FH-BUG-071** - extension kept ringing after a radio-initiated call was hung up. Two
things stacked: CANCEL was built with a fresh Via branch and a tagged To so FreePBX
couldn't match it to the INVITE transaction, and the dialog was deleted right after
sending it, so a 200 OK arriving in that window (callee answers as the radio hangs up,
exactly the reported case) was never ACKed or BYEd. Cancelled dialogs now sit in
`Cancelling`, a racing 2xx gets ACK then BYE, stale ones reaped after timer H. Non-2xx
ACKs reuse the INVITE branch/CSeq too.

**FH-BUG-074** - we sent one RTP packet per 60ms TETRA block (480B PCMU). Trunks want
20ms/160B, PortaSIP was dropping the call. Proper packetizer now: one header per ptime
chunk, seq +1, ts += chunk samples, remainder carried, marker on first packet of a
talkspurt. `ptime` configurable, default 20, advertised in SDP.

## Release gates from the audit

**tetra-core** - a Type-3 length indicator bigger than the remaining SDU made
`parse_type3_generic` seek past the window, and `seek_rel` asserts. One crafted uplink
element, unauthenticated, killed the cell. Reachable from most uplink CMCE/MM decoders.
Lengths validated, offsets go through checked seeks, `read_bits_into_slice` returns an
error instead of asserting (that one was live via the SDS decoders).

**phy** - `rxtx_timeslot().expect()` made an ordinary RX overflow fatal. On a Pi +
LimeSDR that's an everyday event, so it crash-looped under normal USB load with nobody
attacking anything. Now classified recoverable. Also clamps the RX skip slice, buffer
is `new+overlap` but `samples_to_skip` lands in `[new, 2*new)` so most sample-loss
events overran it.

**dashboard** - SDS paths narrowed a u64 with `as u32` and only rejected 0, so anything
>= 2^24 hit `write_bits(ssi, 24)` and aborted the thread. `2^32+1` also truncated into
a legal-looking ISSI 1. Range checked now, plus defence in depth in `sds_bs`.

**messagerouter** - entity callbacks ran with no unwind boundary, so any remaining panic
exits the process and the watchdog (tick-age only) can't throttle the loop. Dispatch
wrapped in `catch_unwind`, catches counted into health so a cell quietly eating PDUs
can't look healthy, panic storm escalates to a restart.

## Unbounded state

MM client registry, UMAC defrag map (its `age_buffers` had no caller and only reset
entries instead of removing them), Brew event channel and inbound call table, telemetry
queue, DAPNET line reader. All reachable by an unauthenticated radio or a remote peer.

## Rest

Forged U-ITSI-DETACH could knock any radio off the cell (teardown keyed on the claimed
SSI, whitelist checked after). Now needs the source registered on the same link context,
with a config kill-switch. Whitelist denial was signalled as `MigrationNotSupported`,
which tells a conformant radio to go find another network instead of that it's barred.
Second U-SETUP to an active GSSI allocated a parallel circuit instead of attaching the
joiner, now late entry per cl. 14. Slot-grant delay could encode reserved 14/15 or
truncate to 0 (cl. 21.5.6), defers instead, clamping would point the MS at an
opportunity we never reserved. QUIC's all-accepting cert verifier is now cfg(test).

## Testing

467 pass, 0 fail. ~40 of those are new. Both `--workspace --all-targets` and
`--features asterisk --all-targets` check clean.

asterisk tests were NOT run, no libtetra-codec on this box so the feature type-checks
but won't link. The 071/074 tests need a run somewhere with the codec before merge.

## Risk

`catch_unwind` is the one to look at hardest. It contains the blast radius, it does not
make a caught panic harmless: an entity can be left with half-updated state, so the
first catch in the field is a bug report not an all-clear. Also void if anyone adds
`panic = "abort"` to a release profile.

Operator-visible: `[asterisk] bind_addr` now defaults to 127.0.0.1, SIP datagrams from
anything but the configured peer are dropped, telemetry is lossy under flood (counted
and warned).
