### PR TITLE
Fix FH-BUG-077, FH-BUG-075 and FH-BUG-074 (reopened)

### DIFF
--- a/crates/tetra-config/src/bluestation/sec_asterisk.rs
+++ b/crates/tetra-config/src/bluestation/sec_asterisk.rs
@@ -30,6 +30,10 @@ pub struct CfgAsterisk {
     pub options_interval_secs: u64,
     /// RTP packet duration in ms. Real trunks expect 20 ms / 160 byte G.711 packets.
     pub ptime_ms: u16,
+    /// How much SIP -> TETRA audio may wait for its downlink slot before the oldest is
+    /// dropped. Rounded down to whole 60 ms blocks; anything queued past this is delay the
+    /// call never gets back.
+    pub dl_jitter_ms: u16,
     /// Extra source hosts allowed to talk SIP to us besides the resolved Asterisk peer.
     pub allow_from: Vec<String>,
     /// Cap on dialogs that have not been answered yet, per bridge.
@@ -88,6 +92,8 @@ pub struct CfgAsteriskDto {
     pub options_interval_secs: u64,
     #[serde(default = "default_ptime_ms")]
     pub ptime_ms: u16,
+    #[serde(default = "default_dl_jitter_ms")]
+    pub dl_jitter_ms: u16,
     #[serde(default)]
     pub allow_from: Vec<String>,
     #[serde(default = "default_max_pending_dialogs")]
@@ -123,6 +129,7 @@ impl Default for CfgAsteriskDto {
             realm: default_realm(),
             options_interval_secs: default_options_interval_secs(),
             ptime_ms: default_ptime_ms(),
+            dl_jitter_ms: default_dl_jitter_ms(),
             allow_from: Vec::new(),
             max_pending_dialogs: default_max_pending_dialogs(),
             max_invites_per_minute: default_max_invites_per_minute(),
@@ -204,6 +211,11 @@ fn default_ptime_ms() -> u16 {
     20
 }
 
+// Two 60 ms blocks: enough to ride out a trunk burst, short enough that nobody hears it.
+fn default_dl_jitter_ms() -> u16 {
+    120
+}
+
 fn default_max_pending_dialogs() -> usize {
     8
 }
@@ -246,6 +258,11 @@ pub fn apply_asterisk_patch(src: CfgAsteriskDto) -> Result<CfgAsterisk, String> 
         return Err("asterisk: ptime_ms must be 20, 40 or 60".to_string());
     }
 
+    // Anything queued here is delay the call carries for good, so refuse to buffer a call late.
+    if src.dl_jitter_ms > 500 {
+        return Err("asterisk: dl_jitter_ms must be 500 or less".to_string());
+    }
+
     let allow_from = src
         .allow_from
         .into_iter()
@@ -282,6 +299,7 @@ pub fn apply_asterisk_patch(src: CfgAsteriskDto) -> Result<CfgAsterisk, String> 
         realm: src.realm,
         options_interval_secs: src.options_interval_secs,
         ptime_ms: src.ptime_ms,
+        dl_jitter_ms: src.dl_jitter_ms,
         allow_from,
         max_pending_dialogs: src.max_pending_dialogs,
         max_invites_per_minute: src.max_invites_per_minute,

--- a/crates/tetra-entities/src/cmce/subentities/sds_bs.rs
+++ b/crates/tetra-entities/src/cmce/subentities/sds_bs.rs
@@ -88,6 +88,20 @@ fn ssi_pair_is_valid(what: &str, source_ssi: u32, dest_ssi: u32) -> bool {
 /// timeout (also "failed"), and we never deliver the message late, so the two cannot contradict.
 const SDS_TL_STATUS_UNDELIVERABLE: u8 = 0x02;
 
+/// A terminal whose status transaction does not complete retransmits the identical U-STATUS every
+/// few seconds, so the same (source ISSI, status code) arriving again inside this window is a
+/// retransmission of ONE operator request, not a new one — the action runs once. The window slides
+/// on every repeat, so a retry campaign of any length still executes exactly once, while a
+/// deliberate re-issue only needs this much silence first. Matters because the configured actions
+/// include `restart`, `shutdown` and `kick_all` (FH-BUG-075).
+const SDS_CMD_REPEAT_WINDOW: std::time::Duration = std::time::Duration::from_secs(30);
+
+/// Hard ceiling on `recent_commands`. Its key space is already bounded — only an authorized ISSI
+/// with a configured status code ever gets an entry, so unauthorized traffic cannot grow it — and
+/// expired entries are pruned on every insert, but keep an explicit cap so no config can turn the
+/// map into unbounded growth.
+const SDS_CMD_DEDUP_MAX: usize = 64;
+
 /// One active status-based emergency session (keyed by source ISSI in `emergency_sessions`).
 /// The radio re-sends the emergency status periodically while active and goes silent on exit, so
 /// `last_seen` drives the clear-timeout sweep. Call-raised emergencies are NOT tracked here — the
@@ -121,6 +135,10 @@ pub struct SdsBsSubentity {
     /// a non-Emergency status, clear-timeout (tick), or operator clear. Non-empty means at least one
     /// radio is in emergency. See [`EmergencySession`].
     emergency_sessions: std::collections::HashMap<u32, EmergencySession>,
+    /// Last execution of each SDS remote command, keyed by (source ISSI, status code), so a
+    /// retransmitted U-STATUS does not run the action again. Pruned and capped — see
+    /// `SDS_CMD_REPEAT_WINDOW` / `SDS_CMD_DEDUP_MAX` and `sds_command_is_new`.
+    recent_commands: std::collections::HashMap<(u32, u16), std::time::Instant>,
 }
 
 impl SdsBsSubentity {
@@ -137,6 +155,7 @@ impl SdsBsSubentity {
             wx_cmd_tx: None,
             last_periodic_wx: None,
             emergency_sessions: std::collections::HashMap::new(),
+            recent_commands: std::collections::HashMap::new(),
         }
     }
 
@@ -784,6 +803,23 @@ impl SdsBsSubentity {
         // SDS command control: U-STATUS to ISSI 9999 from an authorized ISSI triggers
         // a system action (restart, shutdown, kick_all) if the status code matches.
         if dest_ssi == 9999 {
+            // Acknowledge the status transaction FIRST. 9999 is the BS's own identity, so here the
+            // BS *is* the called party and owes the originator a response. D-STATUS (ETSI EN 300
+            // 392-2 cl. 14.7.1.11) is the only downlink CMCE PDU carrying a pre-coded status — the
+            // PDU type list (cl. 14.8.28) has no status-ack — so the acknowledgement is that status
+            // echoed back with 9999 as the calling party. Without it the terminal never completes
+            // the transaction: it reports "Status failed" and retransmits the same U-STATUS every
+            // few seconds, re-running the command each time (FH-BUG-075). The SDS an action replies
+            // with is a separate SDS-TL transaction and does NOT close this one — the field radio
+            // provably received that reply and still reported failure. Echoed for every status to
+            // 9999, authorized or not: the echo closes the transport transaction, authorization
+            // only decides whether the action runs. Two values are NOT echoed, because reflecting
+            // them would mean something to the terminal: Emergency (0) would raise an emergency on
+            // the sender, and an SDS-TL short report (cl. 14.8.34 table 14.72 / cl. 29.4.2.3) is
+            // itself an acknowledgement, carrying the terminal's own message reference.
+            if !matches!(pdu.pre_coded_status, PreCodedStatus::Emergency | PreCodedStatus::SdsTl(_)) {
+                self.send_d_status(queue, dest_ssi, source_ssi, pdu.pre_coded_status);
+            }
             self.handle_sds_command_status(queue, source_ssi, &pdu.pre_coded_status);
             return;
         }
@@ -1353,6 +1389,23 @@ impl SdsBsSubentity {
         );
     }
 
+    /// True when this (source ISSI, status code) is a fresh command rather than a retransmission of
+    /// one already executed within `SDS_CMD_REPEAT_WINDOW`. Records the sighting either way, so a
+    /// retry campaign keeps sliding the window instead of falling out of it mid-way. Expired entries
+    /// are pruned on every call, and the map is capped by evicting the oldest, so it stays small.
+    fn sds_command_is_new(&mut self, source_ssi: u32, status_code: u16) -> bool {
+        let now = std::time::Instant::now();
+        self.recent_commands
+            .retain(|_, last| now.duration_since(*last) < SDS_CMD_REPEAT_WINDOW);
+        if self.recent_commands.len() >= SDS_CMD_DEDUP_MAX {
+            let oldest = self.recent_commands.iter().min_by_key(|(_, last)| **last).map(|(k, _)| *k);
+            if let Some(key) = oldest {
+                self.recent_commands.remove(&key);
+            }
+        }
+        self.recent_commands.insert((source_ssi, status_code), now).is_none()
+    }
+
     fn handle_sds_command_status(&mut self, queue: &mut MessageQueue, source_ssi: u32, status: &PreCodedStatus) {
         let status_code = status.into_raw() as u16;
 
@@ -1383,6 +1436,24 @@ impl SdsBsSubentity {
             );
             return;
         };
+
+        // Idempotence, independent of the acknowledgement above: even a conformant SwMI loses the
+        // odd downlink, and the terminal then legitimately retransmits the identical U-STATUS. A
+        // second `restart`/`shutdown`/`kick_all` off one operator request is destructive, so a
+        // repeat inside SDS_CMD_REPEAT_WINDOW is treated as the same request and the action is
+        // skipped. The D-STATUS acknowledgement is still sent for every copy (see the caller), so
+        // the terminal can complete its transaction; a genuine re-issue works once the window has
+        // elapsed. (FH-BUG-075.)
+        if !self.sds_command_is_new(source_ssi, status_code) {
+            tracing::info!(
+                "SDS-CMD: ISSI {} re-sent status={} (action='{}') within {}s — retransmission, not executing again",
+                source_ssi,
+                status_code,
+                entry.action,
+                SDS_CMD_REPEAT_WINDOW.as_secs()
+            );
+            return;
+        }
 
         tracing::info!(
             "SDS-CMD: ISSI {} triggered action='{}' via status={}",

--- a/crates/tetra-entities/src/net_asterisk/audio.rs
+++ b/crates/tetra-entities/src/net_asterisk/audio.rs
@@ -1,3 +1,4 @@
+use std::collections::VecDeque;
 use std::ptr::NonNull;
 
 pub(crate) const PCMU_PAYLOAD_TYPE: u8 = 0;
@@ -6,6 +7,8 @@ const PCMU_SAMPLES_PER_MS: usize = 8;
 
 const TETRA_PCM_SAMPLES_PER_FRAME: usize = 240;
 const TETRA_PCM_SAMPLES_PER_BLOCK: usize = TETRA_PCM_SAMPLES_PER_FRAME * 2;
+/// One TMD block is 60 ms of speech, which is also what one traffic frame carries.
+const TETRA_BLOCK_MS: usize = TETRA_PCM_SAMPLES_PER_BLOCK / PCMU_SAMPLES_PER_MS;
 const TETRA_CODED_BITS_PER_FRAME: usize = 137;
 const TETRA_CODED_BYTES_PER_FRAME: usize = (TETRA_CODED_BITS_PER_FRAME + 7) / 8;
 const TETRA_TMD_BITS_PER_BLOCK: usize = TETRA_CODED_BITS_PER_FRAME * 2;
@@ -79,9 +82,17 @@ impl AsteriskAudioTranscoder {
         Some(out)
     }
 
+    /// Throw away the part-filled block left over from earlier audio, so the next payload
+    /// starts a fresh block instead of being glued behind something stale.
+    pub(crate) fn reset_downlink(&mut self) {
+        self.downlink_pcm.clear();
+    }
+
     pub(crate) fn encode_pcmu_to_tmd(&mut self, payload: &[u8]) -> Vec<Vec<u8>> {
         self.downlink_pcm.extend(payload.iter().map(|&sample| ulaw_to_linear(sample)));
 
+        // Everything that fills a block leaves here, so the remainder is always under one
+        // block - this cannot become a second, untrimmable queue behind the backlog.
         let mut out = Vec::new();
         while self.downlink_pcm.len() >= TETRA_PCM_SAMPLES_PER_BLOCK {
             let mut pcm_a = [0i16; TETRA_PCM_SAMPLES_PER_FRAME];
@@ -100,6 +111,53 @@ impl AsteriskAudioTranscoder {
         }
 
         out
+    }
+}
+
+/// SIP -> TETRA blocks waiting for their downlink slot.
+///
+/// UMAC takes exactly one block per traffic frame, so every block handed over early just
+/// queues up there, out of reach, and sits in front of the live audio for the rest of the
+/// call - that is the constant 2-4 s offset of FH-BUG-074. Blocks wait here instead, and once
+/// the backlog is longer than the jitter allowance the OLDEST are dropped: late voice is
+/// worthless and dropping the oldest is what keeps the delay bounded.
+pub(crate) struct DownlinkBacklog {
+    blocks: VecDeque<Vec<u8>>,
+    max_blocks: usize,
+}
+
+impl DownlinkBacklog {
+    pub(crate) fn new(jitter_ms: u16) -> Self {
+        // A block is the smallest thing the downlink can carry, so never go below one.
+        let max_blocks = (jitter_ms as usize / TETRA_BLOCK_MS).max(1);
+        Self {
+            blocks: VecDeque::with_capacity(max_blocks + 1),
+            max_blocks,
+        }
+    }
+
+    /// Queues a block and returns how many old ones had to go to stay inside the allowance.
+    pub(crate) fn push(&mut self, block: Vec<u8>) -> usize {
+        self.blocks.push_back(block);
+        let mut dropped = 0;
+        while self.blocks.len() > self.max_blocks {
+            self.blocks.pop_front();
+            dropped += 1;
+        }
+        dropped
+    }
+
+    pub(crate) fn take(&mut self) -> Option<Vec<u8>> {
+        self.blocks.pop_front()
+    }
+
+    pub(crate) fn clear(&mut self) {
+        self.blocks.clear();
+    }
+
+    #[cfg(test)]
+    fn len(&self) -> usize {
+        self.blocks.len()
     }
 }
 
@@ -301,6 +359,44 @@ mod tests {
 
         let frames_again = split_tmd_block_to_codec_frames(&packed).unwrap();
         assert_eq!(frames, frames_again);
+    }
+
+    #[test]
+    fn downlink_backlog_stays_bounded_when_blocks_arrive_faster_than_they_drain() {
+        // 180 ms of allowance is three blocks; push a second of audio without draining.
+        let mut backlog = DownlinkBacklog::new(180);
+        let mut dropped = 0;
+        for idx in 0..17u8 {
+            dropped += backlog.push(vec![idx; TETRA_TMD_PACKED_BYTES]);
+            assert!(backlog.len() <= 3, "backlog grew to {} blocks", backlog.len());
+        }
+
+        assert_eq!(dropped, 14);
+        // What survives is the newest audio, in order - dropping the oldest is the point.
+        assert_eq!(backlog.take().unwrap()[0], 14);
+        assert_eq!(backlog.take().unwrap()[0], 15);
+        assert_eq!(backlog.take().unwrap()[0], 16);
+        assert!(backlog.take().is_none());
+    }
+
+    #[test]
+    fn downlink_backlog_keeps_one_block_even_with_a_zero_allowance() {
+        let mut backlog = DownlinkBacklog::new(0);
+        assert_eq!(backlog.push(vec![1]), 0);
+        assert_eq!(backlog.push(vec![2]), 1);
+        assert_eq!(backlog.len(), 1);
+
+        backlog.clear();
+        assert!(backlog.take().is_none());
+    }
+
+    #[test]
+    fn downlink_backlog_allowance_is_whole_blocks() {
+        // 60 ms per block, so the knob rounds down to what the downlink can actually hold.
+        assert_eq!(TETRA_BLOCK_MS, 60);
+        assert_eq!(DownlinkBacklog::new(120).max_blocks, 2);
+        assert_eq!(DownlinkBacklog::new(179).max_blocks, 2);
+        assert_eq!(DownlinkBacklog::new(200).max_blocks, 3);
     }
 
     fn seq_of(packet: &[u8]) -> u16 {

--- a/crates/tetra-entities/src/net_asterisk/entity.rs
+++ b/crates/tetra-entities/src/net_asterisk/entity.rs
@@ -15,9 +15,18 @@ use uuid::Uuid;
 
 use crate::{MessageQueue, TetraEntityTrait};
 
-use super::audio::{AsteriskAudioTranscoder, PCMU_PAYLOAD_TYPE, RtpPacketizer, rtp_payload};
+use super::audio::{AsteriskAudioTranscoder, DownlinkBacklog, PCMU_PAYLOAD_TYPE, RtpPacketizer, rtp_payload};
 
 const SIP_MAX_DATAGRAM: usize = 8192;
+const RTP_MAX_DATAGRAM: usize = 1720;
+/// Datagrams read per socket per pass. Well above the ~1 packet a 20 ms stream produces per
+/// tick, and bounded so a flooded socket cannot hold the tick hostage.
+const RTP_READS_PER_TICK: usize = 32;
+/// Reads used to empty a socket in one go. A default receive buffer holds a few hundred
+/// 172-byte datagrams; whatever is left over goes on the next tick's drain.
+const RTP_DISCARD_READS: usize = 1024;
+/// Frame 18 carries no traffic, so the downlink drains 17 blocks per multiframe.
+const TDMA_CONTROL_FRAME: u8 = 18;
 /// RFC 3261 timer H: how long a cancelled INVITE may wait for its final response before we
 /// give up on it and free the RTP port.
 const CANCEL_REAP_AFTER: Duration = Duration::from_secs(32);
@@ -49,7 +58,22 @@ struct RtpSession {
     local_port: u16,
     remote: Option<SocketAddr>,
     packetizer: RtpPacketizer,
+    dl_backlog: DownlinkBacklog,
     last_tx: Option<Instant>,
+}
+
+impl RtpSession {
+    /// Throw away whatever the socket is holding. Audio that arrived before playout starts is
+    /// already stale by the time TETRA could carry it, and left in the kernel receive buffer it
+    /// becomes a permanent head start over the live stream (FH-BUG-074).
+    fn discard_pending(&mut self) {
+        let mut buf = [0u8; RTP_MAX_DATAGRAM];
+        for _ in 0..RTP_DISCARD_READS {
+            if self.socket.recv_from(&mut buf).is_err() {
+                break;
+            }
+        }
+    }
 }
 
 struct SipDialog {
@@ -816,6 +840,7 @@ impl AsteriskEntity {
                         local_port: port,
                         remote: None,
                         packetizer: RtpPacketizer::new(ssrc, self.asterisk_config.ptime_ms),
+                        dl_backlog: DownlinkBacklog::new(self.asterisk_config.dl_jitter_ms),
                         last_tx: None,
                     });
                 }
@@ -1124,6 +1149,11 @@ impl AsteriskEntity {
 
     fn mark_media_ready(&mut self, brew_uuid: Uuid, call_id: u16, carrier_num: u16, ts: u8) {
         if let Some(dialog) = self.dialogs.get_mut(&brew_uuid) {
+            // Playout starts now, not seconds ago: drop anything that arrived while the circuit
+            // was still coming up, plus the part-filled block behind it (FH-BUG-074).
+            dialog.rtp.discard_pending();
+            dialog.rtp.dl_backlog.clear();
+            dialog.audio.reset_downlink();
             dialog.media_ready = Some((call_id, carrier_num, ts));
             self.rtp_by_ts.insert((carrier_num, ts), brew_uuid);
             tracing::info!(
@@ -1231,15 +1261,20 @@ impl AsteriskEntity {
         };
     }
 
-    fn poll_rtp(&mut self, queue: &mut MessageQueue) {
+    fn poll_rtp(&mut self, queue: &mut MessageQueue, now: TdmaTime) {
         let mut downlink = Vec::new();
         let mut last_error = None;
-        let mut buf = [0u8; 1720];
+        let mut buf = [0u8; RTP_MAX_DATAGRAM];
         for dialog in self.dialogs.values_mut() {
             let Some((_, carrier_num, ts)) = dialog.media_ready else {
+                // Asterisk is often already sending - early media, ringback, or just the gap
+                // before the circuit is up. Not reading the socket does not stop that audio, it
+                // only parks it in the kernel receive buffer to be played out seconds late once
+                // the circuit opens (FH-BUG-074), so read it and drop it.
+                dialog.rtp.discard_pending();
                 continue;
             };
-            for _ in 0..32 {
+            for _ in 0..RTP_READS_PER_TICK {
                 match dialog.rtp.socket.recv_from(&mut buf) {
                     Ok((len, addr)) => {
                         let Some((payload_type, payload)) = rtp_payload(&buf[..len]) else {
@@ -1264,7 +1299,15 @@ impl AsteriskEntity {
                             }
                         }
                         for frame in dialog.audio.encode_pcmu_to_tmd(payload) {
-                            downlink.push((carrier_num, ts, frame));
+                            let dropped = dialog.rtp.dl_backlog.push(frame);
+                            if dropped > 0 {
+                                tracing::debug!(
+                                    "AsteriskEntity: dropped {} stale downlink block(s) uuid={} ts={}",
+                                    dropped,
+                                    dialog.uuid,
+                                    ts
+                                );
+                            }
                         }
                     }
                     Err(err) if err.kind() == io::ErrorKind::WouldBlock => break,
@@ -1272,6 +1315,15 @@ impl AsteriskEntity {
                         last_error = Some(format!("RTP receive failed uuid={}: {}", dialog.uuid, err));
                         break;
                     }
+                }
+            }
+
+            // Hand over one block per traffic frame, i.e. exactly what UMAC takes off this
+            // timeslot. Pushing any faster only moves the backlog into UMAC's queue, where this
+            // entity can no longer trim it and it becomes permanent delay (FH-BUG-074).
+            if now.t == ts && now.f != TDMA_CONTROL_FRAME {
+                if let Some(data) = dialog.rtp.dl_backlog.take() {
+                    downlink.push((carrier_num, ts, data));
                 }
             }
         }
@@ -1649,10 +1701,10 @@ impl TetraEntityTrait for AsteriskEntity {
         self.refresh_status();
     }
 
-    fn tick_start(&mut self, queue: &mut MessageQueue, _ts: TdmaTime) {
+    fn tick_start(&mut self, queue: &mut MessageQueue, ts: TdmaTime) {
         self.maybe_periodic_sip();
         self.poll_sip(queue);
-        self.poll_rtp(queue);
+        self.poll_rtp(queue, ts);
         self.refresh_status();
     }
 }

--- a/crates/tetra-entities/src/umac/subcomp/bs_sched.rs
+++ b/crates/tetra-entities/src/umac/subcomp/bs_sched.rs
@@ -854,6 +854,11 @@ impl BsChannelScheduler {
         self.circuits.is_active(dir, self.carrier_num, ts)
     }
 
+    /// Downlink voice blocks waiting to be transmitted on this timeslot.
+    pub fn dl_queued_block_count(&self, ts: u8) -> usize {
+        self.circuits.queued_block_count(self.carrier_num, ts)
+    }
+
     pub fn duplex_peer_route(&self, ts: u8) -> Option<(u16, u8)> {
         self.circuits.get_ul_peer_route(self.carrier_num, ts)
     }

--- a/crates/tetra-entities/src/umac/subcomp/circuit_mgr.rs
+++ b/crates/tetra-entities/src/umac/subcomp/circuit_mgr.rs
@@ -3,12 +3,22 @@ use std::collections::{HashMap, VecDeque};
 use tetra_core::Direction;
 use tetra_saps::control::call_control::{Circuit, CircuitDlMediaSource};
 
+/// Jitter allowance for queued downlink voice, in 60 ms blocks. The downlink transmits one
+/// block per timeslot per frame, so anything beyond this is not jitter, it is a backlog that
+/// would sit in front of every later block as permanent added latency.
+const MAX_QUEUED_DL_BLOCKS: usize = 4;
+
+/// Log one overflow line per this many drops, so a stuck feeder cannot flood the log.
+const DL_BLOCK_DROP_LOG_INTERVAL: u64 = 100;
+
 pub struct CircuitMgr {
     dl: HashMap<(u16, u8), Circuit>,
     ul: HashMap<(u16, u8), Circuit>,
 
     /// Data blocks queued to be transmitted, per carrier/timeslot.
     tx_data: HashMap<(u16, u8), VecDeque<Vec<u8>>>,
+    /// Blocks dropped on queue overflow since this circuit was opened, per carrier/timeslot.
+    tx_data_drops: HashMap<(u16, u8), u64>,
 }
 
 impl CircuitMgr {
@@ -17,6 +27,7 @@ impl CircuitMgr {
             dl: HashMap::new(),
             ul: HashMap::new(),
             tx_data: HashMap::new(),
+            tx_data_drops: HashMap::new(),
         }
     }
 
@@ -73,6 +84,7 @@ impl CircuitMgr {
         match dir {
             Direction::Dl => {
                 self.tx_data.remove(&key);
+                self.tx_data_drops.remove(&key);
                 self.dl.remove(&key)
             }
             Direction::Ul => self.ul.remove(&key),
@@ -108,6 +120,7 @@ impl CircuitMgr {
                     );
                     self.tx_data.remove(&key);
                 }
+                self.tx_data_drops.remove(&key);
                 self.dl.insert(key, circuit);
             }
             Direction::Ul => {
@@ -130,7 +143,37 @@ impl CircuitMgr {
             );
             return;
         }
-        self.tx_data.entry(Self::key(carrier_num, ts)).or_default().push_back(block);
+        let key = Self::key(carrier_num, ts);
+        let queue = self.tx_data.entry(key).or_default();
+        queue.push_back(block);
+
+        // Brew and the SIP bridge can hand us a burst in one tick, but only one block per
+        // timeslot leaves per frame. Keep just a jitter allowance and drop the OLDEST on
+        // overflow: stale voice is worthless, and dropping the head is what keeps latency down.
+        let overflow = queue.len().saturating_sub(MAX_QUEUED_DL_BLOCKS);
+        if overflow == 0 {
+            return;
+        }
+        queue.drain(..overflow);
+
+        let drops = self.tx_data_drops.entry(key).or_default();
+        let before = *drops;
+        *drops += overflow as u64;
+        // First drop, then one line per interval, so a stuck feeder cannot flood the log.
+        if before == 0 || before / DL_BLOCK_DROP_LOG_INTERVAL != *drops / DL_BLOCK_DROP_LOG_INTERVAL {
+            tracing::warn!(
+                "CircuitMgr::put_block: DL voice queue full on carrier={} ts={}, dropped {} oldest block(s), {} total on this circuit",
+                carrier_num,
+                ts,
+                overflow,
+                drops
+            );
+        }
+    }
+
+    /// Number of blocks currently queued for downlink transmission on this carrier/timeslot.
+    pub fn queued_block_count(&self, carrier_num: u16, ts: u8) -> usize {
+        self.tx_data.get(&Self::key(carrier_num, ts)).map_or(0, VecDeque::len)
     }
 
     /// Take a to-be-transmitted block from the queue.

--- a/crates/tetra-entities/src/umac/umac_bs.rs
+++ b/crates/tetra-entities/src/umac/umac_bs.rs
@@ -1849,6 +1849,11 @@ impl UmacBs {
         };
 
         for d in dirs {
+            // A close deferred by the previous call on this timeslot must not reach the circuit
+            // we are about to create: the tick would tear the new one down and every DL voice
+            // frame after that is dropped as "inactive circuit" for the rest of the call.
+            self.cancel_pending_circuit_close(carrier_num, ts, d);
+
             // See if pre-existing circuit somehow needs to be closed
             if self.scheduler_for(carrier_num).circuit_is_active(d, ts) {
                 tracing::warn!(
@@ -1928,6 +1933,32 @@ impl UmacBs {
         }
 
         self.close_circuit_now(dir, carrier_num, ts);
+    }
+
+    /// Drop a deferred close queued for an earlier incarnation of this carrier/timeslot.
+    /// Only the direction being reopened is cleared -- a close still pending for the other
+    /// direction refers to a circuit nobody recreated and must still run.
+    fn cancel_pending_circuit_close(&mut self, carrier_num: u16, ts: u8, dir: Direction) {
+        let Some(pending) = self.pending_circuit_closes.get_mut(&(carrier_num, ts)) else {
+            return;
+        };
+        let was_pending = match dir {
+            Direction::Dl => std::mem::take(&mut pending.dl),
+            Direction::Ul => std::mem::take(&mut pending.ul),
+            _ => return,
+        };
+        let drained = !pending.dl && !pending.ul;
+        if drained {
+            self.pending_circuit_closes.remove(&(carrier_num, ts));
+        }
+        if was_pending {
+            tracing::info!(
+                "  rx_control_circuit_open: Cancelled deferred {:?} circuit close for carrier={} ts {}",
+                dir,
+                carrier_num,
+                ts
+            );
+        }
     }
 
     fn close_circuit_now(&mut self, dir: Direction, carrier_num: u16, ts: u8) {

--- a/crates/tetra-entities/tests/test_sds_bs.rs
+++ b/crates/tetra-entities/tests/test_sds_bs.rs
@@ -25,6 +25,7 @@ use tetra_entities::cmce::cmce_bs::CmceBs;
 use tetra_entities::net_control::{ControlCommand, make_control_link};
 use tetra_entities::tpg2200::build_tpg2200_callout_payload;
 use tetra_pdus::cmce::pdus::d_sds_data::DSdsData;
+use tetra_pdus::cmce::pdus::d_status::DStatus;
 
 use crate::common::ComponentTest;
 
@@ -695,6 +696,33 @@ fn d_sds_to(msgs: &[SapMsg], issi: u32) -> Vec<&LcmcMleUnitdataReq> {
         .collect()
 }
 
+/// The D-STATUS PDUs addressed to `issi` — i.e. status-transaction traffic. `d_sds_to` cannot tell
+/// the two downlink PDUs apart (both are LcmcMleUnitdataReq), so decode: a D-SDS-DATA SDU fails the
+/// D-STATUS pdu_type check and drops out.
+fn d_status_to(msgs: &[SapMsg], issi: u32) -> Vec<DStatus> {
+    d_sds_to(msgs, issi)
+        .into_iter()
+        .filter_map(|p| {
+            let mut sdu = p.sdu.clone();
+            sdu.seek(0);
+            DStatus::from_bitbuf(&mut sdu).ok()
+        })
+        .collect()
+}
+
+/// The D-SDS-DATA PDUs addressed to `issi` — i.e. actual short-data replies, as opposed to the
+/// D-STATUS acknowledgements above.
+fn d_sds_data_to(msgs: &[SapMsg], issi: u32) -> Vec<DSdsData> {
+    d_sds_to(msgs, issi)
+        .into_iter()
+        .filter_map(|p| {
+            let mut sdu = p.sdu.clone();
+            sdu.seek(0);
+            DSdsData::from_bitbuf(&mut sdu).ok()
+        })
+        .collect()
+}
+
 /// FH-BUG-034 (final): the field radios do not accept an SDS in-band on the traffic channel
 /// (verified on-air against FACCH stealing with fragmentation, single-block STCH, and a full-slot
 /// SCH/F in the hangtime gap — the BS transmits all of them per ETSI, the radios receive none).
@@ -967,7 +995,11 @@ fn test_u_status_command_ip_replies_to_authorized() {
     );
 }
 
-/// FH-FEAT-014: a U-STATUS from an ISSI that is NOT in authorized_issis must be ignored — no reply.
+/// FH-FEAT-014: a U-STATUS from an ISSI that is NOT in authorized_issis must not run any action —
+/// no SDS reply. Since FH-BUG-075 the status transaction itself is still acknowledged (see
+/// `test_u_status_to_9999_is_acknowledged_with_d_status`): authorization decides whether the command
+/// runs, not whether the terminal gets to finish its transaction, so an unauthorized radio stops
+/// retransmitting instead of hammering the MCCH forever.
 #[test]
 fn test_u_status_command_unauthorized_no_reply() {
     debug::setup_logging_verbose();
@@ -989,8 +1021,119 @@ fn test_u_status_command_unauthorized_no_reply() {
 
     let after = test.dump_sinks();
     assert!(
-        d_sds_to(&after, 1000002).is_empty(),
-        "unauthorized U-STATUS to 9999 must be ignored (no reply)"
+        d_sds_data_to(&after, 1000002).is_empty(),
+        "unauthorized U-STATUS to 9999 must not run the action (no SDS reply)"
+    );
+}
+
+/// FH-BUG-075: a U-STATUS to the 9999 command channel must be acknowledged back to the originator.
+/// D-STATUS (ETSI EN 300 392-2 cl. 14.7.1.11) is the only downlink CMCE PDU carrying a pre-coded
+/// status, so the ack is that status echoed back from 9999. Without it the terminal's status
+/// transaction never completes — it shows "Status failed" and retransmits every few seconds, and the
+/// SDS reply the action sends does not close it (a separate SDS-TL transaction).
+#[test]
+fn test_u_status_to_9999_is_acknowledged_with_d_status() {
+    debug::setup_logging_verbose();
+    let dltime = TdmaTime { h: 0, m: 1, f: 1, t: 1 };
+    let mut config = ComponentTest::get_default_test_config(StackMode::Bs);
+    config.cell.sds_command_control = Some(CfgSdsCommandControl {
+        authorized_issis: vec![1000001],
+        commands: vec![CfgSdsCommandEntry {
+            status_code: 50,
+            action: "ip".to_string(),
+        }],
+    });
+    let mut test = ComponentTest::from_config(config, Some(dltime));
+    test.populate_entities(vec![TetraEntity::Cmce], vec![TetraEntity::Mle, TetraEntity::Brew]);
+    register_subscriber(&mut test, 1000001);
+
+    test.submit_message(build_u_status_msg(1000001, 9999, 50));
+    test.run_stack(Some(2));
+
+    let after = test.dump_sinks();
+    let acks = d_status_to(&after, 1000001);
+    assert_eq!(acks.len(), 1, "U-STATUS to 9999 must be answered with exactly one D-STATUS");
+    assert_eq!(
+        acks[0].calling_party_address_ssi,
+        Some(9999),
+        "the acknowledgement must come from the command-channel ISSI"
+    );
+    assert_eq!(
+        acks[0].pre_coded_status,
+        PreCodedStatus::from(50),
+        "the acknowledgement must echo the status the terminal sent"
+    );
+    assert_eq!(
+        d_sds_data_to(&after, 1000001).len(),
+        1,
+        "the 'ip' action must still send its SDS reply alongside the ack"
+    );
+}
+
+/// FH-BUG-075: a retransmitted (byte-identical) U-STATUS must NOT run the action a second time — the
+/// configured actions include restart/shutdown/kick_all — but it must still be acknowledged, so the
+/// terminal can finish its transaction and stop retransmitting.
+#[test]
+fn test_u_status_command_retransmission_executes_once() {
+    debug::setup_logging_verbose();
+    let dltime = TdmaTime { h: 0, m: 1, f: 1, t: 1 };
+    let mut config = ComponentTest::get_default_test_config(StackMode::Bs);
+    config.cell.sds_command_control = Some(CfgSdsCommandControl {
+        authorized_issis: vec![1000001],
+        commands: vec![CfgSdsCommandEntry {
+            status_code: 50,
+            action: "ip".to_string(),
+        }],
+    });
+    let mut test = ComponentTest::from_config(config, Some(dltime));
+    test.populate_entities(vec![TetraEntity::Cmce], vec![TetraEntity::Mle, TetraEntity::Brew]);
+    register_subscriber(&mut test, 1000001);
+
+    test.submit_message(build_u_status_msg(1000001, 9999, 50));
+    test.run_stack(Some(2));
+    let first = test.dump_sinks();
+    assert_eq!(
+        d_sds_data_to(&first, 1000001).len(),
+        1,
+        "the first U-STATUS must execute the action"
+    );
+    assert_eq!(d_status_to(&first, 1000001).len(), 1, "the first U-STATUS must be acknowledged");
+
+    // The radio missed the downlink and retransmits the very same status a moment later.
+    test.submit_message(build_u_status_msg(1000001, 9999, 50));
+    test.run_stack(Some(2));
+    let second = test.dump_sinks();
+    assert!(
+        d_sds_data_to(&second, 1000001).is_empty(),
+        "a retransmitted U-STATUS must not execute the action a second time"
+    );
+    assert_eq!(
+        d_status_to(&second, 1000001).len(),
+        1,
+        "a retransmitted U-STATUS must still be acknowledged, or the radio keeps retransmitting"
+    );
+}
+
+/// FH-BUG-075: an SDS-TL short report addressed to 9999 (the radio confirming a reply we sent it) is
+/// itself an acknowledgement — ETSI EN 300 392-2 cl. 29.4.2.3 — and carries the terminal's own
+/// message reference. Echoing it back would report against that reference, so it gets no D-STATUS.
+#[test]
+fn test_sds_tl_short_report_to_9999_not_echoed() {
+    debug::setup_logging_verbose();
+    let dltime = TdmaTime { h: 0, m: 1, f: 1, t: 1 };
+    let mut test = ComponentTest::new(StackMode::Bs, Some(dltime));
+    test.populate_entities(vec![TetraEntity::Cmce], vec![TetraEntity::Mle, TetraEntity::Brew]);
+    register_subscriber(&mut test, 1000001);
+
+    // 0b011111_10_00000000 = 31744 + (MessageReceived << 8): an SDS-TL short report, message ref 0.
+    const SDS_TL_SHORT_REPORT_STATUS: u16 = 31744 + (2 << 8);
+    test.submit_message(build_u_status_msg(1000001, 9999, SDS_TL_SHORT_REPORT_STATUS));
+    test.run_stack(Some(2));
+
+    let after = test.dump_sinks();
+    assert!(
+        d_status_to(&after, 1000001).is_empty(),
+        "an SDS-TL short report to 9999 must be absorbed, not echoed back at the terminal"
     );
 }
 

--- a/crates/tetra-entities/tests/test_umac_bs.rs
+++ b/crates/tetra-entities/tests/test_umac_bs.rs
@@ -1119,3 +1119,177 @@ fn test_granting_delay_never_encodes_reserved_or_truncated_code() {
         "a request needing a delay beyond the 4-bit field must be deferred, not encoded"
     );
 }
+
+/// CMCE's end-of-call close for a traffic timeslot (deferred by the UMAC until FACCH drains).
+fn close_shared_voice_circuit(ts: u8) -> SapMsg {
+    SapMsg {
+        sap: Sap::Control,
+        src: TetraEntity::Cmce,
+        dest: TetraEntity::Umac,
+        msg: SapMsgInner::CmceCallControl(CallControl::CloseSlot {
+            direction: Direction::Both,
+            carrier_num: MAIN_CARRIER,
+            ts,
+        }),
+    }
+}
+
+/// One 60 ms DL voice block from Brew, every byte set to `marker` so the block can be
+/// identified again once the scheduler hands it to the LMAC.
+fn brew_dl_voice(ts: u8, marker: u8) -> SapMsg {
+    SapMsg {
+        sap: Sap::TmdSap,
+        src: TetraEntity::Brew,
+        dest: TetraEntity::Umac,
+        msg: SapMsgInner::TmdCircuitDataReq(TmdCircuitDataReq {
+            carrier_num: MAIN_CARRIER,
+            ts,
+            data: vec![marker; 36],
+        }),
+    }
+}
+
+/// First byte of the first DL traffic block the UMAC sent to the LMAC for this timeslot.
+fn first_dl_traffic_marker(msgs: &[SapMsg], ts: u8) -> Option<u8> {
+    msgs.iter().find_map(|msg| {
+        let SapMsgInner::TmvUnitdataReqSlots(req) = &msg.msg else {
+            return None;
+        };
+        req.slots.iter().find_map(|slot| {
+            if slot.ts.t != ts {
+                return None;
+            }
+            [&slot.blk1, &slot.blk2]
+                .into_iter()
+                .flatten()
+                .find(|blk| blk.logical_channel == LogicalChannel::TchS)
+                .and_then(|blk| blk.mac_block.peek_bits_startoffset(0, 8))
+                .map(|marker| marker as u8)
+        })
+    })
+}
+
+fn umac_of(test: &mut ComponentTest) -> &mut UmacBs {
+    test.router
+        .get_entity(TetraEntity::Umac)
+        .expect("umac registered")
+        .as_any_mut()
+        .downcast_mut::<UmacBs>()
+        .expect("entity is UmacBs")
+}
+
+#[test]
+fn test_reopening_traffic_slot_cancels_deferred_close() {
+    // FH-BUG-077: a close on a traffic timeslot is deferred to a later tick so queued
+    // FACCH/STCH can drain. If the next call grabs that timeslot before the deferred close
+    // runs, the stale close must not tear down the fresh circuit -- otherwise every Brew DL
+    // voice frame is dropped as "inactive circuit" for the rest of that call.
+    debug::setup_logging_verbose();
+
+    let mut test = ComponentTest::new(StackMode::Bs, Some(TdmaTime { h: 0, m: 1, f: 1, t: 1 }));
+    test.populate_entities(vec![TetraEntity::Umac], vec![TetraEntity::Cmce]);
+
+    test.submit_message(open_shared_voice_circuit(2));
+    test.run_stack(Some(1));
+    assert!(
+        umac_of(&mut test).channel_scheduler.circuit_is_active(Direction::Dl, 2),
+        "first call should have an active DL circuit"
+    );
+
+    // Old call ends and the new one seizes the same timeslot before the next tick.
+    test.submit_message(close_shared_voice_circuit(2));
+    test.submit_message(open_shared_voice_circuit(2));
+    test.run_stack(Some(4)); // ticks here are where the deferred close would have fired
+
+    let umac = umac_of(&mut test);
+    assert!(
+        umac.channel_scheduler.circuit_is_active(Direction::Dl, 2),
+        "re-opened DL circuit must survive the deferred close of the previous call"
+    );
+    assert!(
+        umac.channel_scheduler.circuit_is_active(Direction::Ul, 2),
+        "re-opened UL circuit must survive the deferred close of the previous call"
+    );
+
+    // ...and DL voice must actually be scheduled rather than dropped.
+    test.submit_message(brew_dl_voice(2, 1));
+    test.deliver_all_messages();
+    assert_eq!(
+        umac_of(&mut test).channel_scheduler.dl_queued_block_count(2),
+        1,
+        "DL voice on the re-opened circuit must be scheduled, not dropped"
+    );
+}
+
+#[test]
+fn test_deferred_close_still_runs_for_direction_not_reopened() {
+    // Cancelling is per-direction: re-opening only the DL must leave the pending UL close
+    // alone, or a stale uplink circuit from the previous call leaks.
+    debug::setup_logging_verbose();
+
+    let mut test = ComponentTest::new(StackMode::Bs, Some(TdmaTime { h: 0, m: 1, f: 1, t: 1 }));
+    test.populate_entities(vec![TetraEntity::Umac], vec![TetraEntity::Cmce]);
+
+    test.submit_message(open_shared_voice_circuit(2));
+    test.run_stack(Some(1));
+
+    test.submit_message(close_shared_voice_circuit(2));
+    let mut reopen_dl_only = open_shared_voice_circuit(2);
+    if let SapMsgInner::CmceCallControl(CallControl::Open(circuit)) = &mut reopen_dl_only.msg {
+        circuit.direction = Direction::Dl;
+    }
+    test.submit_message(reopen_dl_only);
+    test.run_stack(Some(4));
+
+    let umac = umac_of(&mut test);
+    assert!(
+        umac.channel_scheduler.circuit_is_active(Direction::Dl, 2),
+        "re-opened DL circuit must stay active"
+    );
+    assert!(
+        !umac.channel_scheduler.circuit_is_active(Direction::Ul, 2),
+        "a UL close nobody re-opened must still run"
+    );
+}
+
+#[test]
+fn test_dl_block_queue_is_bounded_under_burst() {
+    // Brew and the SIP bridge can deliver a burst of voice blocks in a single tick, while the
+    // downlink sends one block per timeslot per frame. The queue must hold a jitter allowance
+    // only -- an unbounded one turns a burst into permanent latency and unbounded memory.
+    debug::setup_logging_verbose();
+
+    const BURST: u8 = 200;
+    const MAX_QUEUED: u8 = 4;
+
+    let mut test = ComponentTest::new(StackMode::Bs, Some(TdmaTime { h: 0, m: 1, f: 1, t: 1 }));
+    test.populate_entities(vec![TetraEntity::Umac], vec![TetraEntity::Lmac]);
+
+    test.submit_message(open_shared_voice_circuit(2));
+    test.run_stack(Some(1));
+
+    for marker in 0..BURST {
+        test.submit_message(brew_dl_voice(2, marker));
+    }
+    test.deliver_all_messages();
+
+    let queued = umac_of(&mut test).channel_scheduler.dl_queued_block_count(2);
+    assert!(
+        queued > 0 && queued <= MAX_QUEUED as usize,
+        "DL voice queue must be capped at a few blocks of jitter, holds {} after a {}-block burst",
+        queued,
+        BURST
+    );
+
+    // Drop the silence sent while the circuit was idle, then check what actually goes out:
+    // the oldest blocks must have been discarded, not the newest.
+    let _ = test.dump_sinks();
+    test.run_stack(Some(8));
+    let msgs = test.dump_sinks();
+    let marker = first_dl_traffic_marker(&msgs, 2).expect("a DL traffic block for ts2");
+    assert!(
+        marker >= BURST - MAX_QUEUED,
+        "overflow must drop the OLDEST blocks; transmitted block {} instead of one of the newest",
+        marker
+    );
+}


### PR DESCRIPTION
Fixes 3 tracker bugs reported on v0.4.0. One commit each.

**FH-BUG-077** (high) - deferred circuit close was killing the new circuit.

Closes on TS2-4 are deferred until FACCH/STCH drains, but `rx_control_circuit_open`
never cleared a pending one. Old call queues a close, new call opens the same slot,
next tick the stale close hits the *new* circuit, and all Brew DL voice gets dropped
for the rest of the call. Cancel the pending close on open, per direction (a pending
UL close nobody re-opened still has to run).

Also capped the per-TS DL block queue, drop oldest. Brew and the SIP bridge can both
burst into it and the DL only drains 1 block/frame.

**FH-BUG-075** - U-STATUS to 9999 never got a reply, so the radio retried every 5s
and the command ran again each time. Bad with restart/shutdown/kick_all configured.

9999 is our own ISSI here so we're the called party and owe a response. D-STATUS is
the only DL PDU carrying a pre-coded status, so echo it back. Emergency and SDS-TL
short reports excluded, those mean something else when reflected. Plus dedup on
(source, status) for 30s so a lost DL can't re-run a command.

**FH-BUG-074** - reopened. Packetization was fixed in v0.4.0, this is the delay.

Two accumulators, both DL only: the RTP socket wasn't read until `media_ready` so
the kernel buffer filled during setup, and UMAC drains exactly 1 block/frame which
is the arrival rate, so a backlog once formed never drained. Hence constant, not
growing.

Now: drain the socket every tick even before media-ready, flush again at media-ready
(plus the transcoder remainder), and hold blocks in a bounded backlog released
1/frame, drop oldest past the allowance. New `dl_jitter_ms`, default 120. Outbound
still 20ms/160B.

## Testing

473 pass, 0 fail. Both default and `--features asterisk` check clean.

asterisk still can't link here (no libtetra-codec) so 074 is compile-checked only.
Second report on that one, so run it for real before it ships.

On 075: whether the MTP8550Ex accepts the D-STATUS echo as transaction completion is
codeplug dependent. Dedup makes the command safe regardless, worst case is a cosmetic
"Status failed" with the action running once.
