### PR TITLE
Miura

### DIFF
--- a/crates/tetra-entities/src/cmce/subentities/cc_bs/pdu.rs
+++ b/crates/tetra-entities/src/cmce/subentities/cc_bs/pdu.rs
@@ -914,6 +914,20 @@ impl CcBsSubentity {
         let prim = Self::build_sapmsg(sdu, None, self.dltime, dest_addr, None);
         queue.push_back(prim);
 
+        // Also deliver D-RELEASE via FACCH stealing directly on the call's own traffic timeslot,
+        // mirroring send_d_tx_ceased_facch. The ts1/MCCH copy above is a single unacknowledged
+        // burst; an MS still monitoring the traffic channel through hangtime (as it should be)
+        // can miss it entirely if it isn't tuned to ts1 at that exact instant. Observed on a
+        // Sepura SRP2000: the resulting silent traffic-channel teardown is then reported as a
+        // downlink reception failure (RDC_fail) rather than a normal release, triggering a full
+        // band rescan and re-registration instead of a clean return to the control channel.
+        if let Some(call) = self.active_calls.get(&call_id) {
+            let sdu_facch = Self::build_d_release_from_d_setup(&cached.pdu, disconnect_cause);
+            let facch_msg =
+                Self::build_sapmsg_stealing(sdu_facch, self.dltime, dest_addr, call.carrier_num, call.ts, None);
+            queue.push_back(facch_msg);
+        }
+
         // Close the circuit in CircuitMgr and notify Brew
         if let Some(call) = self.active_calls.get(&call_id) {
             let ts = call.ts;

--- a/crates/tetra-entities/src/cmce/subentities/cc_bs/state/mod.rs
+++ b/crates/tetra-entities/src/cmce/subentities/cc_bs/state/mod.rs
@@ -172,6 +172,11 @@ pub(super) struct ActiveCall {
     /// Brew session UUID — set when a network speaker is active on this call,
     /// regardless of call origin. Cleared when the network speaker ends.
     pub(super) brew_uuid: Option<uuid::Uuid>,
+    /// True while the floor is held by a local MS rather than a network speaker. A network-origin
+    /// call whose floor a local radio has taken over stops seeing backhaul media (the audio now
+    /// flows the other way), so `last_activity_at` goes stale and the network-media watchdog would
+    /// release the call mid-transmission. UMAC's UL-inactivity timer owns the stuck-floor case here.
+    pub(super) local_floor: bool,
 }
 
 impl ActiveCall {
@@ -188,6 +193,7 @@ impl ActiveCall {
         priority: u8,
     ) -> Self {
         Self {
+            local_floor: true,
             origin: CallOrigin::Local { caller_addr },
             dest_gssi,
             source_issi,
@@ -223,6 +229,7 @@ impl ActiveCall {
         priority: u8,
     ) -> Self {
         Self {
+            local_floor: false,
             origin: CallOrigin::Network { brew_uuid },
             dest_gssi,
             source_issi,
@@ -297,6 +304,7 @@ impl ActiveCall {
         self.tx_active = true;
         self.hangtime_start = None;
         self.queued_tx_demand = None;
+        self.local_floor = speaker_addr.is_some();
 
         if let (CallOrigin::Local { caller_addr }, Some(addr)) = (&mut self.origin, speaker_addr) {
             *caller_addr = addr;

--- a/crates/tetra-entities/src/cmce/subentities/cc_bs/timers.rs
+++ b/crates/tetra-entities/src/cmce/subentities/cc_bs/timers.rs
@@ -562,11 +562,19 @@ impl CcBsSubentity {
 
     /// Handle UL inactivity timeout from UMAC: a radio disappeared mid-transmission.
     /// Force the group floor to released and enter hangtime.
+    ///
+    /// Only calls whose floor is held by a local MS (`local_floor`) are eligible: the timer arms
+    /// off `last_ul_voice`, which a single stray uplink burst in the traffic slot is enough to
+    /// set — a radio keying up while the network speaker holds the floor, or a burst decoded at
+    /// the edge of coverage. Without the check, that lone burst tears down an in-progress
+    /// network call three seconds later and, via `notify_floor_released`, tells the backhaul the
+    /// call is over while it is still streaming. A network-held floor is covered by
+    /// [`Self::check_network_media_inactivity`] and the absolute call time-out instead.
     pub(super) fn handle_ul_inactivity_timeout_slot(&mut self, queue: &mut MessageQueue, carrier_num: u16, ts: u8) {
         let call_id = self
             .active_calls
             .iter()
-            .find(|(_, call)| call.carrier_num == carrier_num && call.ts == ts && call.is_tx_active())
+            .find(|(_, call)| call.carrier_num == carrier_num && call.ts == ts && call.is_tx_active() && call.local_floor)
             .map(|(call_id, _)| *call_id);
 
         let Some(call_id) = call_id else {

--- a/crates/tetra-entities/src/cmce/subentities/cc_bs/timers.rs
+++ b/crates/tetra-entities/src/cmce/subentities/cc_bs/timers.rs
@@ -526,7 +526,9 @@ impl CcBsSubentity {
     /// transmitting are eligible: once GROUP_IDLE arrives the call drops to hang-time
     /// (`tx_active == false`) and the hang-time timer owns its teardown, and local calls never
     /// refresh `last_activity_at` so they are excluded by the origin filter (their stuck-floor
-    /// case is covered by UMAC's UL-inactivity timer).
+    /// case is covered by UMAC's UL-inactivity timer). `local_floor` extends that same exclusion
+    /// to a network-origin call whose floor a local MS has taken over: no backhaul media is due
+    /// while the local radio talks, so the staleness test would otherwise cut it off mid-PTT.
     pub(super) fn check_network_media_inactivity(&mut self, queue: &mut MessageQueue) {
         let stale: Vec<(u16, CallOrigin, u32)> = self
             .active_calls
@@ -534,6 +536,7 @@ impl CcBsSubentity {
             .filter(|(_, call)| {
                 matches!(call.origin, CallOrigin::Network { .. })
                     && call.tx_active
+                    && !call.local_floor
                     && call.last_activity_at.age(self.dltime) > NETWORK_MEDIA_INACTIVITY_TS
             })
             .map(|(&call_id, call)| (call_id, call.origin.clone(), call.dest_gssi))

--- a/crates/tetra-entities/src/umac/umac_bs.rs
+++ b/crates/tetra-entities/src/umac/umac_bs.rs
@@ -371,8 +371,16 @@ impl UmacBs {
             cell_change_flag: false,
             carrier_num,
             ext: None,
-            mon_pattern: 0,
-            frame18_mon_pattern: Some(0),
+            // Explicitly assign Monitoring Pattern Number (MPN) 1 (ETSI EN 300 392-2 clause 9.6) instead
+            // of the mon_pattern=0 special case. With mon_pattern=0 (paired with frame18_mon_pattern=0),
+            // some MSs — observed on Sepura SRP2000 — apply a more aggressive control-channel monitoring
+            // regime while transmitting, interrupting their own uplink synchronization enough that a
+            // sustained continuous PTT (~8-9s+) degrades until the BS's UL-inactivity watchdog fires and
+            // forces TX ceased. Motorola radios were not observed to be affected by the mon_pattern=0 case.
+            // Assigning an explicit MPN (1) resolves this; confirmed stable over 60+ second continuous
+            // transmissions with Sepura SRP2000.
+            mon_pattern: 1,
+            frame18_mon_pattern: None,
         })
     }
 


### PR DESCRIPTION
Resumen del fix para GitHub
Archivo: crates/tetra-entities/src/umac/umac_bs.rs
Función: cmce_to_mac_chanalloc
Causa raíz: el elemento CHANNEL ALLOCATION que el BS envía al radio siempre codificaba mon_pattern: 0 junto con frame18_mon_pattern: Some(0). Según ETSI EN 300 392-2 (cláusula 9.6, "Monitoring pattern for transmitting MSs"), el BS puede asignar un patrón de monitorización numerado (MPN 1-3) al radio durante el establecimiento de la llamada, indicándole exactamente qué frames monitorizar del canal de control mientras transmite. Con mon_pattern=0, el Sepura interpretaba/aplicaba un régimen de monitorización más agresivo que con un patrón explícito — interrumpiendo su propia recepción/sincronismo lo suficiente como para que, tras ~8-9 segundos de PTT continuo, la señal recibida por el BS se degradara hasta disparar el timeout de inactividad UL (ul_inactivity_secs) y cortar la transmisión. El Motorola no se veía afectado por manejar ese mismo caso de forma más tolerante.