### PR TITLE
fix(cmce): don't release a network group call while a local MS holds …

### DIFF
--- a/crates/tetra-entities/src/cmce/subentities/cc_bs/state/mod.rs
+++ b/crates/tetra-entities/src/cmce/subentities/cc_bs/state/mod.rs
@@ -172,6 +172,11 @@ pub(super) struct ActiveCall {
     /// Brew session UUID — set when a network speaker is active on this call,
     /// regardless of call origin. Cleared when the network speaker ends.
     pub(super) brew_uuid: Option<uuid::Uuid>,
+    /// True while the floor is held by a local MS rather than a network speaker. A network-origin
+    /// call whose floor a local radio has taken over stops seeing backhaul media (the audio now
+    /// flows the other way), so `last_activity_at` goes stale and the network-media watchdog would
+    /// release the call mid-transmission. UMAC's UL-inactivity timer owns the stuck-floor case here.
+    pub(super) local_floor: bool,
 }
 
 impl ActiveCall {
@@ -188,6 +193,7 @@ impl ActiveCall {
         priority: u8,
     ) -> Self {
         Self {
+            local_floor: true,
             origin: CallOrigin::Local { caller_addr },
             dest_gssi,
             source_issi,
@@ -223,6 +229,7 @@ impl ActiveCall {
         priority: u8,
     ) -> Self {
         Self {
+            local_floor: false,
             origin: CallOrigin::Network { brew_uuid },
             dest_gssi,
             source_issi,
@@ -297,6 +304,7 @@ impl ActiveCall {
         self.tx_active = true;
         self.hangtime_start = None;
         self.queued_tx_demand = None;
+        self.local_floor = speaker_addr.is_some();
 
         if let (CallOrigin::Local { caller_addr }, Some(addr)) = (&mut self.origin, speaker_addr) {
             *caller_addr = addr;

--- a/crates/tetra-entities/src/cmce/subentities/cc_bs/timers.rs
+++ b/crates/tetra-entities/src/cmce/subentities/cc_bs/timers.rs
@@ -562,11 +562,19 @@ impl CcBsSubentity {
 
     /// Handle UL inactivity timeout from UMAC: a radio disappeared mid-transmission.
     /// Force the group floor to released and enter hangtime.
+    ///
+    /// Only calls whose floor is held by a local MS (`local_floor`) are eligible: the timer arms
+    /// off `last_ul_voice`, which a single stray uplink burst in the traffic slot is enough to
+    /// set — a radio keying up while the network speaker holds the floor, or a burst decoded at
+    /// the edge of coverage. Without the check, that lone burst tears down an in-progress
+    /// network call three seconds later and, via `notify_floor_released`, tells the backhaul the
+    /// call is over while it is still streaming. A network-held floor is covered by
+    /// [`Self::check_network_media_inactivity`] and the absolute call time-out instead.
     pub(super) fn handle_ul_inactivity_timeout_slot(&mut self, queue: &mut MessageQueue, carrier_num: u16, ts: u8) {
         let call_id = self
             .active_calls
             .iter()
-            .find(|(_, call)| call.carrier_num == carrier_num && call.ts == ts && call.is_tx_active())
+            .find(|(_, call)| call.carrier_num == carrier_num && call.ts == ts && call.is_tx_active() && call.local_floor)
             .map(|(call_id, _)| *call_id);
 
         let Some(call_id) = call_id else {

--- a/crates/tetra-entities/src/cmce/subentities/cc_bs/timers.rs
+++ b/crates/tetra-entities/src/cmce/subentities/cc_bs/timers.rs
@@ -526,7 +526,9 @@ impl CcBsSubentity {
     /// transmitting are eligible: once GROUP_IDLE arrives the call drops to hang-time
     /// (`tx_active == false`) and the hang-time timer owns its teardown, and local calls never
     /// refresh `last_activity_at` so they are excluded by the origin filter (their stuck-floor
-    /// case is covered by UMAC's UL-inactivity timer).
+    /// case is covered by UMAC's UL-inactivity timer). `local_floor` extends that same exclusion
+    /// to a network-origin call whose floor a local MS has taken over: no backhaul media is due
+    /// while the local radio talks, so the staleness test would otherwise cut it off mid-PTT.
     pub(super) fn check_network_media_inactivity(&mut self, queue: &mut MessageQueue) {
         let stale: Vec<(u16, CallOrigin, u32)> = self
             .active_calls
@@ -534,6 +536,7 @@ impl CcBsSubentity {
             .filter(|(_, call)| {
                 matches!(call.origin, CallOrigin::Network { .. })
                     && call.tx_active
+                    && !call.local_floor
                     && call.last_activity_at.age(self.dltime) > NETWORK_MEDIA_INACTIVITY_TS
             })
             .map(|(&call_id, call)| (call_id, call.origin.clone(), call.dest_gssi))


### PR DESCRIPTION
…the floor

`check_network_media_inactivity` releases any call matching `origin == Network && tx_active && last_activity_at > 10 s`, but `last_activity_at` is only refreshed by inbound backhaul voice frames.

When a local MS takes the floor of a network-origin group call — answering an ongoing call from the network — `origin` stays `Network` and `tx_active` stays `true`, while no backhaul media is due any more: the audio now flows the other way. The staleness test therefore fires mid-transmission and sends D-RELEASE to the very radio that is talking, which the MS shows as a denied/aborted PTT. The 10 s countdown runs from the previous network speaker's last frame, so the cut can land only a couple of seconds into the local transmission.

`grant_floor` already receives the local speaker's address (`Some(addr)` from the U-TX DEMAND paths, `None` from the network path) but discarded it unless the call origin was already `Local`. Record it as `local_floor` and exclude those calls from the watchdog. UMAC's UL-inactivity timer already owns the stuck-floor case for a local talker, as the existing doc comment notes.

Observed on a live cell running v0.4.0: a local transmission died after 99 voice frames with `releasing network group call_id=231 gssi=214 — no backhaul media for >10s`, followed by a `call_id mismatch` once the freed timeslot was reused. With the fix, local transmissions of 696 and 856 frames (42 s and 51 s) complete normally and none of that fallout appears.