### PR TITLE
Feature: expand public overview with live TETRA RF activity.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /target/
+/config.toml

--- a/crates/tetra-entities/src/net_dashboard/html.rs
+++ b/crates/tetra-entities/src/net_dashboard/html.rs
@@ -265,6 +265,10 @@ a.callsign:hover{
 .public-table .callsign{margin-left:0;}
 .public-table td,.public-table th{white-space:nowrap;}
 .public-table td:last-child,.public-table th:last-child{white-space:normal;}
+.public-mode .sidebar-nav{display:none!important;}
+.public-mode .sidebar-footer{margin-top:auto;}
+.public-rf-sub{display:flex;flex-wrap:wrap;gap:4px 12px;margin-top:2px;}
+.public-rf-sub span{white-space:nowrap;}
 @media(max-width:1050px){.public-dashboard-grid{grid-template-columns:1fr;}}
 
 .sidebar-nav{
@@ -2494,14 +2498,18 @@ tbody tr:hover td{background:color-mix(in srgb,var(--bg3) 70%, transparent);}
           <div class="stat-icon" data-icon="calls"></div>
         </div>
         <div class="stat-card" id="pub-rf-card">
-          <div class="stat-label">RF</div>
-          <div class="stat-value is-text" id="pub-rf">—</div>
-          <div class="stat-sub" id="pub-freq">—</div>
+          <div class="stat-label">RF · <span id="pub-rf-state">—</span></div>
+          <div class="stat-value is-text" id="pub-carrier">—</div>
+          <div class="stat-sub public-rf-sub">
+            <span id="pub-tx">TX / DL —</span>
+            <span id="pub-rx">RX / UL —</span>
+          </div>
           <div class="stat-icon" data-icon="rf"></div>
         </div>
         <div class="stat-card" id="pub-brew-card">
           <div class="stat-label">Network</div>
           <div class="stat-value is-text" id="pub-brew">—</div>
+          <div class="stat-sub" id="pub-netid">MCC — · MNC —</div>
           <div class="stat-sub" id="pub-ver">—</div>
           <div class="stat-icon" data-icon="network"></div>
         </div>
@@ -2549,7 +2557,7 @@ tbody tr:hover td{background:color-mix(in srgb,var(--bg3) 70%, transparent);}
               <div class="table-wrap">
                 <table class="public-table">
                   <thead><tr>
-                    <th>TS</th><th>Type</th><th>Caller</th><th>Target</th><th>Duration</th>
+                    <th>TS</th><th>Type</th><th>Speaker</th><th>Target</th><th>Duration</th>
                   </tr></thead>
                   <tbody id="pub-calls-tbody"></tbody>
                 </table>
@@ -2561,7 +2569,6 @@ tbody tr:hover td{background:color-mix(in srgb,var(--bg3) 70%, transparent);}
         <div class="card">
           <div class="card-head">
             <div class="card-title">RF Activity / Last Heard</div>
-            <div class="card-actions"><span class="muted">RadioID → QRZ</span></div>
           </div>
           <div class="card-body">
             <div class="table-wrap">
@@ -9022,13 +9029,16 @@ async function boot(){
 function enterPublicMode(){
   // Anonymous read-only mode: no WS and no privileged APIs. The public endpoint is polled,
   // Pi-Star-style, while all control/configuration surfaces remain behind Login.
+  document.body.classList.add('public-mode');
   document.querySelectorAll('.nav-item').forEach(n=>{ n.style.display='none'; });
+  const title=document.getElementById('topbar-title');if(title)title.textContent='Dashboard';
+  document.title='TETRA FlowStation — Dashboard';
   const lb=document.getElementById('login-btn'); if(lb) lb.style.display='inline-flex';
   const lo=document.getElementById('logout-btn'); if(lo) lo.style.display='none';
   document.querySelectorAll('.page').forEach(p=>p.classList.remove('active'));
   const pp=document.getElementById('page-public'); if(pp) pp.classList.add('active');
   pollPublic();
-  setInterval(pollPublic, 2000);
+  setInterval(pollPublic, 1000);
 }
 
 function publicIdentity(issi,cs,fl){
@@ -9083,18 +9093,53 @@ function renderPublicCalls(calls){
     const type=c.call_type==='group'
       ? '<span class="pill pill-info">Group</span>'
       : '<span class="pill pill-warn">'+(c.simplex?'Private simplex':'Private')+'</span>';
-    const caller=publicIdentity(c.caller_issi,c.caller_callsign,c.caller_flag);
-    const callerHtml=(caller.call||'')+(caller.call?' ':'')+caller.issi;
+    const speaker=publicIdentity(
+      c.speaker_issi||c.caller_issi,
+      c.speaker_callsign||c.caller_callsign,
+      c.speaker_flag||c.caller_flag
+    );
+    const speakerHtml=(speaker.call||'')+(speaker.call?' ':'')+speaker.issi;
     let target;
     if(c.call_type==='group')target='<code>TG '+c.gssi+'</code>';
     else {
-      const called=publicIdentity(c.called_issi,c.called_callsign,c.called_flag);
-      target=(called.call||'')+(called.call?' ':'')+called.issi;
+      const speakerIsCaller=(c.speaker_issi||c.caller_issi)===c.caller_issi;
+      const peer=speakerIsCaller
+        ? publicIdentity(c.called_issi,c.called_callsign,c.called_flag)
+        : publicIdentity(c.caller_issi,c.caller_callsign,c.caller_flag);
+      target=(peer.call||'')+(peer.call?' ':'')+peer.issi;
     }
     const ts='C'+c.carrier_num+' / TS'+c.ts;
-    return '<tr><td><code>'+ts+'</code></td><td>'+type+'</td><td>'+callerHtml+'</td><td>'+target+'</td><td><span class="num accent">'+formatDur(c.started_secs_ago||0)+'</span></td></tr>';
+    return '<tr><td><code>'+ts+'</code></td><td>'+type+'</td><td>'+speakerHtml+'</td><td>'+target+'</td><td><span class="num accent">'+formatDur(c.started_secs_ago||0)+'</span></td></tr>';
   }).join('');
 }
+function publicFreq(hz){
+  const n=Number(hz||0);
+  return n>0?(n/1e6).toFixed(4)+' MHz':'—';
+}
+function renderPublicCell(cell,rfActive){
+  const setT=(id,v)=>{const e=document.getElementById(id);if(e)e.textContent=v;};
+  setT('pub-rf-state',rfActive?'Active':'Idle');
+  if(!cell){
+    setT('pub-carrier','—');setT('pub-tx','TX / DL —');setT('pub-rx','RX / UL —');
+    setT('pub-netid','MCC — · MNC —');
+    return;
+  }
+  const carriers=Array.isArray(cell.carriers)?cell.carriers:[];
+  const carrText=carriers.length
+    ? carriers.map(c=>'C'+c.carrier).join(' + ')
+    : (cell.main_carrier!=null?'C'+cell.main_carrier:'—');
+  setT('pub-carrier',carrText);
+  if(carriers.length<=1){
+    const c=carriers[0]||{};
+    setT('pub-tx','TX / DL '+publicFreq(c.tx_dl_hz));
+    setT('pub-rx','RX / UL '+publicFreq(c.rx_ul_hz));
+  }else{
+    setT('pub-tx','TX / DL '+carriers.map(c=>'C'+c.carrier+' '+publicFreq(c.tx_dl_hz)).join(' · '));
+    setT('pub-rx','RX / UL '+carriers.map(c=>'C'+c.carrier+' '+publicFreq(c.rx_ul_hz)).join(' · '));
+  }
+  setT('pub-netid','MCC '+(cell.mcc??'—')+' · MNC '+(cell.mnc??'—'));
+}
+
 function setPublicConnectionStatus(d){
   // Public mode intentionally has no WebSocket. A successful /api/public response itself proves
   // that the FlowStation dashboard process is alive, so mirror that as BS ONLINE instead of
@@ -9143,18 +9188,39 @@ function renderPublicLastHeard(entries){
       +'</tr>';
   }).join('');
 }
+let publicPollInFlight=false;
+let publicLastOk=0;
+function markPublicStale(){
+  if(!publicLastOk||Date.now()-publicLastOk<5000)return;
+  const connLed=document.getElementById('connLed');if(connLed)connLed.classList.remove('on');
+  const connText=document.getElementById('connText');
+  if(connText){connText.textContent='STALE';connText.style.color='var(--warn)';}
+  const bs=document.getElementById('chip-bs');
+  if(bs){
+    bs.className='pill pill-warn';
+    const lbl=bs.querySelector('[data-i18n="bs_label"]');if(lbl)lbl.textContent='BS STALE';
+  }
+}
 async function pollPublic(){
+  if(publicPollInFlight)return;
+  publicPollInFlight=true;
+  const ctl=new AbortController();
+  const timeout=setTimeout(()=>ctl.abort(),1800);
   try{
-    const r=await fetch('/api/public', {credentials:'same-origin'});
-    if(!r.ok)return;
+    const r=await fetch('/api/public', {
+      credentials:'same-origin',
+      cache:'no-store',
+      signal:ctl.signal
+    });
+    if(!r.ok)throw new Error('HTTP '+r.status);
     const d=await r.json();
+    publicLastOk=Date.now();
     const setT=(id,v)=>{const e=document.getElementById(id);if(e)e.textContent=v;};
     setT('pub-ms',d.registered_ms??'—');
     setT('pub-calls',d.active_calls??0);
-    setT('pub-freq',d.center_freq_hz?(d.center_freq_hz/1e6).toFixed(4)+' MHz':'—');
-    setT('pub-rf',d.rf_active?'Active':'Idle');
     setT('pub-brew',d.brew_online?'Online':'Offline');
     setT('pub-ver',d.stack_version||'—');
+    renderPublicCell(d.cell||null,!!d.rf_active);
     setPublicConnectionStatus(d);
     const STAT_STATES=['is-ok','is-idle','is-info','is-warn','is-danger'];
     const rfc=document.getElementById('pub-rf-card');
@@ -9164,7 +9230,12 @@ async function pollPublic(){
     renderPublicTimeslots(d.calls||[]);
     renderPublicCalls(d.calls||[]);
     renderPublicLastHeard(d.last_heard||[]);
-  }catch{/* public dashboard stays on the last good snapshot */}
+  }catch{
+    markPublicStale();
+  }finally{
+    clearTimeout(timeout);
+    publicPollInFlight=false;
+  }
 }
 
 boot();

--- a/crates/tetra-entities/src/net_dashboard/html.rs
+++ b/crates/tetra-entities/src/net_dashboard/html.rs
@@ -265,6 +265,33 @@ a.callsign:hover{
 .public-table .callsign{margin-left:0;}
 .public-table td,.public-table th{white-space:nowrap;}
 .public-table td:last-child,.public-table th:last-child{white-space:normal;}
+.public-lastheard-table th:nth-child(1),
+.public-lastheard-table td:nth-child(1),
+.public-lastheard-table th:nth-child(2),
+.public-lastheard-table td:nth-child(2),
+.public-lastheard-table th:nth-child(3),
+.public-lastheard-table td:nth-child(3),
+.public-lastheard-table th:nth-child(4),
+.public-lastheard-table td:nth-child(4){
+  width:1%;
+}
+.public-lastheard-table th:nth-child(2),
+.public-lastheard-table td:nth-child(2){padding-right:6px;}
+.public-lastheard-table th:nth-child(3),
+.public-lastheard-table td:nth-child(3){padding-left:6px;}
+.public-calls-wrap{
+  --public-call-rows:3;
+  height:calc(33px + (var(--public-call-rows) * 34px));
+  overflow-y:auto;
+}
+.public-call-placeholder td{
+  height:34px;
+  padding-top:0;
+  padding-bottom:0;
+  color:transparent;
+  user-select:none;
+}
+.public-call-placeholder:hover td{background:transparent;}
 .public-mode .sidebar-nav{display:none!important;}
 .public-mode .sidebar-footer{margin-top:auto;}
 .public-rf-freqs{
@@ -2581,7 +2608,7 @@ tbody tr:hover td{background:color-mix(in srgb,var(--bg3) 70%, transparent);}
           <div class="card">
             <div class="card-head"><div class="card-title">Current Calls</div></div>
             <div class="card-body">
-              <div class="table-wrap">
+              <div class="table-wrap public-calls-wrap" id="pub-calls-wrap">
                 <table class="public-table">
                   <thead><tr>
                     <th>TS</th><th>Type</th><th>Speaker</th><th>Target</th><th>Duration</th>
@@ -2599,7 +2626,7 @@ tbody tr:hover td{background:color-mix(in srgb,var(--bg3) 70%, transparent);}
           </div>
           <div class="card-body">
             <div class="table-wrap">
-              <table class="public-table">
+              <table class="public-table public-lastheard-table">
                 <thead><tr>
                   <th>Time</th><th>Callsign</th><th>ISSI</th><th>Activity</th><th>Target</th>
                 </tr></thead>
@@ -9084,6 +9111,9 @@ function publicActivityBadge(activity){
 function publicTarget(e){
   if(!e||!e.dest)return '<span class="muted">—</span>';
   if(e.activity==='call_group')return '<code>TG '+e.dest+'</code>';
+  if(e.activity==='call_individual'&&e.dest_callsign){
+    return qrzCallsign(e.dest_callsign,e.dest_flag);
+  }
   return '<code>'+e.dest+'</code>';
 }
 function renderPublicTimeslots(calls){
@@ -9112,11 +9142,15 @@ function renderPublicTimeslots(calls){
     if(dur)dur.style.width=Math.min(100,((c.started_secs_ago||0)/120)*100)+'%';
   }
 }
-function renderPublicCalls(calls){
+function renderPublicCalls(calls,cell){
   const tb=document.getElementById('pub-calls-tbody');if(!tb)return;
+  const wrap=document.getElementById('pub-calls-wrap');
+  const carrierCount=cell&&Array.isArray(cell.carriers)&&cell.carriers.length>1?cell.carriers.length:1;
+  const rowCapacity=carrierCount>1?7:3;
+  if(wrap)wrap.style.setProperty('--public-call-rows',String(rowCapacity));
+
   const arr=[...(calls||[])].sort((a,b)=>(a.carrier_num-b.carrier_num)||(a.ts-b.ts));
-  if(!arr.length){tb.innerHTML='<tr><td colspan="5"><div class="empty-state"><div class="empty-msg">No active calls</div></div></td></tr>';return;}
-  tb.innerHTML=arr.map(c=>{
+  const rows=arr.map(c=>{
     const type=c.call_type==='group'
       ? '<span class="pill pill-info">Group</span>'
       : '<span class="pill pill-warn">'+(c.simplex?'Private simplex':'Private')+'</span>';
@@ -9127,17 +9161,24 @@ function renderPublicCalls(calls){
     );
     const speakerHtml=(speaker.call||'')+(speaker.call?' ':'')+speaker.issi;
     let target;
-    if(c.call_type==='group')target='<code>TG '+c.gssi+'</code>';
-    else {
+    if(c.call_type==='group'){
+      target='<code>TG '+c.gssi+'</code>';
+    }else{
       const speakerIsCaller=(c.speaker_issi||c.caller_issi)===c.caller_issi;
-      const peer=speakerIsCaller
-        ? publicIdentity(c.called_issi,c.called_callsign,c.called_flag)
-        : publicIdentity(c.caller_issi,c.caller_callsign,c.caller_flag);
-      target=(peer.call||'')+(peer.call?' ':'')+peer.issi;
+      const peerCs=speakerIsCaller?c.called_callsign:c.caller_callsign;
+      const peerFlag=speakerIsCaller?c.called_flag:c.caller_flag;
+      const peerIssi=speakerIsCaller?c.called_issi:c.caller_issi;
+      target=peerCs?qrzCallsign(peerCs,peerFlag):('<code>'+peerIssi+'</code>');
     }
     const ts='C'+c.carrier_num+' / TS'+c.ts;
     return '<tr><td><code>'+ts+'</code></td><td>'+type+'</td><td>'+speakerHtml+'</td><td>'+target+'</td><td><span class="num accent">'+formatDur(c.started_secs_ago||0)+'</span></td></tr>';
-  }).join('');
+  });
+
+  const placeholders=Math.max(0,rowCapacity-arr.length);
+  for(let i=0;i<placeholders;i++){
+    rows.push('<tr class="public-call-placeholder" aria-hidden="true"><td>&nbsp;</td><td></td><td></td><td></td><td></td></tr>');
+  }
+  tb.innerHTML=rows.join('');
 }
 function publicFreq(hz){
   const n=Number(hz||0);
@@ -9265,7 +9306,7 @@ async function pollPublic(){
     const pbc=document.getElementById('pub-brew-card');
     if(pbc){pbc.classList.remove(...STAT_STATES);pbc.classList.add(d.brew_online?'is-info':'is-danger');}
     renderPublicTimeslots(d.calls||[]);
-    renderPublicCalls(d.calls||[]);
+    renderPublicCalls(d.calls||[],d.cell||null);
     renderPublicLastHeard(d.last_heard||[]);
   }catch{
     markPublicStale();

--- a/crates/tetra-entities/src/net_dashboard/html.rs
+++ b/crates/tetra-entities/src/net_dashboard/html.rs
@@ -252,6 +252,20 @@ body{
   font-family:var(--mono);font-size:11px;font-weight:700;letter-spacing:0.02em;
   vertical-align:middle;
 }
+a.callsign{ text-decoration:none; transition:background .15s ease,color .15s ease,box-shadow .15s ease; }
+a.callsign:hover{
+  color:var(--text);
+  background:color-mix(in srgb,var(--accent2) 20%,transparent);
+  box-shadow:0 0 0 1px color-mix(in srgb,var(--accent2) 30%,transparent);
+}
+.public-dashboard-grid{display:grid;grid-template-columns:minmax(300px,.85fr) minmax(480px,1.55fr);gap:14px;margin-bottom:14px;}
+.public-stack{display:flex;flex-direction:column;gap:14px;min-width:0;}
+.public-note{display:flex;align-items:center;gap:8px;color:var(--text2);font-size:12px;margin:-2px 0 12px;}
+.public-note .pill{flex-shrink:0;}
+.public-table .callsign{margin-left:0;}
+.public-table td,.public-table th{white-space:nowrap;}
+.public-table td:last-child,.public-table th:last-child{white-space:normal;}
+@media(max-width:1050px){.public-dashboard-grid{grid-template-columns:1fr;}}
 
 .sidebar-nav{
   flex:1;padding:8px 8px;overflow-y:auto;overflow-x:hidden;
@@ -2459,8 +2473,13 @@ tbody tr:hover td{background:color-mix(in srgb,var(--bg3) 70%, transparent);}
   <!-- Content -->
   <div id="content">
 
-    <!-- ── PUBLIC OVERVIEW (FH-FEAT-033) — shown only to anonymous visitors when public_overview is on ── -->
+    <!-- ── PUBLIC OVERVIEW — Pi-Star-inspired information density, FlowStation visual language ── -->
     <div class="page" id="page-public">
+      <div class="public-note">
+        <span class="pill pill-info">PUBLIC</span>
+        <span>Read-only RF activity. Log in for configuration and controls.</span>
+      </div>
+
       <div class="stat-grid">
         <div class="stat-card green">
           <div class="stat-label">Radios</div>
@@ -2487,13 +2506,72 @@ tbody tr:hover td{background:color-mix(in srgb,var(--bg3) 70%, transparent);}
           <div class="stat-icon" data-icon="network"></div>
         </div>
       </div>
-      <div class="card">
-        <div class="card-head"><div class="card-title">Cell Status</div></div>
-        <div class="card-body">
-          <div class="empty-state">
-            <span class="empty-ico" data-icon="login"></span>
-            <div class="empty-msg">Read-only public overview</div>
-            <div class="empty-sub">Log in for full access and controls.</div>
+
+      <div class="public-dashboard-grid">
+        <div class="public-stack">
+          <div class="card">
+            <div class="card-head">
+              <div class="card-title">RF Channel — Timeslots</div>
+            </div>
+            <div class="card-body">
+              <div class="ts-grid" id="pub-ts-grid">
+                <div class="ts-block mcch" id="pub-ts-block-1">
+                  <div class="ts-num">TS 1</div><div class="ts-led"></div>
+                  <div class="ts-wave"></div>
+                  <div class="ts-label">MCCH</div><div class="ts-sub">ACTIVE</div>
+                  <div class="ts-duration-bar"></div>
+                </div>
+                <div class="ts-block" id="pub-ts-block-2">
+                  <div class="ts-num">TS 2</div><div class="ts-timer"></div><div class="ts-led"></div>
+                  <div class="ts-wave"></div>
+                  <div class="ts-label">—</div><div class="ts-sub">Idle</div>
+                  <div class="ts-duration-bar"></div>
+                </div>
+                <div class="ts-block" id="pub-ts-block-3">
+                  <div class="ts-num">TS 3</div><div class="ts-timer"></div><div class="ts-led"></div>
+                  <div class="ts-wave"></div>
+                  <div class="ts-label">—</div><div class="ts-sub">Idle</div>
+                  <div class="ts-duration-bar"></div>
+                </div>
+                <div class="ts-block" id="pub-ts-block-4">
+                  <div class="ts-num">TS 4</div><div class="ts-timer"></div><div class="ts-led"></div>
+                  <div class="ts-wave"></div>
+                  <div class="ts-label">—</div><div class="ts-sub">Idle</div>
+                  <div class="ts-duration-bar"></div>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <div class="card">
+            <div class="card-head"><div class="card-title">Current Calls</div></div>
+            <div class="card-body">
+              <div class="table-wrap">
+                <table class="public-table">
+                  <thead><tr>
+                    <th>TS</th><th>Type</th><th>Caller</th><th>Target</th><th>Duration</th>
+                  </tr></thead>
+                  <tbody id="pub-calls-tbody"></tbody>
+                </table>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="card">
+          <div class="card-head">
+            <div class="card-title">RF Activity / Last Heard</div>
+            <div class="card-actions"><span class="muted">RadioID → QRZ</span></div>
+          </div>
+          <div class="card-body">
+            <div class="table-wrap">
+              <table class="public-table">
+                <thead><tr>
+                  <th>Time</th><th>Callsign</th><th>ISSI</th><th>Activity</th><th>Target</th>
+                </tr></thead>
+                <tbody id="pub-lastheard-tbody"></tbody>
+              </table>
+            </div>
           </div>
         </div>
       </div>
@@ -5200,7 +5278,19 @@ let dgnaUi={selectedGssi:0,targetChecks:{},statusLog:[],lastByIssi:{}};
 let callsigns={};
 let _csInflight=false;
 // Render an ISSI with its RadioID callsign (and country flag, when known) appended.
-function idCell(issi){const c=callsigns[issi];if(!c||!c.cs)return `<code>${issi}</code>`;const fl=c.fl?c.fl+' ':'';return `<code>${issi}</code> <span class="callsign">${fl}${escHtml(c.cs)}</span>`;}
+function qrzCallsign(cs,fl){
+  if(!cs)return '';
+  const clean=String(cs).trim().toUpperCase();
+  if(!clean)return '';
+  const flag=fl?escHtml(fl)+' ':'';
+  const href='https://www.qrz.com/db/'+encodeURIComponent(clean);
+  return `<a class="callsign" href="${href}" target="_blank" rel="noopener noreferrer" title="Open ${escHtmlAttr(clean)} on QRZ.com">${flag}${escHtml(clean)}</a>`;
+}
+function idCell(issi){
+  const c=callsigns[issi];
+  if(!c||!c.cs)return `<code>${issi}</code>`;
+  return `<code>${issi}</code> ${qrzCallsign(c.cs,c.fl)}`;
+}
 // Resolve callsigns for every ISSI currently on screen we have not looked up yet. On-demand: the
 // server fetches unknowns from RadioID in the background and caches them locally; pending IDs are
 // omitted from the response and retried on the next tick. Found/absent results are cached here.
@@ -8930,35 +9020,118 @@ async function boot(){
   checkUpdate();
 }
 function enterPublicMode(){
-  // Anonymous read-only mode: hide every admin nav item + logout, reveal Login, show only the
-  // public overview page, and poll the narrow public snapshot. No WS, no privileged fetches.
+  // Anonymous read-only mode: no WS and no privileged APIs. The public endpoint is polled,
+  // Pi-Star-style, while all control/configuration surfaces remain behind Login.
   document.querySelectorAll('.nav-item').forEach(n=>{ n.style.display='none'; });
   const lb=document.getElementById('login-btn'); if(lb) lb.style.display='inline-flex';
   const lo=document.getElementById('logout-btn'); if(lo) lo.style.display='none';
   document.querySelectorAll('.page').forEach(p=>p.classList.remove('active'));
   const pp=document.getElementById('page-public'); if(pp) pp.classList.add('active');
   pollPublic();
-  setInterval(pollPublic, 3000);
+  setInterval(pollPublic, 2000);
+}
+
+function publicIdentity(issi,cs,fl){
+  const call=qrzCallsign(cs,fl);
+  return {call, issi: issi?('<code>'+issi+'</code>'):'<span class="muted">—</span>'};
+}
+function publicCallsignOnly(cs,fl){
+  return cs?qrzCallsign(cs,fl):'<span class="muted">—</span>';
+}
+function publicActivityBadge(activity){
+  if(activity==='call_group')return '<span class="pill pill-info">Group call</span>';
+  if(activity==='call_individual')return '<span class="pill pill-warn">Private call</span>';
+  if(activity==='sds')return '<span class="pill pill-info">SDS</span>';
+  return '<span class="pill pill-idle">'+escHtml(activity||'—')+'</span>';
+}
+function publicTarget(e){
+  if(!e||!e.dest)return '<span class="muted">—</span>';
+  if(e.activity==='call_group')return '<code>TG '+e.dest+'</code>';
+  return '<code>'+e.dest+'</code>';
+}
+function renderPublicTimeslots(calls){
+  const byTs={};
+  (calls||[]).forEach(c=>{
+    if(c.ts>=2&&c.ts<=4)byTs[c.ts]=c;
+    if(c.peer_ts>=2&&c.peer_ts<=4&&!byTs[c.peer_ts])byTs[c.peer_ts]=c;
+  });
+  for(let ts=1;ts<=4;ts++){
+    const b=document.getElementById('pub-ts-block-'+ts);if(!b)continue;
+    const label=b.querySelector('.ts-label'),sub=b.querySelector('.ts-sub'),timer=b.querySelector('.ts-timer'),dur=b.querySelector('.ts-duration-bar');
+    if(ts===1){
+      b.className='ts-block mcch';label.textContent='MCCH';sub.textContent='ACTIVE';if(timer)timer.textContent='';if(dur)dur.style.width='0%';continue;
+    }
+    const c=byTs[ts];
+    if(!c){
+      b.className='ts-block';label.textContent='—';sub.textContent='Idle';if(timer)timer.textContent='';if(dur)dur.style.width='0%';continue;
+    }
+    b.className='ts-block call';
+    if((c.priority||0)>=15)b.classList.add('emergency');
+    label.textContent=c.call_type==='group'?('GSSI '+c.gssi):'PRIVATE';
+    const spk=c.speaker_issi||c.caller_issi;
+    const cs=c.speaker_callsign||c.caller_callsign;
+    sub.textContent=cs?(spk+' · '+cs):('ISSI '+spk);
+    if(timer)timer.textContent=formatDur(c.started_secs_ago||0);
+    if(dur)dur.style.width=Math.min(100,((c.started_secs_ago||0)/120)*100)+'%';
+  }
+}
+function renderPublicCalls(calls){
+  const tb=document.getElementById('pub-calls-tbody');if(!tb)return;
+  const arr=[...(calls||[])].sort((a,b)=>(a.carrier_num-b.carrier_num)||(a.ts-b.ts));
+  if(!arr.length){tb.innerHTML='<tr><td colspan="5"><div class="empty-state"><div class="empty-msg">No active calls</div></div></td></tr>';return;}
+  tb.innerHTML=arr.map(c=>{
+    const type=c.call_type==='group'
+      ? '<span class="pill pill-info">Group</span>'
+      : '<span class="pill pill-warn">'+(c.simplex?'Private simplex':'Private')+'</span>';
+    const caller=publicIdentity(c.caller_issi,c.caller_callsign,c.caller_flag);
+    const callerHtml=(caller.call||'')+(caller.call?' ':'')+caller.issi;
+    let target;
+    if(c.call_type==='group')target='<code>TG '+c.gssi+'</code>';
+    else {
+      const called=publicIdentity(c.called_issi,c.called_callsign,c.called_flag);
+      target=(called.call||'')+(called.call?' ':'')+called.issi;
+    }
+    const ts='C'+c.carrier_num+' / TS'+c.ts;
+    return '<tr><td><code>'+ts+'</code></td><td>'+type+'</td><td>'+callerHtml+'</td><td>'+target+'</td><td><span class="num accent">'+formatDur(c.started_secs_ago||0)+'</span></td></tr>';
+  }).join('');
+}
+function renderPublicLastHeard(entries){
+  const tb=document.getElementById('pub-lastheard-tbody');if(!tb)return;
+  const arr=entries||[];
+  if(!arr.length){tb.innerHTML='<tr><td colspan="5"><div class="empty-state"><div class="empty-msg">No RF activity yet</div></div></td></tr>';return;}
+  tb.innerHTML=arr.map(e=>{
+    return '<tr>'
+      +'<td><span class="num">'+escHtml(e.ts||'—')+'</span></td>'
+      +'<td>'+publicCallsignOnly(e.callsign,e.flag)+'</td>'
+      +'<td><code>'+e.issi+'</code></td>'
+      +'<td>'+publicActivityBadge(e.activity)+'</td>'
+      +'<td>'+publicTarget(e)+'</td>'
+      +'</tr>';
+  }).join('');
 }
 async function pollPublic(){
   try{
     const r=await fetch('/api/public', {credentials:'same-origin'});
-    if(!r.ok) return;
+    if(!r.ok)return;
     const d=await r.json();
-    const setT=(id,v)=>{ const e=document.getElementById(id); if(e) e.textContent=v; };
-    setT('pub-ms', d.registered_ms ?? '—');
-    setT('pub-calls', (d.active_calls ?? 0) + (d.active_calls ? ' ('+d.group_calls+'G / '+d.individual_calls+'I)' : ''));
-    setT('pub-freq', d.center_freq_hz ? (d.center_freq_hz/1e6).toFixed(4)+' MHz' : '—');
-    setT('pub-rf', d.rf_active ? 'Active' : 'Idle');
-    setT('pub-brew', d.brew_online ? 'Online' : 'Offline');
-    setT('pub-ver', d.stack_version || '—');
+    const setT=(id,v)=>{const e=document.getElementById(id);if(e)e.textContent=v;};
+    setT('pub-ms',d.registered_ms??'—');
+    setT('pub-calls',d.active_calls??0);
+    setT('pub-freq',d.center_freq_hz?(d.center_freq_hz/1e6).toFixed(4)+' MHz':'—');
+    setT('pub-rf',d.rf_active?'Active':'Idle');
+    setT('pub-brew',d.brew_online?'Online':'Offline');
+    setT('pub-ver',d.stack_version||'—');
     const STAT_STATES=['is-ok','is-idle','is-info','is-warn','is-danger'];
     const rfc=document.getElementById('pub-rf-card');
-    if(rfc){ rfc.classList.remove(...STAT_STATES); rfc.classList.add(d.rf_active?'is-ok':'is-idle'); }
+    if(rfc){rfc.classList.remove(...STAT_STATES);rfc.classList.add(d.rf_active?'is-ok':'is-idle');}
     const pbc=document.getElementById('pub-brew-card');
-    if(pbc){ pbc.classList.remove(...STAT_STATES); pbc.classList.add(d.brew_online?'is-info':'is-danger'); }
-  }catch{/* silent */}
+    if(pbc){pbc.classList.remove(...STAT_STATES);pbc.classList.add(d.brew_online?'is-info':'is-danger');}
+    renderPublicTimeslots(d.calls||[]);
+    renderPublicCalls(d.calls||[]);
+    renderPublicLastHeard(d.last_heard||[]);
+  }catch{/* public dashboard stays on the last good snapshot */}
 }
+
 boot();
 </script>
 </body>

--- a/crates/tetra-entities/src/net_dashboard/html.rs
+++ b/crates/tetra-entities/src/net_dashboard/html.rs
@@ -6203,7 +6203,16 @@ function renderCalls(){
     const allocMeta=c.call_type==='individual'
       ? `<div style="margin-top:4px;font-family:var(--mono);font-size:10px;color:var(--text2)">${escHtml(privateAllocText(c))}</div>`
       : '';
-    const to=c.call_type==='group'?`GSSI ${c.gssi}`:`${idCell(c.called_issi)}${allocMeta}`;
+    let to;
+    if(c.call_type==='group'){
+      to=`<code>TG ${c.gssi}</code>`;
+    }else{
+      const targetCs=callsigns[c.called_issi];
+      const targetIdentity=targetCs&&targetCs.cs
+        ? qrzCallsign(targetCs.cs,targetCs.fl)
+        : `<code>${c.called_issi}</code>`;
+      to=`${targetIdentity}${allocMeta}`;
+    }
     const spk=c.active_speaker
       ? `${idCell(c.active_speaker)}${c.call_type==='individual'?` <span class="badge badge-dim" style="font-size:9px">${privatePartyRole(c,c.active_speaker)}</span>`:''}`
       : '<span style="color:var(--text3)">—</span>';

--- a/crates/tetra-entities/src/net_dashboard/html.rs
+++ b/crates/tetra-entities/src/net_dashboard/html.rs
@@ -9170,7 +9170,7 @@ function renderPublicCalls(calls,cell){
       const peerIssi=speakerIsCaller?c.called_issi:c.caller_issi;
       target=peerCs?qrzCallsign(peerCs,peerFlag):('<code>'+peerIssi+'</code>');
     }
-    const ts='C'+c.carrier_num+' / TS'+c.ts;
+    const ts=c.carrier_num+' / TS'+c.ts;
     return '<tr><td><code>'+ts+'</code></td><td>'+type+'</td><td>'+speakerHtml+'</td><td>'+target+'</td><td><span class="num accent">'+formatDur(c.started_secs_ago||0)+'</span></td></tr>';
   });
 

--- a/crates/tetra-entities/src/net_dashboard/html.rs
+++ b/crates/tetra-entities/src/net_dashboard/html.rs
@@ -282,7 +282,7 @@ a.callsign:hover{
 .public-calls-wrap{
   --public-call-rows:3;
   height:calc(33px + (var(--public-call-rows) * 34px));
-  overflow-y:auto;
+  overflow-y:hidden;
 }
 .public-call-placeholder td{
   height:34px;
@@ -2628,7 +2628,7 @@ tbody tr:hover td{background:color-mix(in srgb,var(--bg3) 70%, transparent);}
             <div class="table-wrap">
               <table class="public-table public-lastheard-table">
                 <thead><tr>
-                  <th>Time</th><th>Callsign</th><th>ISSI</th><th>Activity</th><th>Target</th>
+                  <th>Time</th><th>Callsign</th><th>ISSI</th><th>Activity</th><th>Target</th><th>Src</th>
                 </tr></thead>
                 <tbody id="pub-lastheard-tbody"></tbody>
               </table>
@@ -9255,7 +9255,7 @@ function setPublicConnectionStatus(d){
 function renderPublicLastHeard(entries){
   const tb=document.getElementById('pub-lastheard-tbody');if(!tb)return;
   const arr=entries||[];
-  if(!arr.length){tb.innerHTML='<tr><td colspan="5"><div class="empty-state"><div class="empty-msg">No RF activity yet</div></div></td></tr>';return;}
+  if(!arr.length){tb.innerHTML='<tr><td colspan="6"><div class="empty-state"><div class="empty-msg">No RF activity yet</div></div></td></tr>';return;}
   tb.innerHTML=arr.map(e=>{
     return '<tr>'
       +'<td><span class="num">'+escHtml(e.ts||'—')+'</span></td>'
@@ -9263,6 +9263,7 @@ function renderPublicLastHeard(entries){
       +'<td><code>'+e.issi+'</code></td>'
       +'<td>'+publicActivityBadge(e.activity)+'</td>'
       +'<td>'+publicTarget(e)+'</td>'
+      +'<td><span class="pill '+(e.source==='RF'?'pill-ok':'pill-info')+'">'+escHtml(e.source||'—')+'</span></td>'
       +'</tr>';
   }).join('');
 }

--- a/crates/tetra-entities/src/net_dashboard/html.rs
+++ b/crates/tetra-entities/src/net_dashboard/html.rs
@@ -6205,7 +6205,7 @@ function renderCalls(){
       : '';
     let to;
     if(c.call_type==='group'){
-      to=`<code>TG ${c.gssi}</code>`;
+      to=`<code>GSSI ${c.gssi}</code>`;
     }else{
       const targetCs=callsigns[c.called_issi];
       const targetIdentity=targetCs&&targetCs.cs
@@ -9127,7 +9127,7 @@ function publicActivityBadge(activity){
 }
 function publicTarget(e){
   if(!e||!e.dest)return '<span class="muted">—</span>';
-  if(e.activity==='call_group')return '<code>TG '+e.dest+'</code>';
+  if(e.activity==='call_group')return '<code>GSSI '+e.dest+'</code>';
   if(e.activity==='call_individual'&&e.dest_callsign){
     return qrzCallsign(e.dest_callsign,e.dest_flag);
   }
@@ -9179,7 +9179,7 @@ function renderPublicCalls(calls,cell){
       : '<code>'+speakerIssi+'</code>';
     let target;
     if(c.call_type==='group'){
-      target='<code>TG '+c.gssi+'</code>';
+      target='<code>GSSI '+c.gssi+'</code>';
     }else{
       const speakerIsCaller=(c.speaker_issi||c.caller_issi)===c.caller_issi;
       const peerCs=speakerIsCaller?c.called_callsign:c.caller_callsign;

--- a/crates/tetra-entities/src/net_dashboard/html.rs
+++ b/crates/tetra-entities/src/net_dashboard/html.rs
@@ -267,8 +267,30 @@ a.callsign:hover{
 .public-table td:last-child,.public-table th:last-child{white-space:normal;}
 .public-mode .sidebar-nav{display:none!important;}
 .public-mode .sidebar-footer{margin-top:auto;}
-.public-rf-sub{display:flex;flex-wrap:wrap;gap:4px 12px;margin-top:2px;}
-.public-rf-sub span{white-space:nowrap;}
+.public-rf-freqs{
+  display:grid;
+  grid-template-columns:1fr 1fr;
+  gap:14px;
+  margin-top:2px;
+}
+.public-rf-freq{min-width:0;}
+.public-rf-freq-label{
+  color:var(--text3);
+  font-family:var(--mono);
+  font-size:10px;
+  font-weight:700;
+  letter-spacing:.08em;
+  margin-bottom:2px;
+}
+.public-rf-freq-value{
+  color:var(--accent);
+  font-family:var(--mono);
+  font-size:18px;
+  font-weight:700;
+  line-height:1.2;
+  white-space:nowrap;
+}
+.public-rf-meta{margin-top:8px;white-space:normal;}
 @media(max-width:1050px){.public-dashboard-grid{grid-template-columns:1fr;}}
 
 .sidebar-nav{
@@ -2499,17 +2521,22 @@ tbody tr:hover td{background:color-mix(in srgb,var(--bg3) 70%, transparent);}
         </div>
         <div class="stat-card" id="pub-rf-card">
           <div class="stat-label">RF · <span id="pub-rf-state">—</span></div>
-          <div class="stat-value is-text" id="pub-carrier">—</div>
-          <div class="stat-sub public-rf-sub">
-            <span id="pub-tx">TX / DL —</span>
-            <span id="pub-rx">RX / UL —</span>
+          <div class="public-rf-freqs">
+            <div class="public-rf-freq">
+              <div class="public-rf-freq-label">DL</div>
+              <div class="public-rf-freq-value" id="pub-dl">—</div>
+            </div>
+            <div class="public-rf-freq">
+              <div class="public-rf-freq-label">UL</div>
+              <div class="public-rf-freq-value" id="pub-ul">—</div>
+            </div>
           </div>
+          <div class="stat-sub public-rf-meta" id="pub-rf-meta">Carrier: — · MCC: — · MNC: —</div>
           <div class="stat-icon" data-icon="rf"></div>
         </div>
         <div class="stat-card" id="pub-brew-card">
           <div class="stat-label">Network</div>
           <div class="stat-value is-text" id="pub-brew">—</div>
-          <div class="stat-sub" id="pub-netid">MCC — · MNC —</div>
           <div class="stat-sub" id="pub-ver">—</div>
           <div class="stat-icon" data-icon="network"></div>
         </div>
@@ -9120,24 +9147,34 @@ function renderPublicCell(cell,rfActive){
   const setT=(id,v)=>{const e=document.getElementById(id);if(e)e.textContent=v;};
   setT('pub-rf-state',rfActive?'Active':'Idle');
   if(!cell){
-    setT('pub-carrier','—');setT('pub-tx','TX / DL —');setT('pub-rx','RX / UL —');
-    setT('pub-netid','MCC — · MNC —');
+    setT('pub-dl','—');
+    setT('pub-ul','—');
+    setT('pub-rf-meta','Carrier: — · MCC: — · MNC: —');
     return;
   }
+
   const carriers=Array.isArray(cell.carriers)?cell.carriers:[];
-  const carrText=carriers.length
-    ? carriers.map(c=>'C'+c.carrier).join(' + ')
-    : (cell.main_carrier!=null?'C'+cell.main_carrier:'—');
-  setT('pub-carrier',carrText);
+  const activeCarriers=carriers.length
+    ? carriers.map(c=>c.carrier)
+    : (cell.main_carrier!=null?[cell.main_carrier]:[]);
+
+  const carrierText=activeCarriers.length?activeCarriers.join(' + '):'—';
+
   if(carriers.length<=1){
     const c=carriers[0]||{};
-    setT('pub-tx','TX / DL '+publicFreq(c.tx_dl_hz));
-    setT('pub-rx','RX / UL '+publicFreq(c.rx_ul_hz));
+    setT('pub-dl',publicFreq(c.tx_dl_hz));
+    setT('pub-ul',publicFreq(c.rx_ul_hz));
   }else{
-    setT('pub-tx','TX / DL '+carriers.map(c=>'C'+c.carrier+' '+publicFreq(c.tx_dl_hz)).join(' · '));
-    setT('pub-rx','RX / UL '+carriers.map(c=>'C'+c.carrier+' '+publicFreq(c.rx_ul_hz)).join(' · '));
+    setT('pub-dl',carriers.map(c=>publicFreq(c.tx_dl_hz)).join(' · '));
+    setT('pub-ul',carriers.map(c=>publicFreq(c.rx_ul_hz)).join(' · '));
   }
-  setT('pub-netid','MCC '+(cell.mcc??'—')+' · MNC '+(cell.mnc??'—'));
+
+  setT(
+    'pub-rf-meta',
+    'Carrier: '+carrierText+
+    ' · MCC: '+(cell.mcc??'—')+
+    ' · MNC: '+(cell.mnc??'—')
+  );
 }
 
 function setPublicConnectionStatus(d){

--- a/crates/tetra-entities/src/net_dashboard/html.rs
+++ b/crates/tetra-entities/src/net_dashboard/html.rs
@@ -278,7 +278,7 @@ a.callsign:hover{
 .public-lastheard-table th:nth-child(1),
 .public-lastheard-table td:nth-child(1){width:12%;}
 .public-lastheard-table th:nth-child(2),
-.public-lastheard-table td:nth-child(2){width:14%;}
+.public-lastheard-table td:nth-child(2){width:15%;}
 .public-lastheard-table th:nth-child(3),
 .public-lastheard-table td:nth-child(3){width:14%;}
 .public-lastheard-table th:nth-child(4),
@@ -286,8 +286,11 @@ a.callsign:hover{
 .public-lastheard-table th:nth-child(5),
 .public-lastheard-table td:nth-child(5){width:20%;}
 .public-lastheard-table th:nth-child(6),
-.public-lastheard-table td:nth-child(6){width:20%;}
+.public-lastheard-table td:nth-child(6){width:14%;}
 .public-calls-wrap{overflow:visible;}
+.public-calls-wrap table{table-layout:fixed;}
+.public-calls-wrap th,
+.public-calls-wrap td{text-align:center;}
 .public-calls-wrap tbody tr{height:36px;}
 .public-call-placeholder td{
   height:36px;
@@ -9159,12 +9162,12 @@ function renderPublicCalls(calls,cell){
     const type=c.call_type==='group'
       ? '<span class="pill pill-info">Group</span>'
       : '<span class="pill pill-warn">'+(c.simplex?'Private simplex':'Private')+'</span>';
-    const speaker=publicIdentity(
-      c.speaker_issi||c.caller_issi,
-      c.speaker_callsign||c.caller_callsign,
-      c.speaker_flag||c.caller_flag
-    );
-    const speakerHtml=(speaker.call||'')+(speaker.call?' ':'')+speaker.issi;
+    const speakerIssi=c.speaker_issi||c.caller_issi;
+    const speakerCs=c.speaker_callsign||c.caller_callsign;
+    const speakerFlag=c.speaker_flag||c.caller_flag;
+    const speakerHtml=speakerCs
+      ? qrzCallsign(speakerCs,speakerFlag)
+      : '<code>'+speakerIssi+'</code>';
     let target;
     if(c.call_type==='group'){
       target='<code>TG '+c.gssi+'</code>';

--- a/crates/tetra-entities/src/net_dashboard/html.rs
+++ b/crates/tetra-entities/src/net_dashboard/html.rs
@@ -258,26 +258,35 @@ a.callsign:hover{
   background:color-mix(in srgb,var(--accent2) 20%,transparent);
   box-shadow:0 0 0 1px color-mix(in srgb,var(--accent2) 30%,transparent);
 }
-.public-dashboard-grid{display:grid;grid-template-columns:minmax(300px,.85fr) minmax(480px,1.55fr);gap:14px;margin-bottom:14px;}
+.public-dashboard-grid{display:grid;grid-template-columns:minmax(360px,.68fr) minmax(680px,1.72fr);gap:14px;margin-bottom:14px;}
 .public-stack{display:flex;flex-direction:column;gap:14px;min-width:0;}
 .public-note{display:flex;align-items:center;gap:8px;color:var(--text2);font-size:12px;margin:-2px 0 12px;}
 .public-note .pill{flex-shrink:0;}
 .public-table .callsign{margin-left:0;}
 .public-table td,.public-table th{white-space:nowrap;}
 .public-table td:last-child,.public-table th:last-child{white-space:normal;}
-.public-lastheard-table th:nth-child(-n+6),
-.public-lastheard-table td:nth-child(-n+6){
-  width:1%;
+.public-lastheard-table{
+  table-layout:fixed;
 }
+.public-lastheard-table th,
+.public-lastheard-table td{
+  padding-left:12px;
+  padding-right:12px;
+  overflow:hidden;
+  text-overflow:ellipsis;
+}
+.public-lastheard-table th:nth-child(1),
+.public-lastheard-table td:nth-child(1){width:12%;}
 .public-lastheard-table th:nth-child(2),
-.public-lastheard-table td:nth-child(2){padding-right:6px;}
+.public-lastheard-table td:nth-child(2){width:14%;}
 .public-lastheard-table th:nth-child(3),
-.public-lastheard-table td:nth-child(3){padding-left:6px;}
-.public-lastheard-table th.public-table-fill,
-.public-lastheard-table td.public-table-fill{
-  width:auto;
-  padding:0;
-}
+.public-lastheard-table td:nth-child(3){width:14%;}
+.public-lastheard-table th:nth-child(4),
+.public-lastheard-table td:nth-child(4){width:20%;}
+.public-lastheard-table th:nth-child(5),
+.public-lastheard-table td:nth-child(5){width:20%;}
+.public-lastheard-table th:nth-child(6),
+.public-lastheard-table td:nth-child(6){width:20%;}
 .public-calls-wrap{overflow:visible;}
 .public-calls-wrap tbody tr{height:36px;}
 .public-call-placeholder td{
@@ -2624,7 +2633,7 @@ tbody tr:hover td{background:color-mix(in srgb,var(--bg3) 70%, transparent);}
             <div class="table-wrap">
               <table class="public-table public-lastheard-table">
                 <thead><tr>
-                  <th>Time</th><th>Callsign</th><th>ISSI</th><th>Activity</th><th>Target</th><th>Src</th><th class="public-table-fill"></th>
+                  <th>Time</th><th>Callsign</th><th>ISSI</th><th>Activity</th><th>Target</th><th>Src</th>
                 </tr></thead>
                 <tbody id="pub-lastheard-tbody"></tbody>
               </table>
@@ -9251,7 +9260,7 @@ function setPublicConnectionStatus(d){
 function renderPublicLastHeard(entries){
   const tb=document.getElementById('pub-lastheard-tbody');if(!tb)return;
   const arr=entries||[];
-  if(!arr.length){tb.innerHTML='<tr><td colspan="7"><div class="empty-state"><div class="empty-msg">No RF activity yet</div></div></td></tr>';return;}
+  if(!arr.length){tb.innerHTML='<tr><td colspan="6"><div class="empty-state"><div class="empty-msg">No RF activity yet</div></div></td></tr>';return;}
   tb.innerHTML=arr.map(e=>{
     return '<tr>'
       +'<td><span class="num">'+escHtml(e.ts||'—')+'</span></td>'
@@ -9260,7 +9269,6 @@ function renderPublicLastHeard(entries){
       +'<td>'+publicActivityBadge(e.activity)+'</td>'
       +'<td>'+publicTarget(e)+'</td>'
       +'<td><span class="pill '+(e.source==='RF'?'pill-ok':'pill-info')+'">'+escHtml(e.source||'—')+'</span></td>'
-      +'<td class="public-table-fill"></td>'
       +'</tr>';
   }).join('');
 }

--- a/crates/tetra-entities/src/net_dashboard/html.rs
+++ b/crates/tetra-entities/src/net_dashboard/html.rs
@@ -9095,6 +9095,40 @@ function renderPublicCalls(calls){
     return '<tr><td><code>'+ts+'</code></td><td>'+type+'</td><td>'+callerHtml+'</td><td>'+target+'</td><td><span class="num accent">'+formatDur(c.started_secs_ago||0)+'</span></td></tr>';
   }).join('');
 }
+function setPublicConnectionStatus(d){
+  // Public mode intentionally has no WebSocket. A successful /api/public response itself proves
+  // that the FlowStation dashboard process is alive, so mirror that as BS ONLINE instead of
+  // leaving the WS-driven controls in their boot-time OFFLINE state.
+  const connLed=document.getElementById('connLed');
+  const connText=document.getElementById('connText');
+  if(connLed)connLed.classList.add('on');
+  if(connText){connText.textContent=t('online');connText.style.color='var(--accent)';}
+
+  state.brewOnline=!!d.brew_online;
+  state.brewVer=Number(d.brew_version||0);
+
+  const brewLed=document.getElementById('brewLed');
+  const brewText=document.getElementById('brewText');
+  const brewBadge=document.getElementById('brewVerBadge');
+  if(state.brewOnline){
+    if(brewLed)brewLed.classList.add('on');
+    if(brewText){brewText.textContent=t('brew_online');brewText.style.color='var(--accent2)';}
+    if(brewBadge){
+      brewBadge.textContent='v'+state.brewVer;
+      brewBadge.style.display='inline-block';
+      brewBadge.style.background=state.brewVer>=1?'rgba(0,212,168,0.15)':'rgba(255,178,36,0.15)';
+      brewBadge.style.color=state.brewVer>=1?'var(--accent)':'var(--warn)';
+      brewBadge.style.border='1px solid '+(state.brewVer>=1?'rgba(0,212,168,0.4)':'rgba(255,178,36,0.4)');
+    }
+  }else{
+    if(brewLed)brewLed.classList.remove('on');
+    if(brewText){brewText.textContent=t('brew_offline');brewText.style.color='var(--text2)';}
+    if(brewBadge)brewBadge.style.display='none';
+  }
+
+  syncTopbarChips();
+}
+
 function renderPublicLastHeard(entries){
   const tb=document.getElementById('pub-lastheard-tbody');if(!tb)return;
   const arr=entries||[];
@@ -9121,6 +9155,7 @@ async function pollPublic(){
     setT('pub-rf',d.rf_active?'Active':'Idle');
     setT('pub-brew',d.brew_online?'Online':'Offline');
     setT('pub-ver',d.stack_version||'—');
+    setPublicConnectionStatus(d);
     const STAT_STATES=['is-ok','is-idle','is-info','is-warn','is-danger'];
     const rfc=document.getElementById('pub-rf-card');
     if(rfc){rfc.classList.remove(...STAT_STATES);rfc.classList.add(d.rf_active?'is-ok':'is-idle');}

--- a/crates/tetra-entities/src/net_dashboard/html.rs
+++ b/crates/tetra-entities/src/net_dashboard/html.rs
@@ -265,27 +265,23 @@ a.callsign:hover{
 .public-table .callsign{margin-left:0;}
 .public-table td,.public-table th{white-space:nowrap;}
 .public-table td:last-child,.public-table th:last-child{white-space:normal;}
-.public-lastheard-table th:nth-child(1),
-.public-lastheard-table td:nth-child(1),
-.public-lastheard-table th:nth-child(2),
-.public-lastheard-table td:nth-child(2),
-.public-lastheard-table th:nth-child(3),
-.public-lastheard-table td:nth-child(3),
-.public-lastheard-table th:nth-child(4),
-.public-lastheard-table td:nth-child(4){
+.public-lastheard-table th:nth-child(-n+6),
+.public-lastheard-table td:nth-child(-n+6){
   width:1%;
 }
 .public-lastheard-table th:nth-child(2),
 .public-lastheard-table td:nth-child(2){padding-right:6px;}
 .public-lastheard-table th:nth-child(3),
 .public-lastheard-table td:nth-child(3){padding-left:6px;}
-.public-calls-wrap{
-  --public-call-rows:3;
-  height:calc(33px + (var(--public-call-rows) * 34px));
-  overflow-y:hidden;
+.public-lastheard-table th.public-table-fill,
+.public-lastheard-table td.public-table-fill{
+  width:auto;
+  padding:0;
 }
+.public-calls-wrap{overflow:visible;}
+.public-calls-wrap tbody tr{height:36px;}
 .public-call-placeholder td{
-  height:34px;
+  height:36px;
   padding-top:0;
   padding-bottom:0;
   color:transparent;
@@ -2628,7 +2624,7 @@ tbody tr:hover td{background:color-mix(in srgb,var(--bg3) 70%, transparent);}
             <div class="table-wrap">
               <table class="public-table public-lastheard-table">
                 <thead><tr>
-                  <th>Time</th><th>Callsign</th><th>ISSI</th><th>Activity</th><th>Target</th><th>Src</th>
+                  <th>Time</th><th>Callsign</th><th>ISSI</th><th>Activity</th><th>Target</th><th>Src</th><th class="public-table-fill"></th>
                 </tr></thead>
                 <tbody id="pub-lastheard-tbody"></tbody>
               </table>
@@ -9147,7 +9143,7 @@ function renderPublicCalls(calls,cell){
   const wrap=document.getElementById('pub-calls-wrap');
   const carrierCount=cell&&Array.isArray(cell.carriers)&&cell.carriers.length>1?cell.carriers.length:1;
   const rowCapacity=carrierCount>1?7:3;
-  if(wrap)wrap.style.setProperty('--public-call-rows',String(rowCapacity));
+  void wrap; // wrapper kept for DOM compatibility; row count itself fixes the height
 
   const arr=[...(calls||[])].sort((a,b)=>(a.carrier_num-b.carrier_num)||(a.ts-b.ts));
   const rows=arr.map(c=>{
@@ -9255,7 +9251,7 @@ function setPublicConnectionStatus(d){
 function renderPublicLastHeard(entries){
   const tb=document.getElementById('pub-lastheard-tbody');if(!tb)return;
   const arr=entries||[];
-  if(!arr.length){tb.innerHTML='<tr><td colspan="6"><div class="empty-state"><div class="empty-msg">No RF activity yet</div></div></td></tr>';return;}
+  if(!arr.length){tb.innerHTML='<tr><td colspan="7"><div class="empty-state"><div class="empty-msg">No RF activity yet</div></div></td></tr>';return;}
   tb.innerHTML=arr.map(e=>{
     return '<tr>'
       +'<td><span class="num">'+escHtml(e.ts||'—')+'</span></td>'
@@ -9264,6 +9260,7 @@ function renderPublicLastHeard(entries){
       +'<td>'+publicActivityBadge(e.activity)+'</td>'
       +'<td>'+publicTarget(e)+'</td>'
       +'<td><span class="pill '+(e.source==='RF'?'pill-ok':'pill-info')+'">'+escHtml(e.source||'—')+'</span></td>'
+      +'<td class="public-table-fill"></td>'
       +'</tr>';
   }).join('');
 }

--- a/crates/tetra-entities/src/net_dashboard/server.rs
+++ b/crates/tetra-entities/src/net_dashboard/server.rs
@@ -4079,6 +4079,7 @@ fn serve_public_snapshot(
                 "center_freq_hz": center_freq_hz,
                 "rf_active": s.last_tx_visual.is_some(),
                 "brew_online": s.brew_online,
+                "brew_version": s.brew_version,
                 "stack_version": tetra_core::STACK_VERSION,
                 "calls": calls,
                 "last_heard": last_heard,

--- a/crates/tetra-entities/src/net_dashboard/server.rs
+++ b/crates/tetra-entities/src/net_dashboard/server.rs
@@ -1920,7 +1920,7 @@ fn handle_connection(
                     || req_line.starts_with("GET /api/public?")
                     || req_line == "GET /api/public HTTP/1.1")
             {
-                serve_public_snapshot(inner, &state);
+                serve_public_snapshot(inner, &state, &radioid);
                 return;
             }
 
@@ -3979,17 +3979,98 @@ fn save_config_profile(config_path: &str, profile_name: &str, content: &str) -> 
     atomic_write(profile_path, &content).map_err(|e| format!("failed to write profile: {}", e))
 }
 
-/// GET /api/public — anonymous read-only overview (FH-FEAT-033). Projects ONLY non-sensitive,
-/// already-public scalars from the dashboard's own state — never SharedConfig/StackState, and never
-/// ISSIs/GSSIs, the whitelist, SDS contents or the log ring. The read lock is the dashboard's own
-/// RwLock (the same one the WS snapshot takes), held only long enough to copy a handful of counts.
-fn serve_public_snapshot(stream: TcpStream, state: &DashboardState) {
+/// Resolve only identities that are already present in the live dashboard state.
+/// Unknown IDs are queued through the existing bounded RadioID worker; anonymous clients
+/// cannot submit arbitrary lookup IDs through this path.
+fn public_identity(
+    radioid: &crate::net_dashboard::radioid::RadioIdCache,
+    issi: u32,
+) -> (Option<String>, String) {
+    use crate::net_dashboard::radioid::Lookup;
+    match radioid.get(issi) {
+        Lookup::Found(cs) => {
+            let flag = crate::net_dashboard::callsign::callsign_flag(&cs).unwrap_or_default();
+            (Some(cs), flag)
+        }
+        Lookup::NotFound | Lookup::Pending => (None, String::new()),
+    }
+}
+
+/// GET /api/public — anonymous read-only operator overview (FH-FEAT-033).
+///
+/// This endpoint is available only when `[dashboard] public_overview = true` AND dashboard
+/// authentication is configured. In that explicit opt-in mode it exposes the same type of
+/// on-air activity normally visible on a repeater dashboard: registered-radio count, active
+/// call/timeslot assignment and the rolling Last Heard list. It deliberately does NOT expose
+/// config contents, whitelist data, SDS message bodies, logs, control endpoints or WebSocket.
+///
+/// Callsigns are resolved only for ISSIs already present in live state; clients cannot turn this
+/// endpoint into an arbitrary RadioID lookup proxy.
+fn serve_public_snapshot(
+    stream: TcpStream,
+    state: &DashboardState,
+    radioid: &crate::net_dashboard::radioid::RadioIdCache,
+) {
     let body = match state.read() {
         Ok(s) => {
             let active_calls = s.calls.len();
             let group_calls = s.calls.values().filter(|c| c.is_group).count();
             let individual_calls = active_calls - group_calls;
             let center_freq_hz = s.last_tx_visual.as_ref().map(|v| v.center_freq_hz);
+
+            let calls = s
+                .calls
+                .values()
+                .map(|c| {
+                    let speaker_issi = c.speaker_issi.unwrap_or(c.caller_issi);
+                    let (caller_callsign, caller_flag) = public_identity(radioid, c.caller_issi);
+                    let (speaker_callsign, speaker_flag) = public_identity(radioid, speaker_issi);
+                    let (called_callsign, called_flag) = if !c.is_group && c.called_issi != 0 {
+                        public_identity(radioid, c.called_issi)
+                    } else {
+                        (None, String::new())
+                    };
+                    serde_json::json!({
+                        "call_id": c.call_id,
+                        "call_type": if c.is_group { "group" } else { "individual" },
+                        "gssi": c.gssi,
+                        "caller_issi": c.caller_issi,
+                        "caller_callsign": caller_callsign,
+                        "caller_flag": caller_flag,
+                        "called_issi": c.called_issi,
+                        "called_callsign": called_callsign,
+                        "called_flag": called_flag,
+                        "speaker_issi": speaker_issi,
+                        "speaker_callsign": speaker_callsign,
+                        "speaker_flag": speaker_flag,
+                        "started_secs_ago": c.started_at.elapsed().as_secs(),
+                        "simplex": c.simplex,
+                        "carrier_num": c.carrier_num,
+                        "ts": c.ts,
+                        "peer_carrier_num": c.peer_carrier_num,
+                        "peer_ts": c.peer_ts,
+                        "priority": c.priority,
+                    })
+                })
+                .collect::<Vec<_>>();
+
+            let last_heard = s
+                .last_heard
+                .iter()
+                .take(crate::net_dashboard::state::LAST_HEARD_MAX)
+                .map(|e| {
+                    let (callsign, flag) = public_identity(radioid, e.issi);
+                    serde_json::json!({
+                        "ts": e.ts,
+                        "issi": e.issi,
+                        "callsign": callsign,
+                        "flag": flag,
+                        "activity": e.activity,
+                        "dest": e.dest,
+                    })
+                })
+                .collect::<Vec<_>>();
+
             serde_json::json!({
                 "registered_ms": s.ms_map.len(),
                 "active_calls": active_calls,
@@ -3999,6 +4080,8 @@ fn serve_public_snapshot(stream: TcpStream, state: &DashboardState) {
                 "rf_active": s.last_tx_visual.is_some(),
                 "brew_online": s.brew_online,
                 "stack_version": tetra_core::STACK_VERSION,
+                "calls": calls,
+                "last_heard": last_heard,
             })
             .to_string()
         }

--- a/crates/tetra-entities/src/net_dashboard/server.rs
+++ b/crates/tetra-entities/src/net_dashboard/server.rs
@@ -4061,11 +4061,11 @@ fn serve_public_snapshot(
                 .map(|e| {
                     let (callsign, flag) = public_identity(radioid, e.issi);
                     serde_json::json!({
-                        "ts": e.ts,
+                        "ts": e.ts.clone(),
                         "issi": e.issi,
                         "callsign": callsign,
                         "flag": flag,
-                        "activity": e.activity,
+                        "activity": e.activity.clone(),
                         "dest": e.dest,
                     })
                 })

--- a/crates/tetra-entities/src/net_dashboard/server.rs
+++ b/crates/tetra-entities/src/net_dashboard/server.rs
@@ -1180,27 +1180,45 @@ impl DashboardServer {
                     carrier_num,
                     ts,
                 } => {
-                    if let Some(c) = s.calls.get_mut(call_id) {
-                        c.speaker_issi = Some(*speaker_issi);
-                    }
-                    // Whoever is speaking has this TG/peer selected.
-                    if let Some(e) = s.ms_map.get_mut(speaker_issi) {
-                        e.selected_group = if *is_group { Some(*dest_addr) } else { None };
-                    }
-                    s.push_last_heard(*speaker_issi, if *is_group { "call_group" } else { "call_individual" }, *dest_addr);
-                    if let Ok(json) = serde_json::to_string(&serde_json::json!({
-                        "type":"speaker_changed",
-                        "call_id":call_id,
-                        "speaker_issi":speaker_issi,
-                        "carrier_num":carrier_num,
-                        "ts":ts,
-                        "last_heard":{
-                            "issi":speaker_issi,
-                            "activity":if *is_group { "call_group" } else { "call_individual" },
-                            "dest":dest_addr
+                    // GroupCallStarted already seeds speaker_issi with the originating ISSI.
+                    // CMCE may immediately emit CallSpeakerChanged for that same radio; treating
+                    // it as a new Last Heard event produced the duplicate rows seen for one PTT.
+                    let changed = s
+                        .calls
+                        .get_mut(call_id)
+                        .map(|c| {
+                            let changed = c.speaker_issi != Some(*speaker_issi);
+                            c.speaker_issi = Some(*speaker_issi);
+                            changed
+                        })
+                        .unwrap_or(false);
+
+                    if changed {
+                        // Whoever is speaking has this TG/peer selected.
+                        if let Some(e) = s.ms_map.get_mut(speaker_issi) {
+                            e.selected_group = if *is_group { Some(*dest_addr) } else { None };
                         }
-                    })) {
-                        msg = Some(json);
+                        s.push_last_heard(
+                            *speaker_issi,
+                            if *is_group { "call_group" } else { "call_individual" },
+                            *dest_addr,
+                        );
+                        let source = if s.ms_map.contains_key(speaker_issi) { "RF" } else { "Net" };
+                        if let Ok(json) = serde_json::to_string(&serde_json::json!({
+                            "type":"speaker_changed",
+                            "call_id":call_id,
+                            "speaker_issi":speaker_issi,
+                            "carrier_num":carrier_num,
+                            "ts":ts,
+                            "last_heard":{
+                                "issi":speaker_issi,
+                                "activity":if *is_group { "call_group" } else { "call_individual" },
+                                "dest":dest_addr,
+                                "source":source
+                            }
+                        })) {
+                            msg = Some(json);
+                        }
                     }
                 }
                 TelemetryEvent::IndividualCallStarted {
@@ -4147,6 +4165,7 @@ fn serve_public_snapshot(
                         "flag": flag,
                         "activity": e.activity.clone(),
                         "dest": e.dest,
+                        "source": e.source.clone(),
                         "dest_callsign": dest_callsign,
                         "dest_flag": dest_flag,
                     })

--- a/crates/tetra-entities/src/net_dashboard/server.rs
+++ b/crates/tetra-entities/src/net_dashboard/server.rs
@@ -1280,43 +1280,49 @@ impl DashboardServer {
                     ts,
                     speaker_issi,
                 } => {
-                    // The authenticated dashboard gets these frames directly over WS, but the
-                    // anonymous public dashboard intentionally polls /api/public instead. Mirror
-                    // the live RF speaker into CallEntry so polling clients see the same operator.
-                    //
-                    // Do NOT append Last Heard on every voice frame: only a genuine speaker change
-                    // produces a new activity row.
-                    let changed = s
-                        .calls
-                        .values_mut()
-                        .find(|c| {
-                            (c.carrier_num == *carrier_num && c.ts == *ts)
-                                || (c.peer_carrier_num == Some(*carrier_num) && c.peer_ts == Some(*ts))
-                        })
-                        .and_then(|c| {
-                            if c.speaker_issi == Some(*speaker_issi) {
-                                return None;
-                            }
-                            c.speaker_issi = Some(*speaker_issi);
-                            let dest = if c.is_group {
-                                c.gssi
-                            } else if *speaker_issi == c.caller_issi {
-                                c.called_issi
-                            } else {
-                                c.caller_issi
-                            };
-                            Some((c.is_group, dest))
-                        });
+                    // speaker_issi is optional: some PHY activity frames can identify the occupied
+                    // traffic slot without attributing it to an ISSI. Only an attributed voice
+                    // frame may update the public/current speaker.
+                    if let Some(speaker_issi) = *speaker_issi {
+                        // The authenticated dashboard gets these frames directly over WS, but the
+                        // anonymous public dashboard intentionally polls /api/public instead.
+                        // Mirror the live RF speaker into CallEntry so polling clients see the same
+                        // operator.
+                        //
+                        // Do NOT append Last Heard on every voice frame: only a genuine speaker
+                        // change produces a new activity row.
+                        let changed = s
+                            .calls
+                            .values_mut()
+                            .find(|c| {
+                                (c.carrier_num == *carrier_num && c.ts == *ts)
+                                    || (c.peer_carrier_num == Some(*carrier_num) && c.peer_ts == Some(*ts))
+                            })
+                            .and_then(|c| {
+                                if c.speaker_issi == Some(speaker_issi) {
+                                    return None;
+                                }
+                                c.speaker_issi = Some(speaker_issi);
+                                let dest = if c.is_group {
+                                    c.gssi
+                                } else if speaker_issi == c.caller_issi {
+                                    c.called_issi
+                                } else {
+                                    c.caller_issi
+                                };
+                                Some((c.is_group, dest))
+                            });
 
-                    if let Some((is_group, dest)) = changed {
-                        if let Some(e) = s.ms_map.get_mut(speaker_issi) {
-                            e.selected_group = if is_group { Some(dest) } else { None };
+                        if let Some((is_group, dest)) = changed {
+                            if let Some(e) = s.ms_map.get_mut(&speaker_issi) {
+                                e.selected_group = if is_group { Some(dest) } else { None };
+                            }
+                            s.push_last_heard(
+                                speaker_issi,
+                                if is_group { "call_group" } else { "call_individual" },
+                                dest,
+                            );
                         }
-                        s.push_last_heard(
-                            *speaker_issi,
-                            if is_group { "call_group" } else { "call_individual" },
-                            dest,
-                        );
                     }
                 }
                 TelemetryEvent::TxVisual {

--- a/crates/tetra-entities/src/net_dashboard/server.rs
+++ b/crates/tetra-entities/src/net_dashboard/server.rs
@@ -4133,6 +4133,13 @@ fn serve_public_snapshot(
                 .take(crate::net_dashboard::state::LAST_HEARD_MAX)
                 .map(|e| {
                     let (callsign, flag) = public_identity(radioid, e.issi);
+                    // Only a private-call destination is another subscriber identity. Resolve it
+                    // for display in the public Last Heard table; group destinations remain TG IDs.
+                    let (dest_callsign, dest_flag) = if e.activity == "call_individual" && e.dest != 0 {
+                        public_identity(radioid, e.dest)
+                    } else {
+                        (None, String::new())
+                    };
                     serde_json::json!({
                         "ts": e.ts.clone(),
                         "issi": e.issi,
@@ -4140,6 +4147,8 @@ fn serve_public_snapshot(
                         "flag": flag,
                         "activity": e.activity.clone(),
                         "dest": e.dest,
+                        "dest_callsign": dest_callsign,
+                        "dest_flag": dest_flag,
                     })
                 })
                 .collect::<Vec<_>>();

--- a/crates/tetra-entities/src/net_dashboard/server.rs
+++ b/crates/tetra-entities/src/net_dashboard/server.rs
@@ -1275,8 +1275,49 @@ impl DashboardServer {
                 } => {
                     s.push_sds_log(direction, *source_issi, *dest_issi, *is_group, *protocol_id, text.clone());
                 }
-                TelemetryEvent::TsVoiceActivity { .. } => {
-                    // Handled below with rate limiting — no state update needed
+                TelemetryEvent::TsVoiceActivity {
+                    carrier_num,
+                    ts,
+                    speaker_issi,
+                } => {
+                    // The authenticated dashboard gets these frames directly over WS, but the
+                    // anonymous public dashboard intentionally polls /api/public instead. Mirror
+                    // the live RF speaker into CallEntry so polling clients see the same operator.
+                    //
+                    // Do NOT append Last Heard on every voice frame: only a genuine speaker change
+                    // produces a new activity row.
+                    let changed = s
+                        .calls
+                        .values_mut()
+                        .find(|c| {
+                            (c.carrier_num == *carrier_num && c.ts == *ts)
+                                || (c.peer_carrier_num == Some(*carrier_num) && c.peer_ts == Some(*ts))
+                        })
+                        .and_then(|c| {
+                            if c.speaker_issi == Some(*speaker_issi) {
+                                return None;
+                            }
+                            c.speaker_issi = Some(*speaker_issi);
+                            let dest = if c.is_group {
+                                c.gssi
+                            } else if *speaker_issi == c.caller_issi {
+                                c.called_issi
+                            } else {
+                                c.caller_issi
+                            };
+                            Some((c.is_group, dest))
+                        });
+
+                    if let Some((is_group, dest)) = changed {
+                        if let Some(e) = s.ms_map.get_mut(speaker_issi) {
+                            e.selected_group = if is_group { Some(dest) } else { None };
+                        }
+                        s.push_last_heard(
+                            *speaker_issi,
+                            if is_group { "call_group" } else { "call_individual" },
+                            dest,
+                        );
+                    }
                 }
                 TelemetryEvent::TxVisual {
                     sample_rate,
@@ -1920,7 +1961,7 @@ fn handle_connection(
                     || req_line.starts_with("GET /api/public?")
                     || req_line == "GET /api/public HTTP/1.1")
             {
-                serve_public_snapshot(inner, &state, &radioid);
+                serve_public_snapshot(inner, &state, &radioid, shared_config.as_ref());
                 return;
             }
 
@@ -4010,6 +4051,7 @@ fn serve_public_snapshot(
     stream: TcpStream,
     state: &DashboardState,
     radioid: &crate::net_dashboard::radioid::RadioIdCache,
+    shared_config: Option<&tetra_config::bluestation::SharedConfig>,
 ) {
     let body = match state.read() {
         Ok(s) => {
@@ -4017,6 +4059,31 @@ fn serve_public_snapshot(
             let group_calls = s.calls.values().filter(|c| c.is_group).count();
             let individual_calls = active_calls - group_calls;
             let center_freq_hz = s.last_tx_visual.as_ref().map(|v| v.center_freq_hz);
+
+            // Explicit public projection of RF/cell identity. Read the already-parsed immutable
+            // config; never serialize StackConfig itself, so credentials/secrets cannot leak.
+            let cell = shared_config.map(|shared| {
+                let cfg = shared.config();
+                let carriers = cfg
+                    .bs_phase_mod_carriers()
+                    .unwrap_or_default()
+                    .into_iter()
+                    .map(|(carrier, dl_hz, ul_hz)| {
+                        serde_json::json!({
+                            "carrier": carrier,
+                            "tx_dl_hz": dl_hz,
+                            "rx_ul_hz": ul_hz,
+                        })
+                    })
+                    .collect::<Vec<_>>();
+                serde_json::json!({
+                    "mcc": cfg.net.mcc,
+                    "mnc": cfg.net.mnc,
+                    "main_carrier": cfg.cell.main_carrier,
+                    "secondary_carrier": cfg.cell.secondary_carrier,
+                    "carriers": carriers,
+                })
+            });
 
             let calls = s
                 .calls
@@ -4081,6 +4148,7 @@ fn serve_public_snapshot(
                 "brew_online": s.brew_online,
                 "brew_version": s.brew_version,
                 "stack_version": tetra_core::STACK_VERSION,
+                "cell": cell,
                 "calls": calls,
                 "last_heard": last_heard,
             })

--- a/crates/tetra-entities/src/net_dashboard/state.rs
+++ b/crates/tetra-entities/src/net_dashboard/state.rs
@@ -70,6 +70,9 @@ pub struct LastHeardEntry {
     pub issi: u32,        // source ISSI
     pub activity: String, // "call_group", "call_individual", "sds"
     pub dest: u32,        // destination GSSI or ISSI (0 if unknown)
+    /// Origin of the activity at the moment it was recorded: a locally registered MS (RF)
+    /// or a remote subscriber received through the network/backhaul (Net).
+    pub source: String,
 }
 
 /// SDS Log entry — one SDS message the BS sent or received locally. Persisted to disk
@@ -305,11 +308,15 @@ impl DashboardStateInner {
     }
 
     pub fn push_last_heard(&mut self, issi: u32, activity: &str, dest: u32) {
+        // Capture RF/Net now rather than deriving it later when rendering history. A radio may
+        // deregister after the transmission; its historical row must still remain RF.
+        let source = if self.ms_map.contains_key(&issi) { "RF" } else { "Net" };
         let entry = LastHeardEntry {
             ts: chrono::Local::now().format("%H:%M:%S").to_string(),
             issi,
             activity: activity.to_string(),
             dest,
+            source: source.to_string(),
         };
         if self.last_heard.len() >= LAST_HEARD_MAX {
             self.last_heard.pop_back();


### PR DESCRIPTION
## Summary

Expands the existing optional public dashboard into a more useful read-only live TETRA status view while keeping configuration and control functions behind authentication.

The public page is intended to provide an operator/repeater-style overview of the cell without exposing privileged dashboard functionality.

## Changes

### Public dashboard

- Added live registered-radio and active-call counters.
- Added RF/network status cards.
- Display DL and UL frequencies calculated from the active FlowStation configuration.
- Display the configured carrier, MCC and MNC.
- Added live carrier/timeslot visualization:
  - TS1 / MCCH
  - traffic slot allocation
  - active GSSI
  - current speaker
  - call duration
- Added a fixed-size Current Calls table:
  - 3 traffic calls for a single-carrier cell
  - 7 traffic calls for a dual-carrier cell
- Added RF Activity / Last Heard with:
  - timestamp
  - RadioID callsign
  - ISSI
  - activity type
  - GSSI / private-call destination
  - RF / Net source
- RadioID callsigns link directly to the corresponding QRZ page.
- Private-call destinations use the resolved callsign when available.
- TETRA terminology is kept consistently (`GSSI` rather than `TG`).

### Live activity handling

- Mirror `TsVoiceActivity` into dashboard call state so the public polling view follows the actual current speaker.
- Ignore unattributed voice activity where `speaker_issi` is not available.
- Avoid duplicate Last Heard entries when `GroupCallStarted` is immediately followed by `CallSpeakerChanged` for the same subscriber.
- Record RF/Net origin when Last Heard entries are created so historical entries do not change classification after a subscriber deregisters.

### Public endpoint

`/api/public` now exposes only an explicit read-only projection required by the public dashboard, including:

- registered MS count
- active calls
- call/timeslot information
- Last Heard activity
- Brew status/version
- MCC/MNC
- carrier numbers
- calculated DL/UL frequencies

The complete FlowStation configuration is never serialized to the public endpoint, so dashboard passwords, Brew credentials and other configuration secrets are not exposed.

The public page also deliberately does not open the authenticated dashboard WebSocket or expose control/configuration APIs.

### UI

- Keeps the existing FlowStation visual style and theme support.
- Public mode hides administrator navigation sections.
- Improved layout for live RF activity and calls.
- Updated the authenticated Active Calls destination display to use the same GSSI / RadioID presentation style.
- Added `/config.toml` to `.gitignore` to avoid accidentally committing a local runtime configuration.

## Configuration

The public dashboard remains opt-in:

```toml
[dashboard]
public_overview = true